### PR TITLE
renamed aero_model.F90 to oslo_aero_model.F90

### DIFF
--- a/oslo_aero_model.F90
+++ b/oslo_aero_model.F90
@@ -1,4 +1,4 @@
-module aero_model
+module oslo_aero_model
 
   !===============================================================================
   ! Oslo Aerosol Model
@@ -944,4 +944,4 @@ contains
 
   end subroutine calcaersize_sub
 
-end module aero_model
+end module oslo_aero_model


### PR DESCRIPTION
This is consistent with the release code usage for release-noresm2.0.6.