### PR TITLE
updates to noresm2_3_develop to refactor shadow files

### DIFF
--- a/src/aero_model.F90
+++ b/src/aero_model.F90
@@ -20,7 +20,6 @@ module aero_model
   use physics_types,            only: physics_state, physics_ptend, physics_ptend_init
   use physics_buffer,           only: physics_buffer_desc, pbuf_get_field, pbuf_get_index, pbuf_set_field
   use physconst,                only: gravit, rair, rhoh2o, pi
-  use spmd_utils,               only: masterproc
   use time_manager,             only: get_nstep
   use cam_history,              only: outfld, fieldname_len, addfld, add_default, horiz_only
   use chem_mods,                only: gas_pcnst, adv_mass

--- a/src/oslo_aero_coag.F90
+++ b/src/oslo_aero_coag.F90
@@ -15,7 +15,19 @@ module oslo_aero_coag
   use cam_history,    only: addfld, add_default, fieldname_len, horiz_only, outfld
   use cam_logfile,    only: iulog
   !
-  use oslo_aero_share
+  use oslo_aero_share, only: nmodes
+  use oslo_aero_share, only: normnk, rBinMidpoint, nBinsTab, VolumeToNumber, rhopart
+  use oslo_aero_share, only: MODE_IDX_BC_EXT_AC, MODE_IDX_SO4_AC, MODE_IDX_BC_AIT
+  use oslo_aero_share, only: MODE_IDX_OMBC_INTMIX_COAT_AIT, MODE_IDX_BC_NUC, MODE_IDX_OMBC_INTMIX_AIT
+  use oslo_aero_share, only: MODE_IDX_SO4_AC, MODE_IDX_DST_A2, MODE_IDX_DST_A3
+  use oslo_aero_share, only: MODE_IDX_SS_A1, MODE_IDX_SS_A2, MODE_IDX_SS_A3, MODE_IDX_SO4SOA_AIT
+  use oslo_aero_share, only: l_bc_ax, l_so4_na, l_bc_a, l_bc_ai, l_om_ai
+  use oslo_aero_share, only: l_bc_n, l_bc_ni, l_om_ni, l_so4_a1
+  use oslo_aero_share, only: l_bc_ax, l_bc_ac, l_so4_na, l_so4_ac, l_bc_a, l_bc_ai
+  use oslo_aero_share, only: l_om_ai, l_om_ac, l_om_ni, l_bc_n, l_bc_ni
+  use oslo_aero_share, only: l_so4_a1, l_soa_na, l_soa_a1, l_so4_a2
+  use oslo_aero_share, only: chemistryindex, physicsindex, is_process_mode
+  use oslo_aero_share, only: getNumberOfTracersInMode, getTracerIndex, qqcw_get_field
 
   implicit none
   private
@@ -33,31 +45,43 @@ module oslo_aero_coag
   integer, parameter, public :: numberOfCoagulationReceivers = 6
   integer, parameter, public :: numberOfAddCoagReceivers = 6
 
-  real(r8), public :: normalizedCoagulationSink(0:nmodes,0:nmodes) ! [m3/#/s]
-  real(r8), public :: NCloudCoagulationSink(0:nmodes)              ! [m3/#/s]
-  real(r8), public :: normCoagSinkAdd(numberOfAddCoagReceivers)    ! [m3/#/s]
+  real(r8), public :: normalizedCoagulationSink(0:nmodes,0:nmodes) ![m3/#/s]
+  real(r8), public :: NCloudCoagulationSink(0:nmodes)              ![m3/#/s]
+  real(r8), public :: normCoagSinkAdd(numberOfAddCoagReceivers)    ![m3/#/s]
 
-  ! These are the modes which are coagulating (belonging to mixtures no. 0, 1, 2, 4, 12, 14)
+  !These are the modes which are coagulating (belonging to mixtures no. 0, 1, 2, 4, 12, 14)
   integer , parameter :: numberOfCoagulatingModes = 6
   integer, public :: coagulatingMode(numberOfCoagulatingModes) =    &
-       (/MODE_IDX_BC_EXT_AC                                               &  ! inert mode
-       , MODE_IDX_SO4SOA_AIT, MODE_IDX_BC_AIT, MODE_IDX_OMBC_INTMIX_COAT_AIT &  ! internally mixed small modes
-       , MODE_IDX_BC_NUC, MODE_IDX_OMBC_INTMIX_AIT /)      ! externally mixed small modes
+       (/MODE_IDX_BC_EXT_AC,            & !inert mode
+         MODE_IDX_SO4SOA_AIT,           & !internally mixed small mode
+         MODE_IDX_BC_AIT,               & !internally mixed small mode
+         MODE_IDX_OMBC_INTMIX_COAT_AIT, & !internally mixed small mode
+         MODE_IDX_BC_NUC,               & !externally mixed small mode
+         MODE_IDX_OMBC_INTMIX_AIT /)      !externally mixed small mode
 
-  ! These are the modes which are receiving coagulating material in OsloAero
+  !These are the modes which are receiving coagulating material in OsloAero
   ! (belonging to mixtures no. 5, 6, 7, 8, 9, 10)
   integer, public :: receiverMode(numberOfCoagulationReceivers) = &
-       (/MODE_IDX_SO4_AC,MODE_IDX_DST_A2, MODE_IDX_DST_A3, MODE_IDX_SS_A1, MODE_IDX_SS_A2, MODE_IDX_SS_A3 /)
+       (/MODE_IDX_SO4_AC, &
+         MODE_IDX_DST_A2, &
+         MODE_IDX_DST_A3, &
+         MODE_IDX_SS_A1,  &
+         MODE_IDX_SS_A2,  &
+         MODE_IDX_SS_A3 /)
 
-  ! And these are the additional modes which are allowed to contribute to the
+  !And these are the additional modes which are allowed to contribute to the
   ! coagulation sink, defined here and to be used only in the nucleation code in condtend.F90
   ! (belonging to mixtures no. 0, 1, 2, 4, 12, 14)
   integer, public :: addReceiverMode(numberOfAddCoagReceivers) = &
-       (/MODE_IDX_BC_EXT_AC,MODE_IDX_SO4SOA_AIT,MODE_IDX_BC_AIT, &
-         MODE_IDX_OMBC_INTMIX_COAT_AIT,MODE_IDX_BC_NUC,MODE_IDX_OMBC_INTMIX_AIT /)
+       (/MODE_IDX_BC_EXT_AC,            &
+         MODE_IDX_SO4SOA_AIT,           &
+         MODE_IDX_BC_AIT,               &
+         MODE_IDX_OMBC_INTMIX_COAT_AIT, &
+         MODE_IDX_BC_NUC,               &
+         MODE_IDX_OMBC_INTMIX_AIT /)
 
-  ! Coagulation moves aerosol mass to the "coagulate" species, so some
-  ! lifecycle species will receive mass in this routine!
+  !Coagulation moves aerosol mass to the "coagulate" species, so some
+  !lifecycle species will receive mass in this routine!
   integer :: lifeCycleReceiver(gas_pcnst)
 
   ! Coagulation between aerosol and cloud droplets move coagulate into
@@ -65,18 +89,17 @@ module oslo_aero_coag
   ! Exception: Sulphate coagulation with cloud droplets is merged with
   ! component from aqueous phase chemistry in order to take advantage of the
   ! more detailed addition onto larger particles.
-
   integer :: CloudAerReceiver(gas_pcnst)
 
   ! Closest Table index for assumed size of droplets used in coagulation
   integer :: tableindexcloud
 
   real(r8), parameter :: rcoagdroplet = 10.e-6   ! m
-  real(r8), parameter :: kboltzmann = 1.3806488e-23_r8       ! [m2 kg s-2 K-1]
-  real(r8), parameter :: temperatureLookupTables = 293.15_r8 ! Temperature used in look up tables
-  real(r8), parameter :: mfpAir = 63.3e-9_r8                 ! [m] mean free path air
-  real(r8), parameter :: viscosityAir = 1.983e-5_r8          ! [Pa s] viscosity of air
-  real(r8), parameter :: rhoh2o = 1000._r8                   ! Density of water
+  real(r8), parameter :: kboltzmann = 1.3806488e-23_r8       ![m2 kg s-2 K-1]
+  real(r8), parameter :: temperatureLookupTables = 293.15_r8 !Temperature used in look up tables
+  real(r8), parameter :: mfpAir = 63.3e-9_r8                 ![m] mean free path air
+  real(r8), parameter :: viscosityAir = 1.983e-5_r8          ![Pa s] viscosity of air
+  real(r8), parameter :: rhoh2o = 1000._r8                   !Density of water
 
 !================================================================
 contains
@@ -85,22 +108,22 @@ contains
   subroutine initializeCoagulation(rhob,rk)
 
     ! arguments
-    real(r8), intent(in) :: rk(0:nmodes)   ! [unit] radius of background (receiver) mode
-    real(r8), intent(in) :: rhob(0:nmodes) ! density of background mode
+    real(r8), intent(in) :: rk(0:nmodes)   ![unit] radius of background (receiver) mode
+    real(r8), intent(in) :: rhob(0:nmodes) !density of background mode
 
     ! local variables
-    real(r8), dimension(numberOfCoagulationReceivers, numberOfCoagulatingModes, nBinsTab) :: K12 = 0.0_r8  ! Coagulation coefficient (m3/s)
-    real(r8), dimension(numberOfAddCoagReceivers,nBinsTab) :: CoagCoeffModeAdd = 0.0_r8  ! Coagulation coefficient mode 1 (m3/s)
-    real(r8), dimension(numberOfCoagulatingModes,nBinsTab) :: K12Cl = 0.0_r8  ! Coagulation coefficient (m3/s)
+    real(r8), dimension(numberOfCoagulationReceivers, numberOfCoagulatingModes, nBinsTab) :: K12 = 0.0_r8  !Coagulation coefficient (m3/s)
+    real(r8), dimension(numberOfAddCoagReceivers,nBinsTab) :: CoagCoeffModeAdd = 0.0_r8  !Coagulation coefficient mode 1 (m3/s)
+    real(r8), dimension(numberOfCoagulatingModes,nBinsTab) :: K12Cl = 0.0_r8  !Coagulation coefficient (m3/s)
     real(r8), dimension(nBinsTab) :: coagulationCoefficient
     !
     integer :: aMode
     integer :: modeIndex
-    integer :: modeIndexCoagulator  ! Index of coagulating mode
-    integer :: modeIndexReceiver    ! Index of receiving mode
-    integer :: iCoagulatingMode     ! Counter for coagulating mode
-    integer :: iReceiverMode        ! Counter for receiver modes
-    integer :: nsiz                 ! counter for look up table sizes
+    integer :: modeIndexCoagulator  !Index of coagulating mode
+    integer :: modeIndexReceiver    !Index of receiving mode
+    integer :: iCoagulatingMode     !Counter for coagulating mode
+    integer :: iReceiverMode        !Counter for receiver modes
+    integer :: nsiz                 !counter for look up table sizes
     !
     integer                        :: iChem
     character(len=fieldname_len+3) :: fieldname_receiver
@@ -115,26 +138,26 @@ contains
 
     lifeCycleReceiver(:) = -99
     lifeCycleReceiver(chemistryIndex(l_bc_ax))  = chemistryIndex(l_bc_ac)
-    lifeCycleReceiver(chemistryIndex(l_so4_na)) = chemistryIndex(l_so4_ac) ! create so4 coagulate from so4 in mode 1
-    lifeCycleReceiver(chemistryIndex(l_bc_a))   = chemistryIndex(l_bc_ac)  ! create bc coagulate  from bc in mode 2
-    lifeCycleReceiver(chemistryIndex(l_bc_ai))  = chemistryIndex(l_bc_ac)  ! create bc coagulate from bc in mode 4
-    lifeCycleReceiver(chemistryIndex(l_om_ai))  = chemistryIndex(l_om_ac)  ! create om coagulate from om in mode 4
-    lifeCycleReceiver(chemistryIndex(l_bc_n))   = chemistryIndex(l_bc_ac)  ! create bc coagulate from bc in mode 12
-    lifeCycleReceiver(chemistryIndex(l_bc_ni))  = chemistryIndex(l_bc_ac)  ! create bc coagulate from om in mode 14
-    lifeCycleReceiver(chemistryIndex(l_om_ni))  = chemistryIndex(l_om_ac)  ! create om coagulate from om in mode 14
-    lifeCycleReceiver(chemistryIndex(l_so4_a1)) = chemistryIndex(l_so4_ac) ! Create so4 coagulate from so4 condensate
+    lifeCycleReceiver(chemistryIndex(l_so4_na)) = chemistryIndex(l_so4_ac) !create so4 coagulate from so4 in mode 1
+    lifeCycleReceiver(chemistryIndex(l_bc_a))   = chemistryIndex(l_bc_ac)  !create bc coagulate  from bc in mode 2
+    lifeCycleReceiver(chemistryIndex(l_bc_ai))  = chemistryIndex(l_bc_ac)  !create bc coagulate from bc in mode 4
+    lifeCycleReceiver(chemistryIndex(l_om_ai))  = chemistryIndex(l_om_ac)  !create om coagulate from om in mode 4
+    lifeCycleReceiver(chemistryIndex(l_bc_n))   = chemistryIndex(l_bc_ac)  !create bc coagulate from bc in mode 12
+    lifeCycleReceiver(chemistryIndex(l_bc_ni))  = chemistryIndex(l_bc_ac)  !create bc coagulate from om in mode 14
+    lifeCycleReceiver(chemistryIndex(l_om_ni))  = chemistryIndex(l_om_ac)  !create om coagulate from om in mode 14
+    lifeCycleReceiver(chemistryIndex(l_so4_a1)) = chemistryIndex(l_so4_ac) !Create so4 coagulate from so4 condensate
     lifeCycleReceiver(chemistryINdex(l_soa_na)) = chemistryIndex(l_soa_a1)
 
     CloudAerReceiver(:) = -99
     CloudAerReceiver(chemistryIndex(l_bc_ax))  = chemistryIndex(l_bc_ac)
-    CloudAerReceiver(chemistryIndex(l_so4_na)) = chemistryIndex(l_so4_a2) ! create so4 coagulate from so4 in mode 1
-    CloudAerReceiver(chemistryIndex(l_bc_a))   = chemistryIndex(l_bc_ac)  ! create bc coagulate  from bc in mode 2
-    CloudAerReceiver(chemistryIndex(l_bc_ai))  = chemistryIndex(l_bc_ac)  ! create bc coagulate from bc in mode 4
-    CloudAerReceiver(chemistryIndex(l_om_ai))  = chemistryIndex(l_om_ac)  ! create om coagulate from om in mode 4
-    CloudAerReceiver(chemistryIndex(l_bc_n))   = chemistryIndex(l_bc_ac)  ! create bc coagulate from bc in mode 12
-    CloudAerReceiver(chemistryIndex(l_bc_ni))  = chemistryIndex(l_bc_ac)  ! create bc coagulate from om in mode 14
-    CloudAerReceiver(chemistryIndex(l_om_ni))  = chemistryIndex(l_om_ac)  ! create om coagulate from om in mode 14
-    CloudAerReceiver(chemistryIndex(l_so4_a1)) = chemistryIndex(l_so4_a2) ! Create so4 coagulate from so4 condensate
+    CloudAerReceiver(chemistryIndex(l_so4_na)) = chemistryIndex(l_so4_a2) !create so4 coagulate from so4 in mode 1
+    CloudAerReceiver(chemistryIndex(l_bc_a))   = chemistryIndex(l_bc_ac)  !create bc coagulate  from bc in mode 2
+    CloudAerReceiver(chemistryIndex(l_bc_ai))  = chemistryIndex(l_bc_ac)  !create bc coagulate from bc in mode 4
+    CloudAerReceiver(chemistryIndex(l_om_ai))  = chemistryIndex(l_om_ac)  !create om coagulate from om in mode 4
+    CloudAerReceiver(chemistryIndex(l_bc_n))   = chemistryIndex(l_bc_ac)  !create bc coagulate from bc in mode 12
+    CloudAerReceiver(chemistryIndex(l_bc_ni))  = chemistryIndex(l_bc_ac)  !create bc coagulate from om in mode 14
+    CloudAerReceiver(chemistryIndex(l_om_ni))  = chemistryIndex(l_om_ac)  !create om coagulate from om in mode 14
+    CloudAerReceiver(chemistryIndex(l_so4_a1)) = chemistryIndex(l_so4_a2) !Create so4 coagulate from so4 condensate
     cloudAerReceiver(chemistryIndex(l_soa_na)) = chemistryIndex(l_soa_a1)
 
     !-------------------------------------
@@ -144,111 +167,111 @@ contains
     do iReceiverMode = 1, numberOfCoagulationReceivers
        do iCoagulatingMode = 1,numberOfCoagulatingModes
 
-          ! Index of the coagulating mode (0-14), see list above
+          !Index of the coagulating mode (0-14), see list above
           modeIndexCoagulator = coagulatingMode(iCoagulatingMode)
 
-          ! Index of receiver mode (0-14), see list above
+          !Index of receiver mode (0-14), see list above
           modeIndexReceiver = receiverMode(iReceiverMode)
 
-          ! Pre-calculate coagulation coefficients for this coagulator..
-          ! Note: Not using actual density of coagulator here
-          ! Since this is not known at init-time
+          !Pre-calculate coagulation coefficients for this coagulator..
+          !Note: Not using actual density of coagulator here
+          !Since this is not known at init-time
           call calculateCoagulationCoefficient( &
-               CoagulationCoefficient,          & ! O [m3/s] coagulation coefficient
-               rk(modeIndexCoagulator),         & ! I [m] radius of coagulator
-               rhob(modeIndexCoagulator),       & ! I [kg/m3] density of coagulator
-               rhob(modeIndexReceiver) )          ! I [kg/m3] density of receiver
+               CoagulationCoefficient,          & !O [m3/s] coagulation coefficient
+               rk(modeIndexCoagulator),         & !I [m] radius of coagulator
+               rhob(modeIndexCoagulator),       & !I [kg/m3] density of coagulator
+               rhob(modeIndexReceiver) )          !I [kg/m3] density of receiver
 
-          ! Save values
+          !Save values
           K12(iReceiverMode,iCoagulatingMode,:) = CoagulationCoefficient(:)
        enddo
-    end do ! receiver modes
+    end do !receiver modes
 
     do iReceiverMode = 1, numberOfAddCoagReceivers
        iCoagulatingMode = 1
 
-       ! Index of the coagulating mode (0-14), see list above
+       !Index of the coagulating mode (0-14), see list above
        modeIndexCoagulator = coagulatingMode(iCoagulatingMode)
 
-       ! Index of receiver mode (0-14), see list above
+       !Index of receiver mode (0-14), see list above
        modeIndexReceiver = addReceiverMode(iReceiverMode)
 
-       ! Pre-calculate coagulation coefficients for this coagulator..
-       ! Note: Not using actual density of coagulator here
-       ! Since this is not known at init-time
-       call calculateCoagulationCoefficient(CoagulationCoefficient    & ! O [m3/s] coagulation coefficient
-            , rk(modeIndexCoagulator)                 & ! I [m] radius of coagulator
-            , rhob(modeIndexCoagulator)               & ! I [kg/m3] density of coagulator
-            , rhob(modeIndexReceiver) )                 ! I [kg/m3] density of receiver
+       !Pre-calculate coagulation coefficients for this coagulator..
+       !Note: Not using actual density of coagulator here
+       !Since this is not known at init-time
+       call calculateCoagulationCoefficient(CoagulationCoefficient    & !O [m3/s] coagulation coefficient
+            , rk(modeIndexCoagulator)                 & !I [m] radius of coagulator
+            , rhob(modeIndexCoagulator)               & !I [kg/m3] density of coagulator
+            , rhob(modeIndexReceiver) )                 !I [kg/m3] density of receiver
 
-       ! Save values
+       !Save values
        CoagCoeffModeAdd(iReceiverMode,:) = CoagulationCoefficient(:)
 
-    end do ! receiver modes
+    end do !receiver modes
 
     ! Only one receivermode for cloud coagulation (water)
     do iCoagulatingMode = 1,numberOfCoagulatingModes
 
-       ! Index of the coagulating mode (0-14), see list above
+       !Index of the coagulating mode (0-14), see list above
        modeIndexCoagulator = coagulatingMode(iCoagulatingMode)
 
-       ! Pre-calculate coagulation coefficients for this coagulator..
-       ! Note: Not using actual density of coagulator here
-       ! Since this is not known at init-time
-       call calculateCoagulationCoefficient(CoagulationCoefficient & ! O [m3/s] coagulation coefficient
-            , rk(modeIndexCoagulator)                              & ! I [m] radius of coagulator
-            , rhob(modeIndexCoagulator)                            & ! I [kg/m3] density of coagulator
-            , rhoh2o )                                               ! I [kg/m3] density of receiver
+       !Pre-calculate coagulation coefficients for this coagulator..
+       !Note: Not using actual density of coagulator here
+       !Since this is not known at init-time
+       call calculateCoagulationCoefficient(CoagulationCoefficient    & !O [m3/s] coagulation coefficient
+            , rk(modeIndexCoagulator)                 & !I [m] radius of coagulator
+            , rhob(modeIndexCoagulator)               & !I [kg/m3] density of coagulator
+            , rhoh2o )                                  !I [kg/m3] density of receiver
 
-       ! Save values
+       !Save values
        K12Cl(iCoagulatingMode,:) = CoagulationCoefficient(:)
 
     enddo
 
-    ! We don't need to remember K12 for all lookuptable sizes
-    ! We only need to rember for 1 [#/m3] of each receiver mode
-    ! and then later scale by number concentration in receiver modes
+    !We don't need to remember K12 for all lookuptable sizes!!
+    !We only need to rember for 1 [#/m3] of each receiver mode
+    !and then later scale by number concentration in receiver modes
     normalizedCoagulationSink(:,:) = 0.0_r8
 
     do iCoagulatingMode = 1, numberOfCoagulatingModes
 
-       ! Sum the loss for all possible receivers
+       !Sum the loss for all possible receivers
        do iReceiverMode = 1, numberOfCoagulationReceivers
 
-          modeIndexCoagulator = coagulatingMode(iCoagulatingMode) ! Index of the coagulating mode
+          modeIndexCoagulator = coagulatingMode(iCoagulatingMode) !Index of the coagulating mode
 
-          modeIndexReceiver = receiverMode(iReceiverMode) ! Index of receiver mode
+          modeIndexReceiver = receiverMode(iReceiverMode) !Index of receiver mode
 
-          do nsiz=1,nBinsTab  ! aerotab bin sizes
+          do nsiz=1,nBinsTab  !aerotab bin sizes
 
-             ! Sum up coagulation sink for this coagulating species (for all receiving modes)
-             normalizedCoagulationSink(modeIndexReceiver, modeIndexCoagulator)      = & ! [m3/#/s]
-                  normalizedCoagulationSink(modeIndexReceiver, modeIndexCoagulator)   & ! [m3/#/s] Previous value
-                  + normnk(modeIndexReceiver, nsiz)                                   & ! Normalized size distribution for receiver mode
-                  * K12(iReceiverMode, iCoagulatingMode, nsiz)                          ! Coagulation coefficient (m3/#/s)
+             !Sum up coagulation sink for this coagulating species (for all receiving modes)
+             normalizedCoagulationSink(modeIndexReceiver, modeIndexCoagulator)      =   & ![m3/#/s]
+                  normalizedCoagulationSink(modeIndexReceiver, modeIndexCoagulator)    &  ![m3/#/s] Previous value
+                  + normnk(modeIndexReceiver, nsiz)          &                            !Normalized size distribution for receiver mode
+                  * K12(iReceiverMode, iCoagulatingMode, nsiz)                            !Coagulation coefficient (m3/#/s)
 
-          end do ! Look up table size
-       end do    ! receiver modes
-    end do       ! coagulator
+          end do !Look up table size
+       end do    !receiver modes
+    end do       !coagulator
 
 
-    ! Calculate additional coagulation sink for mode 1 in such a way that it
-    ! affects coagulationSink but not the lifecycling (directly) otherwise
+    !Calculate additional coagulation sink for mode 1 in such a way that it
+    !affects coagulationSink but not the lifecycling (directly) otherwise
 
-    ! Sum the loss for all possible receivers
+    !Sum the loss for all possible receivers
     normCoagSinkAdd(:) = 0.0_r8
     iCoagulatingMode = 1
     do iReceiverMode = 1, numberOfAddCoagReceivers
-       modeIndexReceiver = addReceiverMode(iReceiverMode) ! Index of additional receiver mode
+       modeIndexReceiver = addReceiverMode(iReceiverMode) !Index of additional receiver mode
 
-       do nsiz=1,nBinsTab  ! aerotab bin sizes
-          ! Sum up coagulation sink for this coagulating species (for all receiving modes)
-          normCoagSinkAdd(iReceiverMode)      =  &     ! [m3/#/s]
-               normCoagSinkAdd(iReceiverMode)    &     ! [m3/#/s] Previous value
-               + normnk(modeIndexReceiver, nsiz) &     ! Normalized size distribution for receiver mode
-               * CoagCoeffModeAdd(iReceiverMode, nsiz) ! Koagulation coefficient (m3/#/s)
-       end do ! Look up table size
-    end do    ! receiver modes
+       do nsiz=1,nBinsTab  !aerotab bin sizes
+          !Sum up coagulation sink for this coagulating species (for all receiving modes)
+          normCoagSinkAdd(iReceiverMode)      =  &     ![m3/#/s]
+               normCoagSinkAdd(iReceiverMode)    &     ![m3/#/s] Previous value
+               + normnk(modeIndexReceiver, nsiz) &     !Normalized size distribution for receiver mode
+               * CoagCoeffModeAdd(iReceiverMode, nsiz) !Koagulation coefficient (m3/#/s)
+       end do !Look up table size
+    end do    !receiver modes
 
     nsiz=1
     do while (rBinMidPoint(nsiz).lt.rcoagdroplet.and.nsiz.lt.nBinsTab)
@@ -264,10 +287,10 @@ contains
          coagulation ',rcoagdroplet, ' nbin ',tableindexcloud,'binmid',rBinMidPoint(tableindexcloud)
 
     do iCoagulatingMode = 1, numberOfCoagulatingModes
-       modeIndexCoagulator = coagulatingMode(iCoagulatingMode) ! Index of the coagulating mode
+       modeIndexCoagulator = coagulatingMode(iCoagulatingMode) !Index of the coagulating mode
 
-       NCloudCoagulationSink(modeIndexCoagulator) =   & ! [m3/#/s]
-            K12Cl(iCoagulatingMode, tableindexcloud)    ! Koagulation coefficient (m3/#/s)
+       NCloudCoagulationSink(modeIndexCoagulator) =   & ![m3/#/s]
+            K12Cl(iCoagulatingMode, tableindexcloud)    !Koagulation coefficient (m3/#/s)
     end do
 
     !-------------------------------------
@@ -278,7 +301,7 @@ contains
 
     isAlreadyOnList(:) = .FALSE.
     do iChem = 1,gas_pcnst
-       ! Does this tracer have a receiver? If yes: It contributes to coagulation
+       !Does this tracer have a receiver? If yes: It contributes to coagulation
        if(lifeCycleReceiver(iChem) .gt. 0)then
           unit = "kg/m2/s"
           fieldname_donor = trim(solsym(iChem))//"coagTend"
@@ -318,38 +341,38 @@ contains
   !================================================================
   subroutine calculateCoagulationCoefficient(CoagulationCoefficient, modeRadius, modeDensity, receiverDensity)
 
-    ! Calculates coagulation coefficient for a coagulator mode
-    ! with a given radius with all look-up table modes
+    !Calculates coagulation coefficient for a coagulator mode
+    !with a given radius with all look-up table modes
 
     real(r8), intent(in)  :: modeRadius      ! [m] (?)
     real(r8), intent(in)  :: modeDensity     ! [kg/m3] densityi
     real(r8), intent(in)  :: receiverDensity ! [kg/m3] density of receiver
-    real(r8), intent(out), dimension(:)  :: coagulationCoefficient ! [m3/s]
+    real(r8), intent(out), dimension(:)  :: coagulationCoefficient ![m3/s]
 
-    integer  :: i     ! Counter for look-up tables
-    real(r8) :: diff1 ! [m2/s] diffusivity
-    real(r8) :: diff2 ! [m2/s] diffusivity
-    real(r8) :: g12   ! [-] factor
-    real(r8) :: g1    ! [-] factor
-    real(r8) :: g2    ! [-] factor
-    real(r8) :: c12   ! [m/s] average particle thermal velocity
-    real(r8) :: c1    ! [m/s] particle thermal velocity
-    real(r8) :: c2    ! [m/s] particle thermal velocity
-    real(r8) :: mfv1  ! [m] mean free path particle
-    real(r8) :: mfv2  ! [m] mean free path particle
+    integer  :: i     !Counter for look-up tables
+    real(r8) :: diff1 ![m2/s] diffusivity
+    real(r8) :: diff2 ![m2/s] diffusivity
+    real(r8) :: g12   ![-] factor
+    real(r8) :: g1    ![-] factor
+    real(r8) :: g2    ![-] factor
+    real(r8) :: c12   ![m/s] average particle thermal velocity
+    real(r8) :: c1    ![m/s] particle thermal velocity
+    real(r8) :: c2    ![m/s] particle thermal velocity
+    real(r8) :: mfv1  ![m] mean free path particle
+    real(r8) :: mfv2  ![m] mean free path particle
 
     ! coagulation coefficient for SO4 (Brownian, Fuchs form)
-    ! loop through indexes in look-up table
+    ! Loop through indexes in look-up table
     do i=1,nBinsTab
-       c1=calculateThermalVelocity(rBinMidPoint(i), receiverDensity) !receiving size
-       c2=calculateThermalVelocity(modeRadius, modeDensity)          !coagulating aerosol
+       c1=calculateThermalVelocity(rBinMidPoint(i), receiverDensity)     !receiving size
+       c2=calculateThermalVelocity(modeRadius, modeDensity)    !coagulating aerosol
        c12=sqrt(c1**2+c2**2)
 
-       diff1 = calculateParticleDiffusivity(rBinMidPoint(i))         !receiving particle
-       diff2 = calculateParticleDiffusivity(modeRadius)              !coagulating particle
+       diff1 = calculateParticleDiffusivity(rBinMidPoint(i))             !receiving particle
+       diff2 = calculateParticleDiffusivity(modeRadius)        !coagulating particle
 
-       mfv1=calculateMeanFreePath(diff1,c1)                          !receiving particle
-       mfv2=calculateMeanFreePath(diff2,c2)                          !coagulating particle
+       mfv1=calculateMeanFreePath(diff1,c1)  !receiving particle
+       mfv2=calculateMeanFreePath(diff2,c2)  !coagulating particle
 
        g1 = calculateGFactor(rBinMidPoint(i), mfv1)
        g2 = calculateGFactor(modeRadius, mfv2)
@@ -357,16 +380,16 @@ contains
        g12=sqrt(g1**2+g2**2)
 
        !Coagulation coefficient of receiver size "i" with the coagulating mode "kcomp"
-       CoagulationCoefficient(i) =                                          &
-            4.0_r8*pi*(rBinMidPoint(i)+modeRadius)*(diff1+diff2)            &
-            /((rBinMidPoint(i)+modeRadius)/(rBinMidPoint(i)+modeRadius+g12) &
+       CoagulationCoefficient(i) =  &
+            4.0_r8*pi*(rBinMidPoint(i)+modeRadius)*(diff1+diff2)          &
+            /((rBinMidPoint(i)+modeRadius)/(rBinMidPoint(i)+modeRadius+g12)         &
             +(4.0_r8/c12)*(diff1+diff2)/(modeRadius+rBinMidPoint(i)))
 
-    enddo ! loop on imax
+    enddo
   end subroutine calculateCoagulationCoefficient
 
   !================================================================
-  subroutine coagtend(  q, pmid, pdel, temperature, delt_inverse, ncol , lchnk)
+  subroutine coagtend(q, pmid, pdel, temperature, delt_inverse, ncol, lchnk)
 
     ! Time step routine for coagulation - called from chemistry
     ! Calculate the coagulation of small aerosols with larger particles and
@@ -374,34 +397,34 @@ contains
     ! 40 nm is assumed to have an efficient coagulation with other particles.
 
     !  input arguments
-    integer, intent(in)     :: ncol             ! number of horizontal grid cells (columns)
-    real(r8), intent(inout) :: q(:,:,:)         ! TMR [kg/kg]  including moisture
+    real(r8), intent(inout) :: q(:,:,:)         ! TMR [kg/kg] including moisture
     real(r8), intent(in)    :: pmid(:,:)        ! [Pa] midpoint pressure
     real(r8), intent(in)    :: pdel(:,:)
     real(r8), intent(in)    :: temperature(:,:) ! [K] temperature
     real(r8), intent(in)    :: delt_inverse     ! [1/s] inverse time step
+    integer, intent(in)     :: ncol             ! number of horizontal grid cells (columns)
     integer, intent(in)     :: lchnk            ! [] chnk id needed for output
 
     ! local
-    integer        :: k                   ! level counter
-    integer        :: i                   ! horizontal counter
-    integer        :: m                   ! Species counter
-    integer        :: iCoagulator         ! counter for species coagulating
-    integer        :: iReceiver           ! counter for species receiving coagulate
-    integer        :: iSpecie             ! counter for species in mode
-    integer        :: nsiz                ! loop up table size
-    integer        :: l_index_receiver
-    integer        :: l_index_donor
-    integer        :: modeIndexCoagulator ! Index of coagulating mode
-    integer        :: modeIndexReceiver   ! Index of receiving mode
-    real(r8)       :: rhoAir              ! [kg/m3] air density
-    real(r8)       :: coagulationSink     ! [1/s] loss for coagulating specie
-    real(r8)       :: numberConcentration(numberOfCoagulationReceivers) ! [#/m3] number concentration
-    real(r8)       :: totalLoss(pcols,pver,gas_pcnst) ! [kg/kg] tracer lost
-    character(128) :: long_name           ! [-] needed for diagnostics
-    real(r8)       :: coltend(pcols, gas_pcnst)
-    real(r8)       :: tracer_coltend(pcols)
-    logical        :: history_aerosol
+    integer           :: k                   ! level counter
+    integer           :: i                   ! horizontal counter
+    integer           :: m                   ! Species counter
+    integer           :: iCoagulator         !counter for species coagulating
+    integer           :: iReceiver           !counter for species receiving coagulate
+    integer           :: iSpecie             !counter for species in mode
+    integer           :: nsiz                !loop up table size
+    integer           :: l_index_receiver
+    integer           :: l_index_donor
+    integer           :: modeIndexCoagulator !Index of coagulating mode
+    integer           :: modeIndexReceiver   !Index of receiving mode
+    real(r8)          :: rhoAir              ![kg/m3] air density
+    real(r8)          :: coagulationSink     ![1/s] loss for coagulating specie
+    real(r8)          :: numberConcentration(numberOfCoagulationReceivers) ![#/m3] number concentration
+    real(r8)          :: totalLoss(pcols,pver,gas_pcnst) ![kg/kg] tracer lost
+    character(128)    :: long_name                       ![-] needed for diagnostics
+    real(r8)          :: coltend(pcols, gas_pcnst)
+    real(r8)          :: tracer_coltend(pcols)
+    logical           :: history_aerosol
 
     totalLoss(:,:,:)=0.0_r8
 
@@ -410,26 +433,24 @@ contains
     do k=1,pver
        do i=1,ncol
 
-          ! Air density
+          !Air density
           rhoAir = pmid(i,k)/rair/temperature(i,k)
 
-          ! Initialize number concentration for all receivers
+          !Initialize number concentration for all receivers
           numberConcentration(:) = 0.0_r8
 
-          ! Go though all modes receiving coagulation
+          !Go though all modes receiving coagulation
           do ireceiver = 1,numberOfCoagulationReceivers
 
-             ! Go through all core species in that mode
+             !Go through all core species in that mode
              do iSpecie = 1,getNumberOfTracersInMode(receiverMode(ireceiver))
 
-                ! Find the lifecycle-specie receiving the coagulation
+                !Find the lifecycle-specie receiving the coagulation
                 l_index_receiver = getTracerIndex(receiverMode(ireceiver) , iSpecie , .true.)
-
-                long_name = solsym(l_index_receiver) ! For testing
-
+                long_name = solsym(l_index_receiver) !For testing
 
                 if(.NOT. is_process_mode(l_index_receiver,.true.)) then
-                   ! Add up the number concentration of the receiving mode
+                   !Add up the number concentration of the receiving mode
                    numberConcentration(iReceiver) = numberConcentration(iReceiver) & !previous value
                         + q(i,k,l_index_receiver)                                  & !kg/kg
                         / rhopart(physicsIndex(l_index_receiver))                  & !*[m3/kg] ==> m3/kg
@@ -454,10 +475,10 @@ contains
                 modeIndexReceiver = receiverMode(iReceiver)
 
                 !Sum up coagulation sink for this coagulating species (for all receiving modes)
-                coagulationSink =                                                      & ![1/s]
-                     coagulationSink +                                                 & ![1/] previous value
-                     normalizedCoagulationSink(modeIndexReceiver, modeIndexCoagulator) & ![m3/#/s]
-                     * numberConcentration(ireceiver)                                    !numberConcentration (#/m3)
+                coagulationSink =   &                                                    ![1/s]
+                     coagulationSink + &                                                   ![1/] previous value
+                     normalizedCoagulationSink(modeIndexReceiver, modeIndexCoagulator) &   ![m3/#/s]
+                     * numberConcentration(ireceiver)                       !numberConcentration (#/m3)
              end do    !receiver modes
 
              !SOME LIFECYCLE SPECIES CHANGE "HOST MODE" WHEN THEY PARTICIPATE
@@ -473,9 +494,9 @@ contains
 
                 !process modes don't change mode except so4 condensate which becomes coagulate instead
                 !assumed to have same sink as MODE_IDX_OMBC_INTMIX_AIT
-                if( .NOT. is_process_mode(l_index_donor,.true.)   &
-                     .OR. ( (l_index_donor.eq.chemistryIndex(l_so4_a1)) &
-                     .AND. modeIndexCoagulator .eq. MODE_IDX_OMBC_INTMIX_COAT_AIT) ) then
+                if( .NOT. is_process_mode(l_index_donor,.true.) .or. &
+                     ( (l_index_donor == chemistryIndex(l_so4_a1)) .and. &
+                        modeIndexCoagulator == MODE_IDX_OMBC_INTMIX_COAT_AIT) ) then
 
                    !Done summing total loss of this coagulating specie
                    totalLoss(i,k,l_index_donor) = coagulationSink & !loss rate for a mode in [1/s] summed over all receivers
@@ -493,16 +514,16 @@ contains
     end do    ! k
 
 
-    !UPDATE THE TRACERS AND DO DIAGNOSTICS
+    ! UPDATE THE TRACERS AND DO DIAGNOSTICS
     do iCoagulator = 1, numberOfCoagulatingModes
        do ispecie = 1, getNumberOfTracersInMode(coagulatingMode(iCoagulator))
 
           l_index_donor = getTracerIndex(coagulatingMode(iCoagulator) , ispecie ,.true.)
 
           !so4_a1 is a process mode (condensate), but is still lost in coagulation
-          if( .NOT. is_process_mode(l_index_donor, .true.)          &
-              .OR. ( (l_index_donor.eq.chemistryIndex(l_so4_a1)) .AND. &
-                      coagulatingMode(iCoagulator) .eq. MODE_IDX_OMBC_INTMIX_COAT_AIT) ) then
+          if( .NOT. is_process_mode(l_index_donor, .true.) .or. &
+               ( (l_index_donor == chemistryIndex(l_so4_a1)) .and. &
+                  coagulatingMode(iCoagulator) == MODE_IDX_OMBC_INTMIX_COAT_AIT) ) then
 
              l_index_donor = getTracerIndex(coagulatingMode(iCoagulator) , ispecie,.true. )
 
@@ -537,14 +558,14 @@ contains
              long_name= trim(solsym(i))//"coagTend"
              call outfld(long_name, coltend(:ncol,i), ncol, lchnk)
              long_name= trim(solsym(lifeCycleReceiver(i)))//"coagTend"
-             call outfld(long_name, coltend(:ncol,lifeCycleReceiver(i)), ncol, lchnk)
+             call outfld(long_name, coltend(:ncol,lifeCycleReceiver(i)),ncol,lchnk)
           end if
        end do
     endif
   end subroutine coagtend
 
   !================================================================
-  subroutine clcoag(q, pmid, pdel, temperature, cldnum, cldfrc, delt_inverse, ncol , lchnk, im, pbuf)
+  subroutine clcoag(q, pmid, pdel, temperature, cldnum, cldfrc, delt_inverse, ncol, lchnk, im, pbuf)
 
     ! Calculate the coagulation of small aerosols with larger particles and
     ! cloud droplets. Only particles smaller that dry radius of
@@ -618,18 +639,17 @@ contains
                    !process modes don't change mode except so4 condensate which becomes coagulate instead
                    !assumed to have same sink as MODE_IDX_OMBC_INTMIX_AIT
                    if( .NOT. is_process_mode(l_index_donor,.true.) .or.  &
-                        ( (l_index_donor.eq.chemistryIndex(l_so4_a1)) .and. &
+                        ( (l_index_donor == chemistryIndex(l_so4_a1)) .and. &
                            modeIndexCoagulator == MODE_IDX_OMBC_INTMIX_COAT_AIT) ) then
 
                       !Done summing total loss of this coagulating specie
                       cloudLoss(i,k,l_index_donor) = coagulationSink & !loss rate for a mode in [1/s] summed over all receivers
                            * cldfrc(i,k)*q(i,k,l_index_donor)        & !* mixing ratio ==> MMR/s
-                           / delt_inverse                              ! seconds ==> MMR
+                           / delt_inverse                              !/ seconds ==> MMR
 
                       !Can not loose more than we have
                       ! At present day assumed lost within the cloud
                       cloudLoss(i,k,l_index_donor) = min(cloudLoss(i,k,l_index_donor) , cldfrc(i,k)*q(i,k,l_index_donor))
-
 
                    end if !check on process modes
                 end do    !species in mode
@@ -639,15 +659,15 @@ contains
        end do ! i
     end do    ! k
 
-    !UPDATE THE TRACERS AND DO DIAGNOSTICS
+    ! UPDATE THE TRACERS AND DO DIAGNOSTICS
     do iCoagulator = 1, numberOfCoagulatingModes
        do ispecie = 1, getNumberOfTracersInMode(coagulatingMode(iCoagulator))
           l_index_donor = getTracerIndex(coagulatingMode(iCoagulator) , ispecie ,.true.)
 
           !so4_a1 is a process mode (condensate), but is still lost in coagulation
-          if( .NOT. is_process_mode(l_index_donor, .true.)          &
-              .OR. ( (l_index_donor.eq.chemistryIndex(l_so4_a1)) .AND. coagulatingMode(iCoagulator) &
-              .eq. MODE_IDX_OMBC_INTMIX_COAT_AIT) ) then
+          if( .NOT. is_process_mode(l_index_donor, .true.) .or. &
+               ( (l_index_donor == chemistryIndex(l_so4_a1)) .and. &
+                  coagulatingMode(iCoagulator) == MODE_IDX_OMBC_INTMIX_COAT_AIT) ) then
 
              l_index_donor = getTracerIndex(coagulatingMode(iCoagulator), ispecie, .true.)
 
@@ -668,7 +688,7 @@ contains
        end do
     end do
 
-    ! Output for diagnostics
+    !Output for diagnostics
     if(history_aerosol)then
        coltend(:ncol,:) = 0.0_r8
        do i=1,gas_pcnst
@@ -686,7 +706,7 @@ contains
              long_name= trim(solsym(i))//"clcoagTend"
              call outfld(long_name, coltend(:ncol,i), ncol, lchnk)
              long_name= trim(solsym(CloudAerReceiver(i)))//"_OCWclcoagTend"
-             call outfld(long_name, coltend(:ncol,CloudAerReceiver(i)), ncol, lchnk)
+             call outfld(long_name, coltend(:ncol,CloudAerReceiver(i)),ncol,lchnk)
           end if
        end do
     endif
@@ -704,13 +724,12 @@ contains
 
   !================================================================
   function calculateParticleDiffusivity(radius) result (diffusivity)
-
     real(r8), intent(in) :: radius        ![m] particle radius
-    real(r8) :: diffusivity   ![m2/s] diffusivity
 
-    real(r8) :: knudsenNumber ![-] knudsen number
-    real(r8) :: factor
-    real(r8) :: numerator, nominator
+    real(r8)             :: knudsenNumber ![-] knudsen number
+    real(r8)             :: diffusivity   ![m2/s] diffusivity
+    real(r8)             :: factor
+    real(r8)             :: numerator, nominator
 
     !Solve eqn for diffusivity in Seinfeld/Pandis, table 12.1
     knudsenNumber = mfpAir/radius

--- a/src/oslo_aero_nucleate_ice.F90
+++ b/src/oslo_aero_nucleate_ice.F90
@@ -155,7 +155,7 @@ contains
     integer :: ierr
     integer :: m, n
     logical :: history_cesm_forcing
-    character(len=*), parameter :: routine = 'nucleate_ice_cam_init'
+    character(len=*), parameter :: routine = 'nucleate_ice_oslo_init'
     !--------------------------------------------------------------------------------------------
 
     call phys_getopts(history_cesm_forcing_out = history_cesm_forcing)

--- a/src/oslo_aero_ocean.F90
+++ b/src/oslo_aero_ocean.F90
@@ -40,7 +40,7 @@ module oslo_aero_ocean
 
   ! Public interfaces
   public :: oslo_aero_ocean_init ! initializing, reading file
-  public :: oslo_aero_ocean_time ! time interpolation
+  public :: oslo_aero_ocean_adv  ! spatial and time interpolation
   public :: oslo_aero_dms_emis   ! calculate dms surface emissions
   public :: oslo_aero_dms_inq    ! logical function which tells mo_srf_emis what to do
   public :: oslo_aero_opom_emis  ! calculate opom surface emissions
@@ -58,7 +58,7 @@ module oslo_aero_ocean
   integer            :: dms_cycle_yr  = 0               !will be collected from NAMELIST
 
   !will be collected from NAMELIST - but can be overwritten by atm_import_export if the ocean is sending DMS to the atm
-  character(len=20), public  :: dms_source = 'emission_file' 
+  character(len=20), public  :: dms_source = 'emission_file'
   !
   character(len=16)  :: opomo_fld_name = 'chlor_a'      !not set from namelist, hard coded, name of nc var
   character(len=16)  :: opomn_fld_name = 'poc'          !not set from namelist, hard coded, name of nc var
@@ -189,7 +189,7 @@ contains
   endsubroutine oslo_aero_ocean_init
 
   !===============================================================================
-  subroutine oslo_aero_ocean_time(state, pbuf2d)
+  subroutine oslo_aero_ocean_adv(state, pbuf2d)
 
     ! Interpolate ocean_species in space and time to model grid and time
 
@@ -204,7 +204,7 @@ contains
        call advance_trcdata( oceanspcs(m)%fields, oceanspcs(m)%file, state, pbuf2d  )
     end do
 
-  endsubroutine oslo_aero_ocean_time
+  endsubroutine oslo_aero_ocean_adv
 
   !===============================================================================
   subroutine oslo_aero_dms_emis(ncol, lchnk, u, v, zm, ocnfrc, icefrc, sst, fdms, cflx)
@@ -219,7 +219,7 @@ contains
     real(r8) , intent(in)    :: icefrc(pcols)
     real(r8) , intent(in)    :: sst(pcols)
     real(r8) , intent(in)    :: fdms(pcols)
-    real(r8) , intent(inout) :: cflx(pcols,pcnst) 
+    real(r8) , intent(inout) :: cflx(pcols,pcnst)
 
     ! local variables
     real(r8) :: u10m(pcols)     ! [m/s]

--- a/src/oslo_aero_optical_params.F90
+++ b/src/oslo_aero_optical_params.F90
@@ -1,746 +1,744 @@
 module oslo_aero_optical_params
 
-  ! Optical parameters for a composite aerosol is calculated by interpolation
-  ! from the tables kcomp1.out-kcomp14.out.
+   ! Optical parameters for a composite aerosol is calculated by interpolation
+   ! from the tables kcomp1.out-kcomp14.out.
 
-  use shr_kind_mod,        only: r8 => shr_kind_r8
-  use ppgrid,              only: pcols, pver, pverp
-  use constituents,        only: pcnst
-  use cam_history,         only: outfld
-  use physconst,           only: rair,pi
-  use physics_types,       only: physics_state
-  use wv_saturation,       only: qsat_water
-  !
-  use oslo_aero_share,     only: eps, rh, fombg, fbcbg, fac, fbc, faq, cate, cat
-  use oslo_aero_share,     only: nmodes, nbmodes, nbands, nlwbands
-  use oslo_aero_share,     only: rhopart, l_soa_na, l_so4_na
-  use oslo_aero_share,     only: calculateNumberConcentration
-  use oslo_aero_conc,      only: calculateBulkProperties, partitionMass
-  use oslo_aero_sw_tables, only: interpol0, interpol1, interpol2to3, interpol4, interpol5to10
-  use oslo_aero_aerocom,   only: aerocom1, aerocom2
+   use shr_kind_mod,        only: r8 => shr_kind_r8
+   use ppgrid,              only: pcols, pver, pverp
+   use constituents,        only: pcnst
+   use cam_history,         only: outfld
+   use physconst,           only: rair,pi
+   use physics_types,       only: physics_state
+   use wv_saturation,       only: qsat_water
+   !
+   use oslo_aero_share,     only: eps, rh, fombg, fbcbg, fac, fbc, faq, cate, cat
+   use oslo_aero_share,     only: nmodes, nbmodes, nbands, nlwbands
+   use oslo_aero_share,     only: rhopart, l_soa_na, l_so4_na
+   use oslo_aero_share,     only: calculateNumberConcentration
+   use oslo_aero_conc,      only: calculateBulkProperties, partitionMass
+   use oslo_aero_sw_tables, only: interpol0, interpol1, interpol2to3, interpol4, interpol5to10
+   use oslo_aero_aerocom,   only: aerocom1, aerocom2
 
-  implicit none
-  private
+   implicit none
+   private
 
-  public  :: oslo_aero_optical_params_calc
+   public  :: oslo_aero_optical_params_calc
 
-  private :: inputForInterpol
+   private :: inputForInterpol
 
 !===============================================================================
 contains
 !===============================================================================
 
-  subroutine oslo_aero_optical_params_calc(lchnk, ncol, pint, pmid,                &
-       coszrs, state, t, cld, qm1, Nnatk,                                          &
-       per_tau, per_tau_w, per_tau_w_g, per_tau_w_f, per_lw_abs,                   &
-       volc_ext_sun, volc_omega_sun, volc_g_sun, volc_ext_earth, volc_omega_earth, &
-       aodvis, absvis)
+   subroutine oslo_aero_optical_params_calc(lchnk, ncol, pint, pmid,                &
+        coszrs, state, t, cld, qm1,                                                 &
+        per_tau, per_tau_w, per_tau_w_g, per_tau_w_f, per_lw_abs,                   &
+        volc_ext_sun, volc_omega_sun, volc_g_sun, volc_ext_earth, volc_omega_earth, &
+        aodvis, absvis)
 
-    ! Input arguments
-    integer , intent(in) :: lchnk                                 ! chunk identifier
-    integer , intent(in) :: ncol                                  ! number of atmospheric columns
-    real(r8), intent(in) :: coszrs(pcols)                         ! Cosine solar zenith angle
-    real(r8), intent(in) :: pint(pcols,pverp)                     ! Model interface pressures (10*Pa)
-    real(r8), intent(in) :: pmid(pcols,pver)                      ! Model level pressures (Pa)
-    real(r8), intent(in) :: t(pcols,pver)                         ! Model level temperatures (K)
-    real(r8), intent(in) :: cld(pcols,pver)                       ! cloud fraction
-    real(r8), intent(in) :: qm1(pcols,pver,pcnst)                 ! Specific humidity and tracers (kg/kg)
-    real(r8), intent(in) :: volc_ext_sun(pcols,pver,nbands)       ! volcanic aerosol extinction for solar bands, CMIP6
-    real(r8), intent(in) :: volc_omega_sun(pcols,pver,nbands)     ! volcanic aerosol SSA for solar bands, CMIP6
-    real(r8), intent(in) :: volc_g_sun(pcols,pver,nbands)         ! volcanic aerosol g for solar bands, CMIP6
-    real(r8), intent(in) :: volc_ext_earth(pcols,pver,nlwbands)   ! volcanic aerosol extinction for terrestrial bands, CMIP6
-    real(r8), intent(in) :: volc_omega_earth(pcols,pver,nlwbands) ! volcanic aerosol SSA for terrestrial bands, CMIP6
-    type(physics_state), intent(in), target :: state
+      ! Input arguments
+      integer , intent(in) :: lchnk                                 ! chunk identifier
+      integer , intent(in) :: ncol                                  ! number of atmospheric columns
+      real(r8), intent(in) :: coszrs(pcols)                         ! Cosine solar zenith angle
+      real(r8), intent(in) :: pint(pcols,pverp)                     ! Model interface pressures (10*Pa)
+      real(r8), intent(in) :: pmid(pcols,pver)                      ! Model level pressures (Pa)
+      real(r8), intent(in) :: t(pcols,pver)                         ! Model level temperatures (K)
+      real(r8), intent(in) :: cld(pcols,pver)                       ! cloud fraction
+      real(r8), intent(in) :: qm1(pcols,pver,pcnst)                 ! Specific humidity and tracers (kg/kg)
+      real(r8), intent(in) :: volc_ext_sun(pcols,pver,nbands)       ! volcanic aerosol extinction for solar bands, CMIP6
+      real(r8), intent(in) :: volc_omega_sun(pcols,pver,nbands)     ! volcanic aerosol SSA for solar bands, CMIP6
+      real(r8), intent(in) :: volc_g_sun(pcols,pver,nbands)         ! volcanic aerosol g for solar bands, CMIP6
+      real(r8), intent(in) :: volc_ext_earth(pcols,pver,nlwbands)   ! volcanic aerosol extinction for terrestrial bands, CMIP6
+      real(r8), intent(in) :: volc_omega_earth(pcols,pver,nlwbands) ! volcanic aerosol SSA for terrestrial bands, CMIP6
+      type(physics_state), intent(in), target :: state
 
-    ! Input-output arguments
-    real(r8), intent(inout) :: Nnatk(pcols,pver,0:nmodes)         ! aerosol mode number concentration
+      ! Input-output arguments
 
-    ! Output arguments
-    ! AOD and absorptive AOD for visible wavelength closest to 0.55 um (0.442-0.625)
-    ! Note that aodvis and absvis output should be divided by dayfoc to give physical (A)AOD values
-    real(r8), intent(out) :: per_tau    (pcols,0:pver,nbands)     ! aerosol extinction optical depth
-    real(r8), intent(out) :: per_tau_w  (pcols,0:pver,nbands)     ! aerosol single scattering albedo * tau
-    real(r8), intent(out) :: per_tau_w_g(pcols,0:pver,nbands)     ! aerosol assymetry parameter * w * tau
-    real(r8), intent(out) :: per_tau_w_f(pcols,0:pver,nbands)     ! aerosol forward scattered fraction * w * tau
-    real(r8), intent(out) :: per_lw_abs (pcols,pver,nlwbands)     ! aerosol absorption optical depth (LW)
-    real(r8), intent(out) :: aodvis(pcols)                        ! AOD vis
-    real(r8), intent(out) :: absvis(pcols)                        ! AAOD vis
+      ! Output arguments
+      ! AOD and absorptive AOD for visible wavelength closest to 0.55 um (0.442-0.625)
+      ! Note that aodvis and absvis output should be divided by dayfoc to give physical (A)AOD values
+      real(r8), intent(out) :: per_tau    (pcols,0:pver,nbands)     ! aerosol extinction optical depth
+      real(r8), intent(out) :: per_tau_w  (pcols,0:pver,nbands)     ! aerosol single scattering albedo * tau
+      real(r8), intent(out) :: per_tau_w_g(pcols,0:pver,nbands)     ! aerosol assymetry parameter * w * tau
+      real(r8), intent(out) :: per_tau_w_f(pcols,0:pver,nbands)     ! aerosol forward scattered fraction * w * tau
+      real(r8), intent(out) :: per_lw_abs (pcols,pver,nlwbands)     ! aerosol absorption optical depth (LW)
+      real(r8), intent(out) :: aodvis(pcols)                        ! AOD vis
+      real(r8), intent(out) :: absvis(pcols)                        ! AAOD vis
 
-    ! Local variables
-    integer  :: i, k, ib, icol, mplus10
-    integer  :: iloop
-    logical  :: daylight(pcols)        ! SW calculations also at (polar) night in interpol* if daylight=.true.
-    real(r8) :: aodvisvolc(pcols)      ! AOD vis for CMIP6 volcanic aerosol
-    real(r8) :: absvisvolc(pcols)      ! AAOD vis for CMIP6 volcanic aerosol
-    real(r8) :: bevisvolc(pcols,pver)  ! Extinction in vis wavelength band for CMIP6 volcanic aerosol
-    real(r8) :: rhum(pcols,pver)       ! (trimmed) relative humidity for the aerosol calculations
-    real(r8) :: deltah_km(pcols,pver)  ! Layer thickness, unit km
-    real(r8) :: deltah, airmassl(pcols,pver), airmass(pcols) !akc6
-    real(r8) :: Ca(pcols,pver), f_c(pcols,pver), f_bc(pcols,pver), f_aq(pcols,pver)
-    real(r8) :: fnbc(pcols,pver), faitbc(pcols,pver), f_so4_cond(pcols,pver)
-    real(r8) :: f_soa(pcols,pver),f_soana(pcols,pver)
-    real(r8) :: v_soana(pcols,pver)
-    real(r8) :: dCtot(pcols,pver), Ctot(pcols,pver)
-    real(r8) :: Cam(pcols,pver,nbmodes), fbcm(pcols,pver,nbmodes), fcm(pcols,pver,nbmodes)
-    real(r8) :: faqm(pcols,pver,nbmodes), f_condm(pcols,pver,nbmodes)
-    real(r8) :: f_soam(pcols, pver,nbmodes), faqm4(pcols,pver)
-    real(r8) :: focm(pcols,pver,4)
-    real(r8) :: ssa(pcols,pver,0:nmodes,nbands), asym(pcols,pver,0:nmodes,nbands)
-    real(r8) :: be(pcols,pver,0:nmodes,nbands), ke(pcols,pver,0:nmodes,nbands)
-    real(r8) :: betotvis(pcols,pver), batotvis(pcols,pver)
-    real(r8) :: ssatot(pcols,pver,nbands)     ! spectral aerosol single scattering albedo
-    real(r8) :: asymtot(pcols,pver,nbands)    ! spectral aerosol asymmetry factor
-    real(r8) :: betot(pcols,pver,nbands)      ! spectral aerosol extinction coefficient
-    real(r8) :: batotlw(pcols,pver,nlwbands)  ! spectral aerosol absportion extinction in LW
-    real(r8) :: kalw(pcols,pver,0:nmodes,nlwbands)
-    real(r8) :: balw(pcols,pver,0:nmodes,nlwbands)
-    real(r8) :: volc_balw(pcols,0:pver,nlwbands) ! volcanic aerosol absorption coefficient for terrestrial bands, CMIP6
-    real(r8) :: rh0(pcols,pver), rhoda(pcols,pver)
-    real(r8) :: ssavis(pcols,pver), asymmvis(pcols,pver), extvis(pcols,pver), dayfoc(pcols,pver)
-    real(r8) :: n_aer(pcols,pver)
-    real(r8) :: es(pcols,pver)      ! saturation vapor pressure
-    real(r8) :: qs(pcols,pver)      ! saturation specific humidity
-    real(r8) :: rht(pcols,pver)     ! relative humidity (fraction) (rh is already used in opptab)
-    real(r8) :: rh_temp(pcols,pver) ! relative humidity (fraction) for input to LUT
-    real(r8) :: xrh(pcols,pver)
-    integer  :: irh1(pcols,pver)
-    real(r8) :: xfombg(pcols,pver)
-    integer  :: ifombg1(pcols,pver), ifombg2(pcols,pver)
-    real(r8) :: xct(pcols,pver,nmodes)
-    integer  :: ict1(pcols,pver,nmodes)
-    real(r8) :: xfac(pcols,pver,nbmodes)
-    integer  :: ifac1(pcols,pver,nbmodes)
-    real(r8) :: xfbc(pcols,pver,nbmodes)
-    integer  :: ifbc1(pcols,pver,nbmodes)
-    real(r8) :: xfaq(pcols,pver,nbmodes)
-    integer  :: ifaq1(pcols,pver,nbmodes)
-    real(r8) :: xfbcbg(pcols,pver)
-    integer  :: ifbcbg1(pcols,pver)
-    real(r8) :: xfbcbgn(pcols,pver)
-    integer  :: ifbcbgn1(pcols,pver)
-    logical  :: lw_on   ! LW calculations are performed in interpol* if true
-    real(r8) :: Ctotdry(pcols,pver)
-    real(r8) :: Cwater(pcols,pver)
-    real(r8) :: mmr_aerh2o(pcols,pver)
-    real(r8) :: batotsw13(pcols,pver)
-    real(r8) :: batotlw01(pcols,pver)
-    real(r8) :: daerh2o(pcols)
-    !-------------------------------------------------------------------------
+      ! Local variables
+      integer  :: i, k, ib, icol, mplus10
+      integer  :: iloop
+      real(r8) :: Nnatk(pcols,pver,0:nmodes) ! aerosol mode number concentration
+      logical  :: daylight(pcols)            ! SW calculations also at (polar) night in interpol* if daylight=.true.
+      real(r8) :: aodvisvolc(pcols)          ! AOD vis for CMIP6 volcanic aerosol
+      real(r8) :: absvisvolc(pcols)          ! AAOD vis for CMIP6 volcanic aerosol
+      real(r8) :: bevisvolc(pcols,pver)      ! Extinction in vis wavelength band for CMIP6 volcanic aerosol
+      real(r8) :: rhum(pcols,pver)           ! (trimmed) relative humidity for the aerosol calculations
+      real(r8) :: deltah_km(pcols,pver)      ! Layer thickness, unit km
+      real(r8) :: deltah, airmassl(pcols,pver), airmass(pcols)
+      real(r8) :: Ca(pcols,pver), f_c(pcols,pver), f_bc(pcols,pver), f_aq(pcols,pver)
+      real(r8) :: fnbc(pcols,pver), faitbc(pcols,pver), f_so4_cond(pcols,pver)
+      real(r8) :: f_soa(pcols,pver),f_soana(pcols,pver)
+      real(r8) :: v_soana(pcols,pver)
+      real(r8) :: dCtot(pcols,pver), Ctot(pcols,pver)
+      real(r8) :: Cam(pcols,pver,nbmodes), fbcm(pcols,pver,nbmodes), fcm(pcols,pver,nbmodes)
+      real(r8) :: faqm(pcols,pver,nbmodes), f_condm(pcols,pver,nbmodes)
+      real(r8) :: f_soam(pcols, pver,nbmodes), faqm4(pcols,pver)
+      real(r8) :: focm(pcols,pver,4)
+      real(r8) :: ssa(pcols,pver,0:nmodes,nbands), asym(pcols,pver,0:nmodes,nbands)
+      real(r8) :: be(pcols,pver,0:nmodes,nbands), ke(pcols,pver,0:nmodes,nbands)
+      real(r8) :: betotvis(pcols,pver), batotvis(pcols,pver)
+      real(r8) :: ssatot(pcols,pver,nbands)     ! spectral aerosol single scattering albedo
+      real(r8) :: asymtot(pcols,pver,nbands)    ! spectral aerosol asymmetry factor
+      real(r8) :: betot(pcols,pver,nbands)      ! spectral aerosol extinction coefficient
+      real(r8) :: batotlw(pcols,pver,nlwbands)  ! spectral aerosol absportion extinction in LW
+      real(r8) :: kalw(pcols,pver,0:nmodes,nlwbands)
+      real(r8) :: balw(pcols,pver,0:nmodes,nlwbands)
+      real(r8) :: volc_balw(pcols,0:pver,nlwbands) ! volcanic aerosol absorption coefficient for terrestrial bands, CMIP6
+      real(r8) :: rh0(pcols,pver), rhoda(pcols,pver)
+      real(r8) :: ssavis(pcols,pver), asymmvis(pcols,pver), extvis(pcols,pver), dayfoc(pcols,pver)
+      real(r8) :: n_aer(pcols,pver)
+      real(r8) :: es(pcols,pver)      ! saturation vapor pressure
+      real(r8) :: qs(pcols,pver)      ! saturation specific humidity
+      real(r8) :: rht(pcols,pver)     ! relative humidity (fraction) (rh is already used in opptab)
+      real(r8) :: rh_temp(pcols,pver) ! relative humidity (fraction) for input to LUT
+      real(r8) :: xrh(pcols,pver)
+      integer  :: irh1(pcols,pver)
+      real(r8) :: xfombg(pcols,pver)
+      integer  :: ifombg1(pcols,pver), ifombg2(pcols,pver)
+      real(r8) :: xct(pcols,pver,nmodes)
+      integer  :: ict1(pcols,pver,nmodes)
+      real(r8) :: xfac(pcols,pver,nbmodes)
+      integer  :: ifac1(pcols,pver,nbmodes)
+      real(r8) :: xfbc(pcols,pver,nbmodes)
+      integer  :: ifbc1(pcols,pver,nbmodes)
+      real(r8) :: xfaq(pcols,pver,nbmodes)
+      integer  :: ifaq1(pcols,pver,nbmodes)
+      real(r8) :: xfbcbg(pcols,pver)
+      integer  :: ifbcbg1(pcols,pver)
+      real(r8) :: xfbcbgn(pcols,pver)
+      integer  :: ifbcbgn1(pcols,pver)
+      logical  :: lw_on   ! LW calculations are performed in interpol* if true
+      real(r8) :: Ctotdry(pcols,pver)
+      real(r8) :: Cwater(pcols,pver)
+      real(r8) :: mmr_aerh2o(pcols,pver)
+      real(r8) :: batotsw13(pcols,pver)
+      real(r8) :: batotlw01(pcols,pver)
+      real(r8) :: daerh2o(pcols)
+      !-------------------------------------------------------------------------
 
-    ! calculate relative humidity for table lookup into rh grid
-    call qsat_water(state%t(1:ncol,1:pver), state%pmid(1:ncol,1:pver), es(1:ncol,1:pver), qs(1:ncol,1:pver))
+      ! calculate relative humidity for table lookup into rh grid
+      call qsat_water(state%t(1:ncol,1:pver), state%pmid(1:ncol,1:pver), es(1:ncol,1:pver), qs(1:ncol,1:pver))
 
-    rht(1:ncol,1:pver) = state%q(1:ncol,1:pver,1) / qs(1:ncol,1:pver)
-    rh_temp(1:ncol,1:pver) = min(rht(1:ncol,1:pver),1._r8)
+      rht(1:ncol,1:pver) = state%q(1:ncol,1:pver,1) / qs(1:ncol,1:pver)
+      rh_temp(1:ncol,1:pver) = min(rht(1:ncol,1:pver),1._r8)
 
-    do k=1,pver
-       do icol=1,ncol
-          ! Set upper and lower relative humidity for the aerosol calculations
-          rhum(icol,k) = min(0.995_r8, max(rh_temp(icol,k), 0.01_r8))
-          rhoda(icol,k) = pmid(icol,k)/(rair*t(icol,k))      ! unit kg/m^3
-          if (cld(icol,k) .lt. 1.0_r8) then
-             rhum(icol,k) = (rhum(icol,k) - cld(icol,k)) / (1.0_r8 - cld(icol,k))  ! clear portion
-          end if
-          rhum(icol,k) = min(0.995_r8, max(rhum(icol,k), 0.01_r8))
-       end do
-    end do
+      do k=1,pver
+         do icol=1,ncol
+            ! Set upper and lower relative humidity for the aerosol calculations
+            rhum(icol,k) = min(0.995_r8, max(rh_temp(icol,k), 0.01_r8))
+            rhoda(icol,k) = pmid(icol,k)/(rair*t(icol,k))      ! unit kg/m^3
+            if (cld(icol,k) .lt. 1.0_r8) then
+               rhum(icol,k) = (rhum(icol,k) - cld(icol,k)) / (1.0_r8 - cld(icol,k))  ! clear portion
+            end if
+            rhum(icol,k) = min(0.995_r8, max(rhum(icol,k), 0.01_r8))
+         end do
+      end do
 
-    ! Layer thickness with unit km
-    do icol=1,ncol
-       do k=1,pver
-          deltah_km(icol,k)=1.e-4_r8*(pint(icol,k+1)-pint(icol,k))/(rhoda(icol,k)*9.8_r8)
-       end do
-    end do
+      ! Layer thickness with unit km
+      do icol=1,ncol
+         do k=1,pver
+            deltah_km(icol,k)=1.e-4_r8*(pint(icol,k+1)-pint(icol,k))/(rhoda(icol,k)*9.8_r8)
+         end do
+      end do
 
-    ! interpol-calculations only when daylight or not:
+      ! interpol-calculations only when daylight or not:
 #ifdef AEROCOM                   ! always calculate optics (also at (polar) night)
-    do icol=1,ncol
-       daylight(icol) = .true.
-    end do
+      do icol=1,ncol
+         daylight(icol) = .true.
+      end do
 #else                            ! calculate optics only in daytime
-    do icol=1,ncol
-       if (coszrs(icol) > 0.0_r8) then
-          daylight(icol) = .true.
-       else
-          daylight(icol) = .false.
-       endif
-    end do
+      do icol=1,ncol
+         if (coszrs(icol) > 0.0_r8) then
+            daylight(icol) = .true.
+         else
+            daylight(icol) = .false.
+         endif
+      end do
 #endif
 
-    ! Set SO4, BC and OC concentrations:
+      ! Set SO4, BC and OC concentrations:
 
-    ! initialize concentration fields
-    do i=0,nmodes
-       do k=1,pver
-          do icol=1,ncol
-             Nnatk(icol,k,i)  = 0.0_r8
-          end do
-       end do
-    end do
-    do k=1,pver
-       do icol=1,ncol
-          n_aer(icol,k)     = 0.0_r8
-       end do
-    end do
-    kalw(:,:,:,:) = 0._r8
-    be(:,:,:,:)   = 0._r8
-    ke(:,:,:,:)   = 0._r8
-    asym(:,:,:,:) = 0._r8
-    ssa(:,:,:,:)  = 0._r8
+      ! initialize concentration fields
+      do i=0,nmodes
+         do k=1,pver
+            do icol=1,ncol
+               Nnatk(icol,k,i)  = 0.0_r8
+            end do
+         end do
+      end do
+      do k=1,pver
+         do icol=1,ncol
+            n_aer(icol,k)     = 0.0_r8
+         end do
+      end do
+      kalw(:,:,:,:) = 0._r8
+      be(:,:,:,:)   = 0._r8
+      ke(:,:,:,:)   = 0._r8
+      asym(:,:,:,:) = 0._r8
+      ssa(:,:,:,:)  = 0._r8
 
-    ! Find process tagged bulk aerosol properies (from the life cycle module):
-    call calculateBulkProperties(ncol, qm1, rhoda, Nnatk, Ca, f_c, f_bc, &
-         f_aq, f_so4_cond, f_soa, faitbc, fnbc, f_soana)
+      ! Find process tagged bulk aerosol properies (from the life cycle module):
+      call calculateBulkProperties(ncol, qm1, rhoda, Nnatk, Ca, f_c, f_bc, &
+           f_aq, f_so4_cond, f_soa, faitbc, fnbc, f_soana)
 
-    ! calculating vulume fractions from mass fractions:
-    do k=1,pver
-       do icol=1,ncol
-          v_soana(icol,k) = f_soana(icol,k)/(f_soana(icol,k) &
-               +(1.0_r8-f_soana(icol,k))*rhopart(l_soa_na)/rhopart(l_so4_na))
-       end do
-    end do
+      ! calculating vulume fractions from mass fractions:
+      do k=1,pver
+         do icol=1,ncol
+            v_soana(icol,k) = f_soana(icol,k)/(f_soana(icol,k) &
+                 +(1.0_r8-f_soana(icol,k))*rhopart(l_soa_na)/rhopart(l_so4_na))
+         end do
+      end do
 
-    ! Avoid very small numbers
-    do k=1,pver
-       do icol=1,ncol
-          Ca(icol,k)     = max(eps,Ca(icol,k))
-          f_c(icol,k)    = max(eps,f_c(icol,k))
-          f_bc(icol,k)   = max(eps,f_bc(icol,k))
-          f_aq(icol,k)   = max(eps,f_aq(icol,k))
-          fnbc(icol,k)   = max(eps,fnbc(icol,k))
-          faitbc(icol,k) = max(eps,faitbc(icol,k))
-       end do
-    end do
+      ! Avoid very small numbers
+      do k=1,pver
+         do icol=1,ncol
+            Ca(icol,k)     = max(eps,Ca(icol,k))
+            f_c(icol,k)    = max(eps,f_c(icol,k))
+            f_bc(icol,k)   = max(eps,f_bc(icol,k))
+            f_aq(icol,k)   = max(eps,f_aq(icol,k))
+            fnbc(icol,k)   = max(eps,fnbc(icol,k))
+            faitbc(icol,k) = max(eps,faitbc(icol,k))
+         end do
+      end do
 
-    ! Calculation of the apportionment of internally mixed SO4, BC and OC
-    ! mass between the various background modes.
+      ! Calculation of the apportionment of internally mixed SO4, BC and OC
+      ! mass between the various background modes.
 
-    !==> calls modalapp to partition the mass
-    call partitionMass(ncol, nnatk, Ca, f_c, f_bc, f_aq, f_so4_cond, f_soa , &
-         cam, fcm, fbcm, faqm, f_condm, f_soam )
+      !==> calls modalapp to partition the mass
+      call partitionMass(ncol, nnatk, Ca, f_c, f_bc, f_aq, f_so4_cond, f_soa , &
+           cam, fcm, fbcm, faqm, f_condm, f_soam )
 
-    !The following uses non-standard units, #/cm3 and ug/m3
-    Nnatk(:ncol,:,:) = Nnatk(:ncol,:,:)*1.e-6_r8
-    cam(:ncol,:,:) = cam(:ncol,:,:)*1.e9_r8
+      !The following uses non-standard units, #/cm3 and ug/m3
+      Nnatk(:ncol,:,:) = Nnatk(:ncol,:,:)*1.e-6_r8
+      cam(:ncol,:,:) = cam(:ncol,:,:)*1.e9_r8
 
-    ! Calculate fraction of added mass which is either SOA condensate or OC coagulate,
-    ! which in AeroTab are both treated as condensate for kcomp=1-4.
-    do i=1,4
-       do k=1,pver
-          do icol=1,ncol
-             focm(icol,k,i) = fcm(icol,k,i)*(1.0_r8-fbcm(icol,k,i))
-          enddo
-       enddo
-    enddo
-    do k=1,pver
-       do icol=1,ncol
-          faqm4(icol,k) = faqm(icol,k,4)
-       end do
-    enddo
+      ! Calculate fraction of added mass which is either SOA condensate or OC coagulate,
+      ! which in AeroTab are both treated as condensate for kcomp=1-4.
+      do i=1,4
+         do k=1,pver
+            do icol=1,ncol
+               focm(icol,k,i) = fcm(icol,k,i)*(1.0_r8-fbcm(icol,k,i))
+            enddo
+         enddo
+      enddo
+      do k=1,pver
+         do icol=1,ncol
+            faqm4(icol,k) = faqm(icol,k,4)
+         end do
+      enddo
 
-    ! find common input parameters for use in the interpolation routines
-    call inputForInterpol (ncol, rhum, xrh, irh1,   &
-         f_soana, xfombg, ifombg1, faitbc, xfbcbg, ifbcbg1,  &
-         fnbc, xfbcbgn, ifbcbgn1, Nnatk, Cam, xct, ict1,     &
-         focm, fcm, xfac, ifac1, fbcm, xfbc, ifbc1, faqm, xfaq, ifaq1)
+      ! find common input parameters for use in the interpolation routines
+      call inputForInterpol (ncol, rhum, xrh, irh1,   &
+           f_soana, xfombg, ifombg1, faitbc, xfbcbg, ifbcbg1,  &
+           fnbc, xfbcbgn, ifbcbgn1, Nnatk, Cam, xct, ict1,     &
+           focm, fcm, xfac, ifac1, fbcm, xfbc, ifbc1, faqm, xfaq, ifaq1)
 
 #ifdef AEROCOM
-    call aerocom1(lchnk, ncol, Cam, Nnatk, deltah_km, &
-       xct, ict1, xfac, ifac1, xfbc, ifbc1, xfaq, ifaq1, &
-       xfbcbg, ifbcbg1, xfbcbgn, ifbcbgn1, &
-       xfombg, ifombg1, Ctotdry)
+      call aerocom1(lchnk, ncol, Cam, Nnatk, deltah_km, &
+           xct, ict1, xfac, ifac1, xfbc, ifbc1, xfaq, ifaq1, &
+           xfbcbg, ifbcbg1, xfbcbgn, ifbcbgn1, &
+           xfombg, ifombg1, Ctotdry)
 #endif
 
-    ! (Wet) Optical properties for each of the aerosol modes:
-    lw_on = .true.  ! No LW optics needed for RH=0 (interpol returns 0-values)
+      ! (Wet) Optical properties for each of the aerosol modes:
+      lw_on = .true.  ! No LW optics needed for RH=0 (interpol returns 0-values)
 
-    ! BC(ax) mode (dry only):
-    call interpol0 (ncol, daylight, Nnatk, ssa, asym, be, ke, lw_on, kalw)
+      ! BC(ax) mode (dry only):
+      call interpol0 (ncol, daylight, Nnatk, ssa, asym, be, ke, lw_on, kalw)
 
-    mplus10=0
-    ! SO4/SOA(Ait) mode:
-    call interpol1 (ncol, daylight, xrh, irh1, mplus10, &
-         Nnatk, xfombg, ifombg1, xct, ict1,    &
-         xfac, ifac1, ssa, asym, be, ke, lw_on, kalw)
+      mplus10=0
+      ! SO4/SOA(Ait) mode:
+      call interpol1 (ncol, daylight, xrh, irh1, mplus10, &
+           Nnatk, xfombg, ifombg1, xct, ict1,    &
+           xfac, ifac1, ssa, asym, be, ke, lw_on, kalw)
 
-    ! BC(Ait) and OC(Ait) modes:
-    call interpol2to3 (ncol, daylight, xrh, irh1, mplus10, &
-         Nnatk, xct, ict1, xfac, ifac1, &
-         ssa, asym, be, ke, lw_on, kalw)
+      ! BC(Ait) and OC(Ait) modes:
+      call interpol2to3 (ncol, daylight, xrh, irh1, mplus10, &
+           Nnatk, xct, ict1, xfac, ifac1, &
+           ssa, asym, be, ke, lw_on, kalw)
 
-    ! BC&OC(Ait) mode:   ------ fcm invalid here (=0). Using faitbc instead
-    call interpol4 (ncol, daylight, xrh, irh1, mplus10, &
-         Nnatk, xfbcbg, ifbcbg1, xct, ict1,    &
-         xfac, ifac1, xfaq, ifaq1, ssa, asym, be, ke, lw_on, kalw)
+      ! BC&OC(Ait) mode:   ------ fcm invalid here (=0). Using faitbc instead
+      call interpol4 (ncol, daylight, xrh, irh1, mplus10, &
+           Nnatk, xfbcbg, ifbcbg1, xct, ict1,    &
+           xfac, ifac1, xfaq, ifaq1, ssa, asym, be, ke, lw_on, kalw)
 
-    ! SO4(Ait75) (5), Mineral (6-7) and Sea-salt (8-10) modes:
-    call interpol5to10 (ncol, daylight, xrh, irh1, &
-         Nnatk, xct, ict1, xfac, ifac1, &
-         xfbc, ifbc1, xfaq, ifaq1, ssa, asym, be, ke, lw_on, kalw)
+      ! SO4(Ait75) (5), Mineral (6-7) and Sea-salt (8-10) modes:
+      call interpol5to10 (ncol, daylight, xrh, irh1, &
+           Nnatk, xct, ict1, xfac, ifac1, &
+           xfbc, ifbc1, xfaq, ifaq1, ssa, asym, be, ke, lw_on, kalw)
 
-    ! total aerosol number concentrations
-    do i=0,nmodes    ! mode 0 to 14
-       do k=1,pver
-          do icol=1,ncol
-             n_aer(icol,k)=n_aer(icol,k)+Nnatk(icol,k,i)
-          end do
-       enddo
-    enddo
-    call outfld('N_AER   ',n_aer ,pcols,lchnk)
+      ! total aerosol number concentrations
+      do i=0,nmodes    ! mode 0 to 14
+         do k=1,pver
+            do icol=1,ncol
+               n_aer(icol,k)=n_aer(icol,k)+Nnatk(icol,k,i)
+            end do
+         enddo
+      enddo
+      call outfld('N_AER   ',n_aer ,pcols,lchnk)
 
-    ! BC(Ait) and OC(Ait) modes:
-    mplus10=1
-    call interpol2to3 (ncol, daylight, xrh, irh1, mplus10, &
-         Nnatk, xct, ict1, xfac, ifac1, &
-         ssa, asym, be, ke, lw_on, kalw)
+      ! BC(Ait) and OC(Ait) modes:
+      mplus10=1
+      call interpol2to3 (ncol, daylight, xrh, irh1, mplus10, &
+           Nnatk, xct, ict1, xfac, ifac1, &
+           ssa, asym, be, ke, lw_on, kalw)
 
-    ! BC&OC(n) mode:    ------ fcm not valid here (=0). Use fnbc instead
-    mplus10=1
-    call interpol4 (ncol, daylight, xrh, irh1, mplus10, &
-         Nnatk, xfbcbgn, ifbcbgn1, xct, ict1,  &
-         xfac, ifac1, xfaq, ifaq1, ssa, asym, be, ke, lw_on, kalw)
+      ! BC&OC(n) mode:    ------ fcm not valid here (=0). Use fnbc instead
+      mplus10=1
+      call interpol4 (ncol, daylight, xrh, irh1, mplus10, &
+           Nnatk, xfbcbgn, ifbcbgn1, xct, ict1,  &
+           xfac, ifac1, xfaq, ifaq1, ssa, asym, be, ke, lw_on, kalw)
 
-    ! Determine Ctot
-    Ctot(:,:) = 0.0_r8
-    do i=0,nmodes    ! mode 0 to 14
-       do k=1,pver
-          do icol=1,ncol
-             dCtot(icol,k)=1.e3_r8*be(icol,k,i,4)/(ke(icol,k,i,4)+eps)
-             Ctot(icol,k)=Ctot(icol,k)+dCtot(icol,k)*Nnatk(icol,k,i)
-          end do
-       enddo
-    enddo
+      ! Determine Ctot
+      Ctot(:,:) = 0.0_r8
+      do i=0,nmodes    ! mode 0 to 14
+         do k=1,pver
+            do icol=1,ncol
+               dCtot(icol,k)=1.e3_r8*be(icol,k,i,4)/(ke(icol,k,i,4)+eps)
+               Ctot(icol,k)=Ctot(icol,k)+dCtot(icol,k)*Nnatk(icol,k,i)
+            end do
+         enddo
+      enddo
 
-    ! SW Optical properties of total aerosol:
-    do ib=1,nbands
-       do k=1,pver
-          do icol=1,ncol
-             betot(icol,k,ib)=0.0_r8
-             ssatot(icol,k,ib)=0.0_r8
-             asymtot(icol,k,ib)=0.0_r8
-          end do
-       enddo
-    enddo
-    do ib=1,nbands
-       do i=0,nmodes
-          do k=1,pver
-             do icol=1,ncol
-                betot(icol,k,ib) = betot(icol,k,ib)+Nnatk(icol,k,i)*be(icol,k,i,ib)
-                ssatot(icol,k,ib) = ssatot(icol,k,ib)+Nnatk(icol,k,i) &
-                     *be(icol,k,i,ib)*ssa(icol,k,i,ib)
-                asymtot(icol,k,ib) = asymtot(icol,k,ib)+Nnatk(icol,k,i) &
-                     *be(icol,k,i,ib)*ssa(icol,k,i,ib)*asym(icol,k,i,ib)
-             end do
-          enddo
-       enddo
-    enddo
+      ! SW Optical properties of total aerosol:
+      do ib=1,nbands
+         do k=1,pver
+            do icol=1,ncol
+               betot(icol,k,ib)=0.0_r8
+               ssatot(icol,k,ib)=0.0_r8
+               asymtot(icol,k,ib)=0.0_r8
+            end do
+         enddo
+      enddo
+      do ib=1,nbands
+         do i=0,nmodes
+            do k=1,pver
+               do icol=1,ncol
+                  betot(icol,k,ib) = betot(icol,k,ib)+Nnatk(icol,k,i)*be(icol,k,i,ib)
+                  ssatot(icol,k,ib) = ssatot(icol,k,ib)+Nnatk(icol,k,i) &
+                       *be(icol,k,i,ib)*ssa(icol,k,i,ib)
+                  asymtot(icol,k,ib) = asymtot(icol,k,ib)+Nnatk(icol,k,i) &
+                       *be(icol,k,i,ib)*ssa(icol,k,i,ib)*asym(icol,k,i,ib)
+               end do
+            enddo
+         enddo
+      enddo
 
-    ! Adding also the volcanic contribution (CMIP6), which is using a CMIP6
-    ! band numbering identical to the AeroTab numbering (unlike CAM) both
-    ! for SW and LW. I.e., no remapping is required here.
-    ! Info from CMIP_CAM6_radiation_v3.nc
-    ! wl1_sun = 0.2, 0.263158, 0.344828, 0.441501, 0.625, 0.77821, 1.24224,
-    ! 1.2987, 1.62602, 1.94175, 2.15054, 2.5, 3.07692, 3.84615 ;
-    ! wl2_sun = 0.263158, 0.344828, 0.441501, 0.625, 0.77821, 1.24224, 1.2987,
-    ! 1.62602, 1.94175, 2.15054, 2.5, 3.07692, 3.84615, 12.1951 ;
-    ! wl1_earth = 3.07692, 3.84615, 4.20168, 4.44444, 4.80769, 5.55556, 6.75676,
-    ! 7.19424, 8.47458, 9.25926, 10.2041, 12.1951, 14.2857, 15.873, 20, 28.5714 ;
-    ! wl2_earth = 3.84615, 4.20168, 4.44444, 4.80769, 5.55556, 6.75676, 7.19424,
-    ! 8.47458, 9.25926, 10.2041, 12.1951, 14.2857, 15.873, 20, 28.5714, 1000 ;
-    do ib=1,nbands
-       betot(1:ncol,1:pver,ib) = betot(1:ncol,1:pver,ib) &
-            + volc_ext_sun(1:ncol,1:pver,ib)
-       ssatot(1:ncol,1:pver,ib) = ssatot(1:ncol,1:pver,ib) &
-            + volc_ext_sun(1:ncol,1:pver,ib)*volc_omega_sun(1:ncol,1:pver,ib)
-       asymtot(1:ncol,1:pver,ib) = asymtot(1:ncol,1:pver,ib) &
-            + volc_ext_sun(1:ncol,1:pver,ib)*volc_omega_sun(1:ncol,1:pver,ib) &
-            *volc_g_sun(1:ncol,1:pver,ib)
-    enddo
-    bevisvolc(1:ncol,1:pver) = volc_ext_sun(1:ncol,1:pver,4)
+      ! Adding also the volcanic contribution (CMIP6), which is using a CMIP6
+      ! band numbering identical to the AeroTab numbering (unlike CAM) both
+      ! for SW and LW. I.e., no remapping is required here.
+      ! Info from CMIP_CAM6_radiation_v3.nc
+      ! wl1_sun = 0.2, 0.263158, 0.344828, 0.441501, 0.625, 0.77821, 1.24224,
+      ! 1.2987, 1.62602, 1.94175, 2.15054, 2.5, 3.07692, 3.84615 ;
+      ! wl2_sun = 0.263158, 0.344828, 0.441501, 0.625, 0.77821, 1.24224, 1.2987,
+      ! 1.62602, 1.94175, 2.15054, 2.5, 3.07692, 3.84615, 12.1951 ;
+      ! wl1_earth = 3.07692, 3.84615, 4.20168, 4.44444, 4.80769, 5.55556, 6.75676,
+      ! 7.19424, 8.47458, 9.25926, 10.2041, 12.1951, 14.2857, 15.873, 20, 28.5714 ;
+      ! wl2_earth = 3.84615, 4.20168, 4.44444, 4.80769, 5.55556, 6.75676, 7.19424,
+      ! 8.47458, 9.25926, 10.2041, 12.1951, 14.2857, 15.873, 20, 28.5714, 1000 ;
+      do ib=1,nbands
+         betot(1:ncol,1:pver,ib) = betot(1:ncol,1:pver,ib) &
+              + volc_ext_sun(1:ncol,1:pver,ib)
+         ssatot(1:ncol,1:pver,ib) = ssatot(1:ncol,1:pver,ib) &
+              + volc_ext_sun(1:ncol,1:pver,ib)*volc_omega_sun(1:ncol,1:pver,ib)
+         asymtot(1:ncol,1:pver,ib) = asymtot(1:ncol,1:pver,ib) &
+              + volc_ext_sun(1:ncol,1:pver,ib)*volc_omega_sun(1:ncol,1:pver,ib)*volc_g_sun(1:ncol,1:pver,ib)
+      enddo
+      bevisvolc(1:ncol,1:pver) = volc_ext_sun(1:ncol,1:pver,4)
 
-    ! and then calculate the total bulk optical parameters
-    do ib=1,nbands
-       do k=1,pver
-          do icol=1,ncol
-             ssatot(icol,k,ib) = ssatot(icol,k,ib)/(betot(icol,k,ib)+eps)
-             asymtot(icol,k,ib)= asymtot(icol,k,ib)/(betot(icol,k,ib)*ssatot(icol,k,ib)+eps)
-          end do
-       enddo
-    enddo
+      ! and then calculate the total bulk optical parameters
+      do ib=1,nbands
+         do k=1,pver
+            do icol=1,ncol
+               ssatot(icol,k,ib) = ssatot(icol,k,ib)/(betot(icol,k,ib)+eps)
+               asymtot(icol,k,ib)= asymtot(icol,k,ib)/(betot(icol,k,ib)*ssatot(icol,k,ib)+eps)
+            end do
+         enddo
+      enddo
 
-    !------------------------------------------------------------------------------------------------
-    ! Replace CAM5 standard aerosol optics with CAM5-Oslo optics (except top layer: no aerosol)
-    ! Remapping from AeroTab to CAM5 SW bands, see p. 167 in the CAM5.0 description:
-    ! CAM5 bands         AeroTab bands
-    ! 14 3.846 12.195        14
-    ! 1 3.077 3.846          13
-    ! 2 2.500 3.077          12
-    ! 3 2.150 2.500          11
-    ! 4 1.942 2.150          10
-    ! 5 1.626 1.942           9
-    ! 6 1.299 1.626           8
-    ! 7 1.242 1.299           7
-    ! 8 0.778 1.242           6
-    ! 9 0.625 0.778           5
-    ! 10 0.442 0.625          4
-    ! 11 0.345 0.442          3
-    ! 12 0.263 0.345          2
-    ! 13 0.200 0.263          1
+      ! Replace CAM5 standard aerosol optics with CAM5-Oslo optics (except top layer: no aerosol)
+      ! Remapping from AeroTab to CAM5 SW bands, see p. 167 in the CAM5.0 description:
+      ! CAM5 bands         AeroTab bands
+      ! 14 3.846 12.195        14
+      ! 1 3.077 3.846          13
+      ! 2 2.500 3.077          12
+      ! 3 2.150 2.500          11
+      ! 4 1.942 2.150          10
+      ! 5 1.626 1.942           9
+      ! 6 1.299 1.626           8
+      ! 7 1.242 1.299           7
+      ! 8 0.778 1.242           6
+      ! 9 0.625 0.778           5
+      ! 10 0.442 0.625          4
+      ! 11 0.345 0.442          3
+      ! 12 0.263 0.345          2
+      ! 13 0.200 0.263          1
 
-    do i=1,ncol  ! zero aerosol in the top layer
-       do ib=1,14 ! 1-nbands
-          per_tau(i,0,ib)= 0._r8
-          per_tau_w(i,0,ib)= 0.999_r8
-          per_tau_w_g(i,0,ib)= 0.5_r8
-          per_tau_w_f(i,0,ib)= 0.25_r8
-       end do
-       do ib=1,14  ! initialize also for the other layers
-          do k=1,pver
-             per_tau(i,k,ib)= 0._r8
-             per_tau_w(i,k,ib)= 0.999_r8
-             per_tau_w_g(i,k,ib)= 0.5_r8
-             per_tau_w_f(i,k,ib)= 0.25_r8
-          end do
-       end do
-    end do
+      do i=1,ncol  ! zero aerosol in the top layer
+         do ib=1,14 ! 1-nbands
+            per_tau(i,0,ib)= 0._r8
+            per_tau_w(i,0,ib)= 0.999_r8
+            per_tau_w_g(i,0,ib)= 0.5_r8
+            per_tau_w_f(i,0,ib)= 0.25_r8
+         end do
+         do ib=1,14  ! initialize also for the other layers
+            do k=1,pver
+               per_tau(i,k,ib)= 0._r8
+               per_tau_w(i,k,ib)= 0.999_r8
+               per_tau_w_g(i,k,ib)= 0.5_r8
+               per_tau_w_f(i,k,ib)= 0.25_r8
+            end do
+         end do
+      end do
 
-    ! Remapping of SW wavelength bands from AeroTab to CAM5
-    do i=1,ncol
-       do ib=1,13
-          do k=1,pver
-             per_tau(i,k,ib)=deltah_km(i,k)*betot(i,k,14-ib)
-             per_tau_w(i,k,ib)=per_tau(i,k,ib)*max(min(ssatot(i,k,14-ib),0.999999_r8),1.e-6_r8)
-             per_tau_w_g(i,k,ib)=per_tau_w(i,k,ib)*asymtot(i,k,14-ib)
-             per_tau_w_f(i,k,ib)=per_tau_w_g(i,k,ib)*asymtot(i,k,14-ib)
-          end do
-       end do
-       ib=14
-       do k=1,pver
-          per_tau(i,k,ib)=deltah_km(i,k)*betot(i,k,ib)
-          per_tau_w(i,k,ib)=per_tau(i,k,ib)*max(min(ssatot(i,k,ib),0.999999_r8),1.e-6_r8)
-          per_tau_w_g(i,k,ib)=per_tau_w(i,k,ib)*asymtot(i,k,ib)
-          per_tau_w_f(i,k,ib)=per_tau_w_g(i,k,ib)*asymtot(i,k,ib)
-       end do
-    end do  ! ncol
+      ! Remapping of SW wavelength bands from AeroTab to CAM5
+      do i=1,ncol
+         do ib=1,13
+            do k=1,pver
+               per_tau(i,k,ib)=deltah_km(i,k)*betot(i,k,14-ib)
+               per_tau_w(i,k,ib)=per_tau(i,k,ib)*max(min(ssatot(i,k,14-ib),0.999999_r8),1.e-6_r8)
+               per_tau_w_g(i,k,ib)=per_tau_w(i,k,ib)*asymtot(i,k,14-ib)
+               per_tau_w_f(i,k,ib)=per_tau_w_g(i,k,ib)*asymtot(i,k,14-ib)
+            end do
+         end do
+         ib=14
+         do k=1,pver
+            per_tau(i,k,ib)=deltah_km(i,k)*betot(i,k,ib)
+            per_tau_w(i,k,ib)=per_tau(i,k,ib)*max(min(ssatot(i,k,ib),0.999999_r8),1.e-6_r8)
+            per_tau_w_g(i,k,ib)=per_tau_w(i,k,ib)*asymtot(i,k,ib)
+            per_tau_w_f(i,k,ib)=per_tau_w_g(i,k,ib)*asymtot(i,k,ib)
+         end do
+      end do  ! ncol
 
-    ! LW Optical properties of total aerosol:
-    do ib=1,nlwbands
-       do k=1,pver
-          do icol=1,ncol
-             batotlw(icol,k,ib)=0.0_r8
-          end do
-       enddo
-    enddo
-    do ib=1,nlwbands
-       do i=0,nmodes
-          do k=1,pver
-             do icol=1,ncol
-                balw(icol,k,i,ib)=kalw(icol,k,i,ib)*(be(icol,k,i,4)/(ke(icol,k,i,4)+eps))
-                batotlw(icol,k,ib)=batotlw(icol,k,ib)+Nnatk(icol,k,i)*balw(icol,k,i,ib)
-             end do
-          enddo
-       enddo
-    enddo
+      ! LW Optical properties of total aerosol:
+      do ib=1,nlwbands
+         do k=1,pver
+            do icol=1,ncol
+               batotlw(icol,k,ib)=0.0_r8
+            end do
+         enddo
+      enddo
+      do ib=1,nlwbands
+         do i=0,nmodes
+            do k=1,pver
+               do icol=1,ncol
+                  balw(icol,k,i,ib)=kalw(icol,k,i,ib)*(be(icol,k,i,4)/(ke(icol,k,i,4)+eps))
+                  batotlw(icol,k,ib)=batotlw(icol,k,ib)+Nnatk(icol,k,i)*balw(icol,k,i,ib)
+               end do
+            enddo
+         enddo
+      enddo
 
-    ! Adding also the volcanic contribution (CMIP6), which is also using
-    ! AeroTab band numbering, so that a remapping is required here
-    do ib=1,nlwbands
-       volc_balw(1:ncol,1:pver,ib) = volc_ext_earth(:ncol,1:pver,ib)*(1.0_r8-volc_omega_earth(:ncol,1:pver,ib))
-       batotlw(1:ncol,1:pver,ib) = batotlw(1:ncol,1:pver,ib)+volc_balw(1:ncol,1:pver,ib)
-    enddo
+      ! Adding also the volcanic contribution (CMIP6), which is also using
+      ! AeroTab band numbering, so that a remapping is required here
+      do ib=1,nlwbands
+         volc_balw(1:ncol,1:pver,ib) = volc_ext_earth(:ncol,1:pver,ib)*(1.0_r8-volc_omega_earth(:ncol,1:pver,ib))
+         batotlw(1:ncol,1:pver,ib) = batotlw(1:ncol,1:pver,ib)+volc_balw(1:ncol,1:pver,ib)
+      enddo
 
-    ! Remapping of LW wavelength bands from AeroTab to CAM5
-    do ib=1,nlwbands
-       do i=1,ncol
-          do k=1,pver
-             per_lw_abs(i,k,ib)=deltah_km(i,k)*batotlw(i,k,17-ib)
-          end do
-       end do
-    end do
+      ! Remapping of LW wavelength bands from AeroTab to CAM5
+      do ib=1,nlwbands
+         do i=1,ncol
+            do k=1,pver
+               per_lw_abs(i,k,ib)=deltah_km(i,k)*batotlw(i,k,17-ib)
+            end do
+         end do
+      end do
 
 #ifdef AEROCOM
-    do i=1,ncol
-       do k=1,pver
-          batotsw13(i,k)=betot(i,k,13)*(1.0_r8-ssatot(i,k,13))
-          batotlw01(i,k)=batotlw(i,k,1)
-       end do
-    end do
-    ! These two fields should be close to equal, both representing absorption
-    ! in the 3.077-3.846 um wavelenght band (i.e., a check of LUT for LW vs. SW).
-    call outfld('BATSW13 ',batotsw13,pcols,lchnk)
-    call outfld('BATLW01 ',batotlw01,pcols,lchnk)
+      do i=1,ncol
+         do k=1,pver
+            batotsw13(i,k)=betot(i,k,13)*(1.0_r8-ssatot(i,k,13))
+            batotlw01(i,k)=batotlw(i,k,1)
+         end do
+      end do
+      ! These two fields should be close to equal, both representing absorption
+      ! in the 3.077-3.846 um wavelenght band (i.e., a check of LUT for LW vs. SW).
+      call outfld('BATSW13 ',batotsw13,pcols,lchnk)
+      call outfld('BATLW01 ',batotlw01,pcols,lchnk)
 #endif
 
-    ! APPROXIMATE aerosol extinction and absorption at 550nm (0.442-0.625 um)
-    ! (in the visible wavelength band)
-    do k=1,pver
-       do icol=1,ncol
-          betotvis(icol,k)=betot(icol,k,4)
-          batotvis(icol,k)=betotvis(icol,k)*(1.0-ssatot(icol,k,4))
-       end do
-    enddo
+      ! APPROXIMATE aerosol extinction and absorption at 550nm (0.442-0.625 um)
+      ! (in the visible wavelength band)
+      do k=1,pver
+         do icol=1,ncol
+            betotvis(icol,k)=betot(icol,k,4)
+            batotvis(icol,k)=betotvis(icol,k)*(1.0-ssatot(icol,k,4))
+         end do
+      enddo
 
-    do k=1,pver
-       do icol=1,ncol
-          ssavis(icol,k) = 0.0_r8
-          asymmvis(icol,k) = 0.0_r8
-          extvis(icol,k) = 0.0_r8
-          dayfoc(icol,k) = 0.0_r8
-       enddo
-    end do
+      do k=1,pver
+         do icol=1,ncol
+            ssavis(icol,k) = 0.0_r8
+            asymmvis(icol,k) = 0.0_r8
+            extvis(icol,k) = 0.0_r8
+            dayfoc(icol,k) = 0.0_r8
+         enddo
+      end do
 
-    do k=1,pver
-       do icol=1,ncol
-          ! dayfoc < 1 when looping only over gridcells with daylight
-          if(daylight(icol)) then
-             dayfoc(icol,k) = 1.0_r8
-             ! with the new bands in CAM5, band 4 is now at ca 0.5 um (0.442-0.625)
-             ssavis(icol,k) = ssatot(icol,k,4)
-             asymmvis(icol,k) = asymtot(icol,k,4)
-             extvis(icol,k) = betot(icol,k,4)
-          endif
-       enddo
-    end do
+      do k=1,pver
+         do icol=1,ncol
+            ! dayfoc < 1 when looping only over gridcells with daylight
+            if(daylight(icol)) then
+               dayfoc(icol,k) = 1.0_r8
+               ! with the new bands in CAM5, band 4 is now at ca 0.5 um (0.442-0.625)
+               ssavis(icol,k) = ssatot(icol,k,4)
+               asymmvis(icol,k) = asymtot(icol,k,4)
+               extvis(icol,k) = betot(icol,k,4)
+            endif
+         enddo
+      end do
 
-    ! optical parameters in visible light (0.442-0.625um)
-    call outfld('SSAVIS  ',ssavis,pcols,lchnk)
-    call outfld('ASYMMVIS',asymmvis,pcols,lchnk)
-    call outfld('EXTVIS  ',extvis,pcols,lchnk)
-    call outfld('DAYFOC  ',dayfoc,pcols,lchnk)
+      ! optical parameters in visible light (0.442-0.625um)
+      call outfld('SSAVIS  ',ssavis,pcols,lchnk)
+      call outfld('ASYMMVIS',asymmvis,pcols,lchnk)
+      call outfld('EXTVIS  ',extvis,pcols,lchnk)
+      call outfld('DAYFOC  ',dayfoc,pcols,lchnk)
 
-    ! Initialize fields
-    do icol=1,ncol
-       aodvis(icol)     =0.0_r8
-       absvis(icol)     =0.0_r8
-       aodvisvolc(icol) =0.0_r8
-       absvisvolc(icol) =0.0_r8
-       airmass(icol)    =0.0_r8
-    enddo
+      ! Initialize fields
+      do icol=1,ncol
+         aodvis(icol)     =0.0_r8
+         absvis(icol)     =0.0_r8
+         aodvisvolc(icol) =0.0_r8
+         absvisvolc(icol) =0.0_r8
+         airmass(icol)    =0.0_r8
+      enddo
 
-    do icol=1,ncol
-       if(daylight(icol)) then
-          do k=1,pver
-             ! Layer thickness, unit km, and layer airmass, unit kg/m2
-             deltah = deltah_km(icol,k)
-             airmassl(icol,k) = 1.e3_r8*deltah*rhoda(icol,k)
-             airmass(icol) = airmass(icol)+airmassl(icol,k)  !akc6
+      do icol=1,ncol
+         if(daylight(icol)) then
+            do k=1,pver
+               ! Layer thickness, unit km, and layer airmass, unit kg/m2
+               deltah = deltah_km(icol,k)
+               airmassl(icol,k) = 1.e3_r8*deltah*rhoda(icol,k)
+               airmass(icol) = airmass(icol)+airmassl(icol,k)
 
-             ! Optical depths at ca. 550 nm (0.442-0.625um) all aerosols
-             aodvis(icol)=aodvis(icol)+betotvis(icol,k)*deltah
-             absvis(icol)=absvis(icol)+batotvis(icol,k)*deltah
+               ! Optical depths at ca. 550 nm (0.442-0.625um) all aerosols
+               aodvis(icol)=aodvis(icol)+betotvis(icol,k)*deltah
+               absvis(icol)=absvis(icol)+batotvis(icol,k)*deltah
 
-             ! Optical depths at ca. 550 nm (0.442-0.625um) CMIP6 volcanic aerosol
-             aodvisvolc(icol)=aodvisvolc(icol)+volc_ext_sun(icol,k,4)*deltah
-             absvisvolc(icol)=absvisvolc(icol)+volc_ext_sun(icol,k,4)*(1.0_r8-volc_omega_sun(icol,k,4))*deltah
+               ! Optical depths at ca. 550 nm (0.442-0.625um) CMIP6 volcanic aerosol
+               aodvisvolc(icol)=aodvisvolc(icol)+volc_ext_sun(icol,k,4)*deltah
+               absvisvolc(icol)=absvisvolc(icol)+volc_ext_sun(icol,k,4)*(1.0_r8-volc_omega_sun(icol,k,4))*deltah
 
-          end do  ! k
-       endif   ! daylight
-    end do   ! icol
+            end do  ! k
+         endif   ! daylight
+      end do   ! icol
 
-    ! Extinction and absorption for 0.55 um for the total aerosol, and AODs
-    call outfld('AOD_VIS ',aodvis ,pcols,lchnk)
-    call outfld('ABSVIS  ',absvis ,pcols,lchnk)
-    call outfld('AODVVOLC',aodvisvolc ,pcols,lchnk)
-    call outfld('ABSVVOLC',absvisvolc ,pcols,lchnk)
-    call outfld('BVISVOLC',bevisvolc ,pcols,lchnk)
+      ! Extinction and absorption for 0.55 um for the total aerosol, and AODs
+      call outfld('AOD_VIS ',aodvis ,pcols,lchnk)
+      call outfld('ABSVIS  ',absvis ,pcols,lchnk)
+      call outfld('AODVVOLC',aodvisvolc ,pcols,lchnk)
+      call outfld('ABSVVOLC',absvisvolc ,pcols,lchnk)
+      call outfld('BVISVOLC',bevisvolc ,pcols,lchnk)
 
 #ifdef AEROCOM
-    ! Extinction and absorption for 0.55 um for the total aerosol, and AODs
-    call outfld('BETOTVIS',betotvis,pcols,lchnk)
-    call outfld('BATOTVIS',batotvis,pcols,lchnk)
-    call outfld('AIRMASSL',airmassl,pcols,lchnk)
-    call outfld('AIRMASS ',airmass ,pcols,lchnk)
+      ! Extinction and absorption for 0.55 um for the total aerosol, and AODs
+      call outfld('BETOTVIS',betotvis,pcols,lchnk)
+      call outfld('BATOTVIS',batotvis,pcols,lchnk)
+      call outfld('AIRMASSL',airmassl,pcols,lchnk)
+      call outfld('AIRMASS ',airmass ,pcols,lchnk)
 
-    ! Mass concentration (ug/m3) and mmr (kg/kg) of aerosol condensed water
-    ! Condensed water mmr (kg/kg)
-    do k=1,pver
-       do icol=1,ncol
-          Cwater(icol,k) = Ctot(icol,k) - Ctotdry(icol,k)
-          mmr_aerh2o(icol,k)=1.e-9_r8*Cwater(icol,k)/rhoda(icol,k)
-       end do
-    enddo
-    call outfld('MMR_AH2O',mmr_aerh2o, pcols, lchnk)
+      ! Mass concentration (ug/m3) and mmr (kg/kg) of aerosol condensed water
+      ! Condensed water mmr (kg/kg)
+      do k=1,pver
+         do icol=1,ncol
+            Cwater(icol,k) = Ctot(icol,k) - Ctotdry(icol,k)
+            mmr_aerh2o(icol,k)=1.e-9_r8*Cwater(icol,k)/rhoda(icol,k)
+         end do
+      enddo
+      call outfld('MMR_AH2O',mmr_aerh2o, pcols, lchnk)
 
-    ! Condensed water loading (mg_m2)
-    daerh2o(:) = 0.0_r8
-    do k=1,pver
-       do icol=1,ncol
-          daerh2o(icol) = daerh2o(icol) + Cwater(icol,k)*deltah_km(icol,k)
-       end do
-    end do
-    call outfld('DAERH2O ',daerh2o ,pcols,lchnk)
+      ! Condensed water loading (mg_m2)
+      daerh2o(:) = 0.0_r8
+      do k=1,pver
+         do icol=1,ncol
+            daerh2o(icol) = daerh2o(icol) + Cwater(icol,k)*deltah_km(icol,k)
+         end do
+      end do
+      call outfld('DAERH2O ',daerh2o ,pcols,lchnk)
 
-    ! Aerocom second phase
-    call aerocom2(lchnk, ncol, Nnatk, pint, deltah_km, faitbc, f_soana, fnbc, rhoda, v_soana, &
-         xct, ict1, xfac, ifac1, xfbc, ifbc1, xfaq, ifaq1, xfbcbg, ifbcbg1, xfbcbgn, ifbcbgn1, &
-         xfombg, ifombg1, xrh, irh1)
+      ! Aerocom second phase
+      call aerocom2(lchnk, ncol, Nnatk, pint, deltah_km, faitbc, f_soana, fnbc, rhoda, v_soana, &
+           xct, ict1, xfac, ifac1, xfbc, ifbc1, xfaq, ifaq1, xfbcbg, ifbcbg1, xfbcbgn, ifbcbgn1, &
+           xfombg, ifombg1, xrh, irh1)
 #endif
 
-  end subroutine oslo_aero_optical_params_calc
+   end subroutine oslo_aero_optical_params_calc
 
-  !===============================================================================
+   !===============================================================================
 
-  subroutine inputForInterpol (ncol, rhum, xrh, irh1, &
-       f_soana, xfombg, ifombg1, faitbc, xfbcbg, ifbcbg1,    &
-       fnbc, xfbcbgn, ifbcbgn1, Nnatk, Cam, xct, ict1,       &
-       focm, fcm, xfac, ifac1, fbcm, xfbc, ifbc1, faqm, xfaq, ifaq1)
+   subroutine inputForInterpol (ncol, rhum, xrh, irh1, &
+        f_soana, xfombg, ifombg1, faitbc, xfbcbg, ifbcbg1,    &
+        fnbc, xfbcbgn, ifbcbgn1, Nnatk, Cam, xct, ict1,       &
+        focm, fcm, xfac, ifac1, fbcm, xfbc, ifbc1, faqm, xfaq, ifaq1)
 
-    ! Arguments
-    integer, intent(in)   :: ncol                       ! number of atmospheric columns
-    real(r8), intent(in)  :: rhum(pcols,pver)           ! level relative humidity (fraction)
-    real(r8), intent(in)  :: f_soana(pcols,pver)        ! SOA/(SOA+H2SO4) mass fraction for the background in mode 1
-    real(r8), intent(in)  :: faitbc(pcols,pver)         ! BC/(BC + OC) mass fraction for the background in mode 4
-    real(r8), intent(in)  :: fnbc(pcols,pver)           ! BC/(BC + OC) mass fraction for the background in mode 14
-    real(r8), intent(in)  :: focm(pcols,pver,4)         ! fraction of added mass which is either SOA condensate or OC coagulate
-    real(r8), intent(in)  :: Cam(pcols,pver,nbmodes)    ! added internally mixed SO4+BC+OC concentration for a normalized mode
-    real(r8), intent(in)  :: Nnatk(pcols,pver,0:nmodes) ! aerosol mode number concentration
-    real(r8), intent(in)  :: fcm(pcols,pver,nbmodes)    ! fraction of added mass which is either BC or OC/SOA (carbonaceous)
-    real(r8), intent(in)  :: fbcm(pcols,pver,nbmodes)   ! fraction of added mass as BC/(BC+OC)
-    real(r8), intent(in)  :: faqm(pcols,pver,nbmodes)   ! fraction of added sulfate which is from aqueous phase (ammonium sulfate)
-    real(r8), intent(out) :: xrh(pcols,pver)            ! rhum for use in the interpolations
-    integer,  intent(out) :: irh1(pcols,pver)
-    real(r8), intent(out) :: xfombg(pcols,pver)         ! f_soana for use in the interpolations (mode 1)
-    integer,  intent(out) :: ifombg1(pcols,pver)
-    real(r8), intent(out) :: xfbcbg(pcols,pver)         ! faitbc for use in the interpolations (mode 4)
-    integer,  intent(out) :: ifbcbg1(pcols,pver)
-    real(r8), intent(out) :: xfbcbgn(pcols,pver)        ! fnbc for use in the interpolations (mode 14)
-    integer,  intent(out) :: ifbcbgn1(pcols,pver)
-    real(r8), intent(out) :: xct(pcols,pver,nmodes)     ! Cam/Nnatk for use in the interpolations
-    integer,  intent(out) :: ict1(pcols,pver,nmodes)
-    real(r8), intent(out) :: xfac(pcols,pver,nbmodes)   ! focm (1-4) or fcm (5-10) for use in the interpolations
-    integer,  intent(out) :: ifac1(pcols,pver,nbmodes)
-    real(r8), intent(out) :: xfbc(pcols,pver,nbmodes)   ! fbcm for use in the interpolations
-    integer,  intent(out) :: ifbc1(pcols,pver,nbmodes)
-    real(r8), intent(out) :: xfaq(pcols,pver,nbmodes)   ! faqm for use in the interpolations
-    integer,  intent(out) :: ifaq1(pcols,pver,nbmodes)
-    !
-    ! Local variables
-    integer k, icol, i, irelh
-    real(r8) :: eps10 = 1.e-10_r8
-    !------------------------------------------------------------------------
-    !
-    do k=1,pver
-       do icol=1,ncol
-          xrh(icol,k)  = min(max(rhum(icol,k),rh(1)),rh(10))
-       end do
-    end do
+      ! Arguments
+      integer, intent(in)   :: ncol                       ! number of atmospheric columns
+      real(r8), intent(in)  :: rhum(pcols,pver)           ! level relative humidity (fraction)
+      real(r8), intent(in)  :: f_soana(pcols,pver)        ! SOA/(SOA+H2SO4) mass fraction for the background in mode 1
+      real(r8), intent(in)  :: faitbc(pcols,pver)         ! BC/(BC + OC) mass fraction for the background in mode 4
+      real(r8), intent(in)  :: fnbc(pcols,pver)           ! BC/(BC + OC) mass fraction for the background in mode 14
+      real(r8), intent(in)  :: focm(pcols,pver,4)         ! fraction of added mass which is either SOA condensate or OC coagulate
+      real(r8), intent(in)  :: Cam(pcols,pver,nbmodes)    ! added internally mixed SO4+BC+OC concentration for a normalized mode
+      real(r8), intent(in)  :: Nnatk(pcols,pver,0:nmodes) ! aerosol mode number concentration
+      real(r8), intent(in)  :: fcm(pcols,pver,nbmodes)    ! fraction of added mass which is either BC or OC/SOA (carbonaceous)
+      real(r8), intent(in)  :: fbcm(pcols,pver,nbmodes)   ! fraction of added mass as BC/(BC+OC)
+      real(r8), intent(in)  :: faqm(pcols,pver,nbmodes)   ! fraction of added sulfate which is from aqueous phase (ammonium sulfate)
+      real(r8), intent(out) :: xrh(pcols,pver)            ! rhum for use in the interpolations
+      integer,  intent(out) :: irh1(pcols,pver)
+      real(r8), intent(out) :: xfombg(pcols,pver)         ! f_soana for use in the interpolations (mode 1)
+      integer,  intent(out) :: ifombg1(pcols,pver)
+      real(r8), intent(out) :: xfbcbg(pcols,pver)         ! faitbc for use in the interpolations (mode 4)
+      integer,  intent(out) :: ifbcbg1(pcols,pver)
+      real(r8), intent(out) :: xfbcbgn(pcols,pver)        ! fnbc for use in the interpolations (mode 14)
+      integer,  intent(out) :: ifbcbgn1(pcols,pver)
+      real(r8), intent(out) :: xct(pcols,pver,nmodes)     ! Cam/Nnatk for use in the interpolations
+      integer,  intent(out) :: ict1(pcols,pver,nmodes)
+      real(r8), intent(out) :: xfac(pcols,pver,nbmodes)   ! focm (1-4) or fcm (5-10) for use in the interpolations
+      integer,  intent(out) :: ifac1(pcols,pver,nbmodes)
+      real(r8), intent(out) :: xfbc(pcols,pver,nbmodes)   ! fbcm for use in the interpolations
+      integer,  intent(out) :: ifbc1(pcols,pver,nbmodes)
+      real(r8), intent(out) :: xfaq(pcols,pver,nbmodes)   ! faqm for use in the interpolations
+      integer,  intent(out) :: ifaq1(pcols,pver,nbmodes)
+      !
+      ! Local variables
+      integer k, icol, i, irelh
+      real(r8) :: eps10 = 1.e-10_r8
+      !------------------------------------------------------------------------
+      !
+      do k=1,pver
+         do icol=1,ncol
+            xrh(icol,k)  = min(max(rhum(icol,k),rh(1)),rh(10))
+         end do
+      end do
 
-    do irelh=1,9
-       do k=1,pver
-          do icol=1,ncol
-             if(xrh(icol,k) >= rh(irelh) .and. xrh(icol,k)<=rh(irelh+1)) then
-                irh1(icol,k)=irelh
-             endif
-          end do
-       end do
-    end do
+      do irelh=1,9
+         do k=1,pver
+            do icol=1,ncol
+               if(xrh(icol,k) >= rh(irelh) .and. xrh(icol,k)<=rh(irelh+1)) then
+                  irh1(icol,k)=irelh
+               endif
+            end do
+         end do
+      end do
 
-    do k=1,pver
-       do icol=1,ncol
-          ! find common xfombg, ifombg1 and ifombg2 for use in the interpolation routines
-          xfombg(icol,k) =min(max(f_soana(icol,k),fombg(1)),fombg(6))
-          ifombg1(icol,k)=int(5.0_r8*xfombg(icol,k)-eps10)+1
-       end do
-    enddo
+      do k=1,pver
+         do icol=1,ncol
+            ! find common xfombg, ifombg1 and ifombg2 for use in the interpolation routines
+            xfombg(icol,k) =min(max(f_soana(icol,k),fombg(1)),fombg(6))
+            ifombg1(icol,k)=int(5.0_r8*xfombg(icol,k)-eps10)+1
+         end do
+      enddo
 
-    do k=1,pver
-       do icol=1,ncol
-          ! find common xfbcbg, ifbcbg1 and ifbcbg2 for use in the interpolation routines
-          xfbcbg(icol,k) =min(max(faitbc(icol,k),fbcbg(1)),fbcbg(6))
-          ifbcbg1(icol,k)=min(max(int(4*log10(xfbcbg(icol,k))+6),1),5)
+      do k=1,pver
+         do icol=1,ncol
+            ! find common xfbcbg, ifbcbg1 and ifbcbg2 for use in the interpolation routines
+            xfbcbg(icol,k) =min(max(faitbc(icol,k),fbcbg(1)),fbcbg(6))
+            ifbcbg1(icol,k)=min(max(int(4*log10(xfbcbg(icol,k))+6),1),5)
 
-          ! find common xfbcbgn, ifbcbgn1 and ifbcbgn2 for use in the interpolation routines
-          xfbcbgn(icol,k) =min(max(fnbc(icol,k),fbcbg(1)),fbcbg(6))
-          ifbcbgn1(icol,k)=min(max(int(4*log10(xfbcbgn(icol,k))+6),1),5)
-       end do
-    enddo
+            ! find common xfbcbgn, ifbcbgn1 and ifbcbgn2 for use in the interpolation routines
+            xfbcbgn(icol,k) =min(max(fnbc(icol,k),fbcbg(1)),fbcbg(6))
+            ifbcbgn1(icol,k)=min(max(int(4*log10(xfbcbgn(icol,k))+6),1),5)
+         end do
+      enddo
 
-    do i=1,4
-       do k=1,pver
-          do icol=1,ncol
-             ! find common xfac, ifac1 and ifac2 for use in the interpolation routines
-             xfac(icol,k,i) =min(max(focm(icol,k,i),fac(1)),fac(6))
-             ifac1(icol,k,i)=int(5.0_r8*xfac(icol,k,i)-eps10)+1
-          end do
-       enddo
-    enddo
-    do i=5,nbmodes
-       do k=1,pver
-          do icol=1,ncol
-             ! find common xfac, ifac1 and ifac2 for use in the interpolation routines
-             xfac(icol,k,i) =min(max(fcm(icol,k,i),fac(1)),fac(6))
-             ifac1(icol,k,i)=int(5.0_r8*xfac(icol,k,i)-eps10)+1
-          end do
-       enddo
-    enddo
+      do i=1,4
+         do k=1,pver
+            do icol=1,ncol
+               ! find common xfac, ifac1 and ifac2 for use in the interpolation routines
+               xfac(icol,k,i) =min(max(focm(icol,k,i),fac(1)),fac(6))
+               ifac1(icol,k,i)=int(5.0_r8*xfac(icol,k,i)-eps10)+1
+            end do
+         enddo
+      enddo
+      do i=5,nbmodes
+         do k=1,pver
+            do icol=1,ncol
+               ! find common xfac, ifac1 and ifac2 for use in the interpolation routines
+               xfac(icol,k,i) =min(max(fcm(icol,k,i),fac(1)),fac(6))
+               ifac1(icol,k,i)=int(5.0_r8*xfac(icol,k,i)-eps10)+1
+            end do
+         enddo
+      enddo
 
-    do i=1,nbmodes
-       do k=1,pver
-          do icol=1,ncol
-             ! find common xfbc, ifbc1 and ifbc2 for use in the interpolation routines
-             xfbc(icol,k,i) =min(max(fbcm(icol,k,i),fbc(1)),fbc(6))
-             ifbc1(icol,k,i)=min(max(int(4*log10(xfbc(icol,k,i))+6),1),5)
-          end do
-       enddo
-    enddo
+      do i=1,nbmodes
+         do k=1,pver
+            do icol=1,ncol
+               ! find common xfbc, ifbc1 and ifbc2 for use in the interpolation routines
+               xfbc(icol,k,i) =min(max(fbcm(icol,k,i),fbc(1)),fbc(6))
+               ifbc1(icol,k,i)=min(max(int(4*log10(xfbc(icol,k,i))+6),1),5)
+            end do
+         enddo
+      enddo
 
-    do i=1,nbmodes
-       do k=1,pver
-          do icol=1,ncol
-             ! find common xfaq, ifaq1 and ifaq2 for use in the interpolation routines
-             xfaq(icol,k,i) =min(max(faqm(icol,k,i),faq(1)),faq(6))
-             ifaq1(icol,k,i)=int(5.0_r8*xfaq(icol,k,i)-eps10)+1
-          end do
-       enddo
-    enddo
+      do i=1,nbmodes
+         do k=1,pver
+            do icol=1,ncol
+               ! find common xfaq, ifaq1 and ifaq2 for use in the interpolation routines
+               xfaq(icol,k,i) =min(max(faqm(icol,k,i),faq(1)),faq(6))
+               ifaq1(icol,k,i)=int(5.0_r8*xfaq(icol,k,i)-eps10)+1
+            end do
+         enddo
+      enddo
 
-    ! find common xct, ict1 and ict2 for use in the interpolation routines
-    do i=1,4
-       do k=1,pver
-          do icol=1,ncol
-             xct(icol,k,i)=min(max(Cam(icol,k,i)/(Nnatk(icol,k,i)+eps),cate(i,1)),cate(i,16))
-             if(i.le.2) then
-                ict1(icol,k,i)=min(max(int(3*log10(xct(icol,k,i))+19.666_r8),1),15)
-             elseif(i.eq.3) then ! mode not used
-                xct(icol,k,i)=cate(i,1)
-                ict1(icol,k,i)=1
-             else
-                ict1(icol,k,i)=min(max(int(3*log10(xct(icol,k,i))+13.903_r8),1),15)
-             endif
-          end do
-       end do
-    end do
+      ! find common xct, ict1 and ict2 for use in the interpolation routines
+      do i=1,4
+         do k=1,pver
+            do icol=1,ncol
+               xct(icol,k,i)=min(max(Cam(icol,k,i)/(Nnatk(icol,k,i)+eps),cate(i,1)),cate(i,16))
+               if(i.le.2) then
+                  ict1(icol,k,i)=min(max(int(3*log10(xct(icol,k,i))+19.666_r8),1),15)
+               elseif(i.eq.3) then ! mode not used
+                  xct(icol,k,i)=cate(i,1)
+                  ict1(icol,k,i)=1
+               else
+                  ict1(icol,k,i)=min(max(int(3*log10(xct(icol,k,i))+13.903_r8),1),15)
+               endif
+            end do
+         end do
+      end do
 
-    do i=5,10
-       do k=1,pver
-          do icol=1,ncol
-             xct(icol,k,i)=min(max(Cam(icol,k,i)/(Nnatk(icol,k,i)+eps),cat(i,1)),cat(i,6))
-             if(i.eq.5) then
-                ict1(icol,k,i)=min(max(int(log10(xct(icol,k,i))+4.824_r8),1),5)
-             elseif(i.eq.6) then
-                ict1(icol,k,i)=min(max(int(log10(xct(icol,k,i))+4.523_r8),1),5)
-             elseif(i.eq.7) then
-                ict1(icol,k,i)=min(max(int(log10(xct(icol,k,i))+4.699_r8),1),5)
-             elseif(i.eq.8) then
-                ict1(icol,k,i)=min(max(int(log10(xct(icol,k,i))+5.921_r8),1),5)
-             elseif(i.eq.9) then
-                ict1(icol,k,i)=min(max(int(log10(xct(icol,k,i))+4.301_r8),1),5)
-             else
-                ict1(icol,k,i)=min(max(int(log10(xct(icol,k,i))+4.699_r8),1),5)
-             endif
-          end do
-       end do
-    end do
+      do i=5,10
+         do k=1,pver
+            do icol=1,ncol
+               xct(icol,k,i)=min(max(Cam(icol,k,i)/(Nnatk(icol,k,i)+eps),cat(i,1)),cat(i,6))
+               if(i.eq.5) then
+                  ict1(icol,k,i)=min(max(int(log10(xct(icol,k,i))+4.824_r8),1),5)
+               elseif(i.eq.6) then
+                  ict1(icol,k,i)=min(max(int(log10(xct(icol,k,i))+4.523_r8),1),5)
+               elseif(i.eq.7) then
+                  ict1(icol,k,i)=min(max(int(log10(xct(icol,k,i))+4.699_r8),1),5)
+               elseif(i.eq.8) then
+                  ict1(icol,k,i)=min(max(int(log10(xct(icol,k,i))+5.921_r8),1),5)
+               elseif(i.eq.9) then
+                  ict1(icol,k,i)=min(max(int(log10(xct(icol,k,i))+4.301_r8),1),5)
+               else
+                  ict1(icol,k,i)=min(max(int(log10(xct(icol,k,i))+4.699_r8),1),5)
+               endif
+            end do
+         end do
+      end do
 
-    do i=11,nmodes ! for the externally mixed modes 11-14 (now only 12 and 14)
-       do k=1,pver
-          do icol=1,ncol
-             xct(icol,k,i)=cate(i-10,1)
-             ict1(icol,k,i)=1
-          end do
-       end do
-    end do
+      do i=11,nmodes ! for the externally mixed modes 11-14 (now only 12 and 14)
+         do k=1,pver
+            do icol=1,ncol
+               xct(icol,k,i)=cate(i-10,1)
+               ict1(icol,k,i)=1
+            end do
+         end do
+      end do
 
-  end subroutine inputForInterpol
+   end subroutine inputForInterpol
 
 end module oslo_aero_optical_params

--- a/src_cam/chemistry.F90
+++ b/src_cam/chemistry.F90
@@ -14,7 +14,7 @@ module chemistry
   use spmd_utils,       only : masterproc
   use cam_logfile,      only : iulog
   use mo_gas_phase_chemdr, only : map2chm
-  use shr_megan_mod,    only : shr_megan_mechcomps, shr_megan_mechcomps_n 
+  use shr_megan_mod,    only : shr_megan_mechcomps, shr_megan_mechcomps_n
   use tracer_data,      only : MAXTRCRS
   use gcr_ionization,   only : gcr_ionization_readnl, gcr_ionization_init, gcr_ionization_adv
   use epp_ionization,   only : epp_ionization_readnl, epp_ionization_adv
@@ -31,7 +31,7 @@ module chemistry
 !---------------------------------------------------------------------------------
   public :: chem_is                        ! identify which chemistry is being used
   public :: chem_register                  ! register consituents
-  public :: chem_readnl                    ! read chem namelist 
+  public :: chem_readnl                    ! read chem namelist
   public :: chem_is_active                 ! returns true
   public :: chem_implements_cnst           ! returns true if consituent is implemented by this package
   public :: chem_init_cnst                 ! initialize mixing ratios if not read from initial file
@@ -45,11 +45,11 @@ module chemistry
   public :: chem_emissions
 
   integer, public :: imozart = -1       ! index of 1st constituent
-  
+
   ! Namelist variables
-  
+
   ! control
-  
+
   integer :: chem_freq = 1 ! time steps
 
   ! ghg
@@ -79,7 +79,7 @@ module chemistry
   character(len=shr_kind_cl) :: photon_file = 'photon_file'
 
   ! dry dep
-  
+
   character(len=shr_kind_cl) :: depvel_file = 'depvel_file'
   character(len=shr_kind_cl) :: depvel_lnd_file = 'depvel_lnd_file'
   character(len=shr_kind_cl) :: clim_soilw_file = 'clim_soilw_file'
@@ -102,7 +102,7 @@ module chemistry
   integer            :: ext_frc_fixed_tod = 0
 
   ! fixed stratosphere
-  
+
   character(len=shr_kind_cl) :: fstrat_file = 'fstrat_file'
   character(len=16)  :: fstrat_list(pcnst)  = ''
 
@@ -136,9 +136,9 @@ module chemistry
 
   character(len=32) :: chem_name = 'NONE'
   logical :: chem_rad_passive = .false.
-  
+
   ! for MEGAN emissions
-  integer, allocatable :: megan_indices_map(:) 
+  integer, allocatable :: megan_indices_map(:)
   real(r8),allocatable :: megan_wght_factors(:)
 
   logical :: chem_use_chemtrop = .false.
@@ -158,10 +158,10 @@ end function chem_is
 !================================================================================================
 
   subroutine chem_register
-!----------------------------------------------------------------------- 
-! 
+!-----------------------------------------------------------------------
+!
 ! Purpose: register advected constituents and physics buffer fields
-! 
+!
 !-----------------------------------------------------------------------
 
     use mo_sim_dat,          only : set_sim_dat
@@ -184,7 +184,7 @@ end function chem_is
     logical  :: ic_from_cam2                        ! wrk variable for initial cond input
     logical  :: has_fixed_ubc                       ! wrk variable for upper bndy cond
     logical  :: has_fixed_ubflx                     ! wrk variable for upper bndy flux
-    integer  :: ch4_ndx, n2o_ndx, o3_ndx 
+    integer  :: ch4_ndx, n2o_ndx, o3_ndx
     integer  :: cfc11_ndx, cfc12_ndx, o2_1s_ndx, o2_1d_ndx, o2_ndx
     integer  :: n_ndx, no_ndx, h_ndx, h2_ndx, o_ndx, e_ndx, np_ndx
     integer  :: op_ndx, o1d_ndx, n2d_ndx, nop_ndx, n2p_ndx, o2p_ndx
@@ -234,7 +234,7 @@ end function chem_is
     !-----------------------------------------------------------------------
     !----------------------------------------------------------------------------------
     ! For WACCM-X, change variable has_fixed_ubc from .true. to .false. which is a flag
-    ! used later to check for a fixed upper boundary condition for species. 
+    ! used later to check for a fixed upper boundary condition for species.
     !----------------------------------------------------------------------------------
      do m = 1,gas_pcnst
      ! setting of these variables is for registration of transported species
@@ -245,14 +245,14 @@ end function chem_is
        molectype = 'minor'
 
        qmin = 1.e-36_r8
-       
+
        if ( lng_name(1:5) .eq. 'num_a' ) then ! aerosol number density
           qmin = 1.e-5_r8
        else if ( m == o3_ndx ) then
           qmin = 1.e-12_r8
        else if ( m == ch4_ndx ) then
           qmin = 1.e-12_r8
-          if ( waccmx_is('ionosphere') .or. waccmx_is('neutral') ) then 
+          if ( waccmx_is('ionosphere') .or. waccmx_is('neutral') ) then
             has_fixed_ubc = .false.   ! diffusive equilibrium at UB
           else
             has_fixed_ubc = .true.
@@ -270,7 +270,7 @@ end function chem_is
           end if
        else if ( m==o2_ndx .or. m==n_ndx .or. m==no_ndx .or. m==h_ndx .or. m==h2_ndx .or. m==o_ndx .or. m==hf_ndx &
                .or. m==f_ndx ) then
-         if ( waccmx_is('ionosphere') .or. waccmx_is('neutral') ) then 
+         if ( waccmx_is('ionosphere') .or. waccmx_is('neutral') ) then
            has_fixed_ubc = .false.   ! diffusive equilibrium at UB
            if ( m == h_ndx ) has_fixed_ubflx = .true. ! fixed flux value for H at UB
            if ( m == o2_ndx .or. m == o_ndx ) molectype = 'major'
@@ -318,22 +318,22 @@ end function chem_is
        endif
 
     end do
-    
+
     call register_short_lived_species()
     call register_cfc11star()
 
-    if ( waccmx_is('ionosphere') ) then 
+    if ( waccmx_is('ionosphere') ) then
        call photo_register()
        call aurora_register()
     endif
-    
+
     ! add fields to pbuf needed by aerosol models
     call aero_model_register()
 
   end subroutine chem_register
 
 !================================================================================================
-  
+
   subroutine chem_readnl(nlfile)
 
     ! Read chem namelist group.
@@ -347,11 +347,9 @@ end function chem_is
     use tracer_cnst,      only: tracer_cnst_defaultopts, tracer_cnst_setopts
     use tracer_srcs,      only: tracer_srcs_defaultopts, tracer_srcs_setopts
     use aero_model,       only: aero_model_readnl
-#ifdef OSLO_AERO
-    use oslo_aero_dust,   only: oslo_aero_dust_readnl 
-#else
-    use dust_model,       only: dust_readnl
-#endif
+    ! OSLO_AERO begin
+    use oslo_aero_dust,   only: oslo_aero_dust_readnl
+    ! OSLO_AERO end
     use gas_wetdep_opts,  only: gas_wetdep_readnl
     use upper_bc,         only: ubc_defaultopts, ubc_setopts
     use mo_drydep,        only: drydep_srf_file
@@ -369,7 +367,7 @@ end function chem_is
     ! linoz data
     character(len=shr_kind_cl) :: linoz_data_file               ! prescribed data file
     character(len=shr_kind_cl) :: linoz_data_filelist           ! list of prescribed data files (series of files)
-    character(len=shr_kind_cl) :: linoz_data_path               ! absolute path of prescribed data files 
+    character(len=shr_kind_cl) :: linoz_data_path               ! absolute path of prescribed data files
     character(len=24)  :: linoz_data_type               ! 'INTERP_MISSING_MONTHS' | 'CYCLICAL' | 'SERIAL' (default)
     logical            :: linoz_data_rmfile             ! remove data file from local disk (default .false.)
     integer            :: linoz_data_cycle_yr
@@ -379,9 +377,9 @@ end function chem_is
     ! trop_mozart prescribed constituent concentratons
     character(len=shr_kind_cl) :: tracer_cnst_file              ! prescribed data file
     character(len=shr_kind_cl) :: tracer_cnst_filelist          ! list of prescribed data files (series of files)
-    character(len=shr_kind_cl) :: tracer_cnst_datapath          ! absolute path of prescribed data files 
+    character(len=shr_kind_cl) :: tracer_cnst_datapath          ! absolute path of prescribed data files
     character(len=24)  :: tracer_cnst_type              ! 'INTERP_MISSING_MONTHS' | 'CYCLICAL' | 'SERIAL' (default)
-    character(len=shr_kind_cl) :: tracer_cnst_specifier(MAXTRCRS) ! string array where each 
+    character(len=shr_kind_cl) :: tracer_cnst_specifier(MAXTRCRS) ! string array where each
     logical            :: tracer_cnst_rmfile            ! remove data file from local disk (default .false.)
     integer            :: tracer_cnst_cycle_yr
     integer            :: tracer_cnst_fixed_ymd
@@ -390,9 +388,9 @@ end function chem_is
     ! trop_mozart prescribed constituent sourrces/sinks
     character(len=shr_kind_cl) :: tracer_srcs_file              ! prescribed data file
     character(len=shr_kind_cl) :: tracer_srcs_filelist          ! list of prescribed data files (series of files)
-    character(len=shr_kind_cl) :: tracer_srcs_datapath          ! absolute path of prescribed data files 
+    character(len=shr_kind_cl) :: tracer_srcs_datapath          ! absolute path of prescribed data files
     character(len=24)  :: tracer_srcs_type              ! 'INTERP_MISSING_MONTHS' | 'CYCLICAL' | 'SERIAL' (default)
-    character(len=shr_kind_cl) :: tracer_srcs_specifier(MAXTRCRS) ! string array where each 
+    character(len=shr_kind_cl) :: tracer_srcs_specifier(MAXTRCRS) ! string array where each
     logical            :: tracer_srcs_rmfile            ! remove data file from local disk (default .false.)
     integer            :: tracer_srcs_cycle_yr
     integer            :: tracer_srcs_fixed_ymd
@@ -443,8 +441,8 @@ end function chem_is
          tracer_srcs_file, tracer_srcs_filelist, tracer_srcs_datapath, &
          tracer_srcs_type, tracer_srcs_specifier, &
          tracer_cnst_rmfile, tracer_cnst_cycle_yr, tracer_cnst_fixed_ymd, tracer_cnst_fixed_tod, &
-         tracer_srcs_rmfile, tracer_srcs_cycle_yr, tracer_srcs_fixed_ymd, tracer_srcs_fixed_tod 
-    
+         tracer_srcs_rmfile, tracer_srcs_cycle_yr, tracer_srcs_fixed_ymd, tracer_srcs_fixed_tod
+
     ! upper boundary conditions
     namelist /chem_inparm/ tgcm_ubc_file, tgcm_ubc_data_type, tgcm_ubc_cycle_yr, tgcm_ubc_fixed_ymd, tgcm_ubc_fixed_tod, &
                            snoe_ubc_file, t_pert_ubc, no_xfac_ubc
@@ -462,7 +460,7 @@ end function chem_is
          linoz_data_rmfile_out    = linoz_data_rmfile,    &
          linoz_data_cycle_yr_out  = linoz_data_cycle_yr,  &
          linoz_data_fixed_ymd_out = linoz_data_fixed_ymd, &
-         linoz_data_fixed_tod_out = linoz_data_fixed_tod  ) 
+         linoz_data_fixed_tod_out = linoz_data_fixed_tod  )
     call tracer_cnst_defaultopts( &
          tracer_cnst_file_out      = tracer_cnst_file,      &
          tracer_cnst_filelist_out  = tracer_cnst_filelist,  &
@@ -472,7 +470,7 @@ end function chem_is
          tracer_cnst_rmfile_out    = tracer_cnst_rmfile,    &
          tracer_cnst_cycle_yr_out  = tracer_cnst_cycle_yr,  &
          tracer_cnst_fixed_ymd_out = tracer_cnst_fixed_ymd, &
-         tracer_cnst_fixed_tod_out = tracer_cnst_fixed_tod  ) 
+         tracer_cnst_fixed_tod_out = tracer_cnst_fixed_tod  )
     call tracer_srcs_defaultopts( &
          tracer_srcs_file_out      = tracer_srcs_file,      &
          tracer_srcs_filelist_out  = tracer_srcs_filelist,  &
@@ -670,11 +668,9 @@ end function chem_is
         tgcm_ubc_fixed_tod_in = tgcm_ubc_fixed_tod )
 
    call aero_model_readnl(nlfile)
-#ifdef OSLO_AERO
-   call oslo_aero_dust_readnl(nlfile)     
-#else
-   call dust_readnl(nlfile)     
-#endif
+   ! OSLO_AERO begin
+   call oslo_aero_dust_readnl(nlfile)
+   ! OSLO_AERO end
 !
    call gas_wetdep_readnl(nlfile)
    call gcr_ionization_readnl(nlfile)
@@ -689,7 +685,7 @@ end function chem_is
 !================================================================================================
 
 function chem_is_active()
-!----------------------------------------------------------------------- 
+!-----------------------------------------------------------------------
 ! Purpose: return true if this package is active
 !-----------------------------------------------------------------------
    logical :: chem_is_active
@@ -700,12 +696,12 @@ end function chem_is_active
 !================================================================================================
 
   function chem_implements_cnst(name)
-!----------------------------------------------------------------------- 
-! 
+!-----------------------------------------------------------------------
+!
 ! Purpose: return true if specified constituent is implemented by this package
-! 
+!
 ! Author: B. Eaton
-! 
+!
 !-----------------------------------------------------------------------
     use chem_mods,       only : gas_pcnst, inv_lst, nfs
     use mo_tracname,     only : solsym
@@ -719,7 +715,7 @@ end function chem_is_active
 !       ... local variables
 !-----------------------------------------------------------------------
     integer :: m
-    
+
     chem_implements_cnst = .false.
     do m = 1,gas_pcnst
        if( trim(name) /= 'H2O' ) then
@@ -742,20 +738,20 @@ end function chem_is_active
 
   subroutine chem_init(phys_state, pbuf2d)
 
-!----------------------------------------------------------------------- 
-! 
+!-----------------------------------------------------------------------
+!
 ! Purpose: initialize parameterized greenhouse gas chemistry
 !          (declare history variables)
-! 
-! Method: 
-! <Describe the algorithm(s) used in the routine.> 
-! <Also include any applicable external references.> 
-! 
+!
+! Method:
+! <Describe the algorithm(s) used in the routine.>
+! <Also include any applicable external references.>
+!
 ! Author: NCAR CMS
-! 
+!
 !-----------------------------------------------------------------------
     use physics_buffer,      only : physics_buffer_desc, pbuf_get_index
-    
+
     use constituents,        only : cnst_get_ind
     use cam_history,         only : addfld, add_default, horiz_only, fieldname_len
     use chem_mods,           only : gas_pcnst
@@ -777,11 +773,11 @@ end function chem_is_active
     use fire_emissions,      only : fire_emissions_init
     use short_lived_species, only : short_lived_species_initic
     use aero_model,            only : aero_model_init
-    
+
     type(physics_buffer_desc), pointer :: pbuf2d(:,:)
     type(physics_state), intent(in):: phys_state(begchunk:endchunk)
 
-    
+
 !-----------------------------------------------------------------------
 ! Local variables
 !-----------------------------------------------------------------------
@@ -792,7 +788,7 @@ end function chem_is_active
     logical :: history_chemistry
     logical :: history_cesm_forcing
 
-    character(len=2)  :: unit_basename  ! Units 'kg' or '1' 
+    character(len=2)  :: unit_basename  ! Units 'kg' or '1'
     logical :: history_budget                 ! output tendencies and state variables for CAM
                                               ! temperature, water vapor, cloud ice and cloud
                                               ! liquid budgets.
@@ -840,17 +836,17 @@ end function chem_is_active
        srcnam(m) = 'CT_' // spc_name ! chem tendancy (source/sink)
 
        call addfld( srcnam(m), (/ 'lev' /), 'A', 'kg/kg/s', trim(spc_name)//' source/sink' )
-       call cnst_get_ind(solsym(m), n, abort=.false. ) 
+       call cnst_get_ind(solsym(m), n, abort=.false. )
        if ( n > 0 ) then
 
           if (sflxnam(n)(3:5) == 'num') then  ! name is in the form of "SF****"
              unit_basename = ' 1'
           else
-             unit_basename = 'kg'  
+             unit_basename = 'kg'
           endif
 
           call addfld (sflxnam(n),horiz_only,    'A',  unit_basename//'/m2/s',trim(solsym(m))//' surface flux')
-          if ( history_aerosol .or. history_chemistry ) then 
+          if ( history_aerosol .or. history_chemistry ) then
              call add_default( sflxnam(n), 1, ' ' )
           endif
 
@@ -859,8 +855,8 @@ end function chem_is_active
                 call add_default( sflxnam(n), 1, ' ' )
              endif
           endif
-  
-          ! this is moved out of chem_register because we need to know where (what pressure) 
+
+          ! this is moved out of chem_register because we need to know where (what pressure)
           ! the upper boundary is to determine if this is a high top configuration -- after
           ! initialization of ref_pres ...
           if ( do_molec_diff ) then ! molecular diffusion requires 'wet' mixing ratios
@@ -870,7 +866,7 @@ end function chem_is_active
     end do
 
     ! Add chemical tendency of water vapor to water budget output
-    if ( history_budget ) then 
+    if ( history_budget ) then
       call add_default ('CT_H2O_GHG'  , history_budget_histfile_num, ' ')
     endif
 
@@ -879,7 +875,7 @@ end function chem_is_active
     !      required because water vapor is not declared by chemistry but
     !      has a fixed ubc only if WACCM chemistry is running.
     !-----------------------------------------------------------------------
-    ! this is moved out of chem_register because we need to know where (what pressure) 
+    ! this is moved out of chem_register because we need to know where (what pressure)
     ! the upper boundary is to determine if this is a high top configuration -- after
     ! initialization of ref_pres ...
     if ( 1.e-2_r8 >= ptop_ref .and. ptop_ref > 1.e-5_r8 ) then ! around waccm top, below top of waccmx
@@ -929,7 +925,7 @@ end function chem_is_active
      if ( ghg_chem ) then
         call ghg_chem_init(phys_state, bndtvg, h2orates)
      endif
-     
+
      call O1D_to_2OH_adj_init()
 
      call lin_strat_chem_inti(phys_state)
@@ -939,7 +935,7 @@ end function chem_is_active
                                  tod = chlorine_loading_fixed_tod )
 
      call init_cfc11star(pbuf2d)
-     
+
      ! MEGAN emissions initialize
      if (shr_megan_mechcomps_n>0) then
 
@@ -966,7 +962,7 @@ end function chem_is_active
 
         enddo
      endif
-     
+
      call noy_ubc_init()
 
      ! Galatic Cosmic Rays ...
@@ -976,13 +972,13 @@ end function chem_is_active
      call fire_emissions_init()
 
      call short_lived_species_initic()
-     
+
   end subroutine chem_init
 
 !================================================================================
 !================================================================================
   subroutine chem_emissions( state, cam_in )
-    use camsrfexch,       only: cam_in_t     
+    use camsrfexch,       only: cam_in_t
     use constituents,     only: sflxnam
     use cam_history,      only: outfld
     use mo_srf_emissions, only: set_srf_emissions
@@ -998,28 +994,28 @@ end function chem_is_active
     ! local vars
 
     integer :: lchnk, ncol
-    integer :: i, m,n 
+    integer :: i, m,n
 
     real(r8) :: sflx(pcols,gas_pcnst)
     real(r8) :: megflx(pcols)
 
     lchnk = state%lchnk
     ncol = state%ncol
-    
+
     ! initialize chemistry constituent surface fluxes to zero
     do m = 2,pcnst
        n = map2chm(m)
-       if (n>0) cam_in%cflx(:,m) = 0._r8 
+       if (n>0) cam_in%cflx(:,m) = 0._r8
     enddo
 
     ! aerosol emissions ...
     call aero_model_emissions( state, cam_in )
 
    ! MEGAN emissions ...
- 
+
     if ( index_x2a_Fall_flxvoc>0 .and. shr_megan_mechcomps_n>0 ) then
 
-       ! set MEGAN fluxes 
+       ! set MEGAN fluxes
        do n = 1,shr_megan_mechcomps_n
           do i =1,ncol
              megflx(i) = -cam_in%meganflx(i,n) * megan_wght_factors(n)
@@ -1034,9 +1030,9 @@ end function chem_is_active
 
    ! prescribed emissions from file ...
 
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
     !        ... Set surface emissions
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
     call set_srf_emissions( lchnk, ncol, sflx(:,:) )
 
     do m = 1,pcnst
@@ -1055,11 +1051,11 @@ end function chem_is_active
 !================================================================================
 
   subroutine chem_init_cnst( name, latvals, lonvals, mask, q)
-!----------------------------------------------------------------------- 
-! 
-! Purpose: 
+!-----------------------------------------------------------------------
+!
+! Purpose:
 ! Specify initial mass mixing ratios
-! 
+!
 !-----------------------------------------------------------------------
 
     use chem_mods, only : inv_lst
@@ -1081,7 +1077,7 @@ end function chem_is_active
 !-----------------------------------------------------------------------
 ! Local variables
 !-----------------------------------------------------------------------
-    
+
     real(r8) :: rmwn2o != mwn2o/mwdry ! ratio of mol weight n2o   to dry air
     real(r8) :: rmwch4 != mwch4/mwdry ! ratio of mol weight ch4   to dry air
     real(r8) :: rmwf11 != mwf11/mwdry ! ratio of mol weight cfc11 to dry air
@@ -1092,10 +1088,10 @@ end function chem_is_active
 ! initialize local variables
 !-----------------------------------------------------------------------
 
-    rmwn2o = mwn2o/mwdry 
-    rmwch4 = mwch4/mwdry 
-    rmwf11 = mwf11/mwdry 
-    rmwf12 = mwf12/mwdry 
+    rmwn2o = mwn2o/mwdry
+    rmwch4 = mwch4/mwdry
+    rmwf11 = mwf11/mwdry
+    rmwf12 = mwf12/mwdry
 
 !-----------------------------------------------------------------------
 ! Get initial mixing ratios
@@ -1163,7 +1159,7 @@ end function chem_is_active
 
     implicit none
 
-    type(physics_state), intent(inout) :: phys_state(begchunk:endchunk)                 
+    type(physics_state), intent(inout) :: phys_state(begchunk:endchunk)
     type(physics_buffer_desc), pointer :: pbuf2d(:,:)
 
     !-----------------------------------------------------------------------
@@ -1226,7 +1222,7 @@ end function chem_is_active
     if ( ghg_chem ) then
        call ghg_chem_timestep_init(phys_state)
     endif
-    
+
     !-----------------------------------------------------------------------
     ! Set up aurora
     !-----------------------------------------------------------------------
@@ -1238,7 +1234,7 @@ end function chem_is_active
     call photo_timestep_init( calday )
 
     call update_cfc11star( pbuf2d, phys_state )
-    
+
     ! Galatic Cosmic Rays ...
     call gcr_ionization_adv( pbuf2d, phys_state )
     call epp_ionization_adv()
@@ -1247,31 +1243,31 @@ end function chem_is_active
 
   subroutine chem_timestep_tend( state, ptend, cam_in, cam_out, dt, pbuf,  fh2o)
 
-!----------------------------------------------------------------------- 
-! 
-! Purpose: 
+!-----------------------------------------------------------------------
+!
+! Purpose:
 ! Interface to parameterized greenhouse gas chemisty (source/sink).
-! 
-! Method: 
-! <Describe the algorithm(s) used in the routine.> 
-! <Also include any applicable external references.> 
-! 
+!
+! Method:
+! <Describe the algorithm(s) used in the routine.>
+! <Also include any applicable external references.>
+!
 ! Author: B.A. Boville
-! 
+!
 !-----------------------------------------------------------------------
 
     use physics_buffer,      only : physics_buffer_desc, pbuf_get_field, pbuf_old_tim_idx
     use cam_history,         only : outfld
     use time_manager,        only : get_curr_calday
     use mo_gas_phase_chemdr, only : gas_phase_chemdr
-    use camsrfexch,          only : cam_in_t, cam_out_t     
+    use camsrfexch,          only : cam_in_t, cam_out_t
     use perf_mod,            only : t_startf, t_stopf
     use tropopause,          only : tropopause_findChemTrop, TROP_ALG_HYBSTOB, TROP_ALG_CLIMATE, tropopause_find
     use mo_drydep,           only : drydep_update
     use mo_neu_wetdep,       only : neu_wetdep_tend
     use aerodep_flx,         only : aerodep_flx_prescribed
     use short_lived_species, only : short_lived_species_writeic
-    
+
     implicit none
 
 !-----------------------------------------------------------------------
@@ -1283,7 +1279,7 @@ end function chem_is_active
     type(cam_in_t),      intent(inout) :: cam_in
     type(cam_out_t),     intent(inout) :: cam_out
     real(r8),            intent(out)   :: fh2o(pcols)     ! h2o flux to balance source from chemistry
-    
+
 
     type(physics_buffer_desc), pointer :: pbuf(:)
 
@@ -1333,7 +1329,7 @@ end function chem_is_active
     if ( ghg_chem ) lq(1) = .true.
 
     call physics_ptend_init(ptend, state%psetcols, 'chemistry', lq=lq)
-    
+
     call drydep_update( state, cam_in )
 
 !-----------------------------------------------------------------------
@@ -1405,7 +1401,7 @@ end function chem_is_active
           call outfld( srcnam(m), ptend%q(:,:,n), pcols, lchnk )
        end if
 
-       ! if the user has specified prescribed aerosol dep fluxes then 
+       ! if the user has specified prescribed aerosol dep fluxes then
        ! do not set cam_out dep fluxes according to the prognostic aerosols
        if (.not.aerodep_flx_prescribed()) then
           ! set deposition fluxes in the export state
@@ -1451,7 +1447,7 @@ end function chem_is_active
     do k = 1,pver
        fh2o(:ncol) = fh2o(:ncol) + ptend%q(:ncol,k,1)*state%pdel(:ncol,k)/gravit
     end do
-    
+
   end subroutine chem_timestep_tend
 
 !-------------------------------------------------------------------

--- a/src_cam/mo_chm_diags.F90
+++ b/src_cam/mo_chm_diags.F90
@@ -49,9 +49,9 @@ module mo_chm_diags
   character(len=fieldname_len) :: depflx_name(gas_pcnst)
   character(len=fieldname_len) :: wetdep_name(gas_pcnst)
   character(len=fieldname_len) :: wtrate_name(gas_pcnst)
-#ifdef OSLO_AERO
+  ! OSLO_AERO begin
   character(len=fieldname_len) :: wetdep_name_area(gas_pcnst)
-#endif
+  ! OSLO_AERO end
 
   real(r8), parameter :: N_molwgt = 14.00674_r8
   real(r8), parameter :: S_molwgt = 32.066_r8
@@ -68,10 +68,10 @@ contains
     use phys_control, only : phys_getopts
     use mo_drydep,    only : has_drydep
     use species_sums_diags, only : species_sums_init
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     use oslo_aero_share, only: getCloudTracerIndexDirect, getCloudTracerName, isAerosol
     use oslo_aero_share, only: aerosol_type_name, N_AEROSOL_TYPES
-#endif
+    ! OSLO_AERO end
 
     integer :: j, k, m, n
     character(len=16) :: jname, spc_name, attr
@@ -104,10 +104,10 @@ contains
     logical :: history_chemspecies_srf ! output the chemistry constituents species in the surface layer
     integer :: bulkaero_species(20)
     logical :: history_dust
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     integer :: cloudTracerIndex_direct
     character(len=20) :: cloudTracerName
-#endif
+    ! OSLO_AERO end
 
     !-----------------------------------------------------------------------
 
@@ -388,7 +388,7 @@ contains
           call addfld( wtrate_name(m), (/ 'lev' /), 'A',   '/s', spc_name//' wet deposition rate' )
        endif
 
-#ifdef OSLO_AERO
+       ! OSLO_AERO begin
        wetdep_name_area(m)='WD_A_'//trim(spc_name)
        call addfld( wetdep_name_area(m), horiz_only, 'A', 'kg/m2/s ', spc_name//' wet deposition' )
 
@@ -400,7 +400,7 @@ contains
             end if
           endif
         end if
-#endif
+        ! OSLO_AERO end
 
        if (spc_name(1:3) == 'num') then
           unit_basename = ' 1'
@@ -408,7 +408,7 @@ contains
           unit_basename = 'kg'
        endif
 
-#ifdef OSLO_AERO
+       ! OSLO_AERO begin
        if (n.gt.0) then
           if ( any( aer_species == m ) .or. isAerosol(n) ) then
              call addfld( spc_name,   (/ 'lev' /), 'A', unit_basename//'/kg ', trim(attr)//' concentration')
@@ -421,15 +421,7 @@ contains
           call addfld( spc_name, (/ 'lev' /), 'A', 'mol/mol', trim(attr)//' concentration')
           call addfld( trim(spc_name)//'_SRF', horiz_only, 'A', 'mol/mol', trim(attr)//" in bottom layer")
        endif
-#else
-       if ( any( aer_species == m ) ) then
-          call addfld( spc_name,   (/ 'lev' /), 'A', unit_basename//'/kg ', trim(attr)//' concentration')
-          call addfld( trim(spc_name)//'_SRF', horiz_only, 'A', unit_basename//'/kg', trim(attr)//" in bottom layer")
-       else
-          call addfld( spc_name, (/ 'lev' /), 'A', 'mol/mol', trim(attr)//' concentration')
-          call addfld( trim(spc_name)//'_SRF', horiz_only, 'A', 'mol/mol', trim(attr)//" in bottom layer")
-       endif
-#endif
+       ! OSLO_AERO end
 
        if ((m /= id_cly) .and. (m /= id_bry)) then
           if (history_aerosol.or.history_chemistry) then
@@ -471,7 +463,7 @@ contains
           if (m==id_cfc12 ) call add_default( spc_name, 1, ' ')
        endif
 
-#ifdef OSLO_AERO
+       ! OSLO_AERO begin
        call add_default( spc_name, 1, ' ' )
 
        !output 3d-field of aersol tracer in cloud water
@@ -508,15 +500,13 @@ contains
              endif
           endif
        end if
-#else
-       if (history_dust .and. (index(spc_name,'dst_') > 0))  call add_default( spc_name, 1, ' ')
-#endif
+       ! OSLO_AERO end
 
     enddo
 
     call addfld( 'MASS', (/ 'lev' /), 'A', 'kg', 'mass of grid box' )
     call addfld( 'AREA', horiz_only,  'A', 'm2', 'area of grid box' )
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
    do n=1,N_AEROSOL_TYPES
       call addfld('cb_'//trim(aerosol_type_name(n)),horiz_only, 'A', 'kg/m2',&
          'cb_'//trim(aerosol_type_name(n))//' column of aerosol type')
@@ -525,7 +515,7 @@ contains
          'mmr_'//trim(aerosol_type_name(n))//' mmr of aerosol type')
       call add_default('mmr_'//trim(aerosol_type_name(n)), 1, ' ')
    end do
-#endif
+   ! OSLO_AERO end
 
     call addfld( 'dry_deposition_NOy_as_N', horiz_only, 'I', 'kg/m2/s', 'NOy dry deposition flux ' )
     call addfld( 'DF_SOX', horiz_only, 'I', 'kg/m2/s', 'SOx dry deposition flux ' )
@@ -549,13 +539,10 @@ contains
 
   end subroutine chm_diags_inti
 
-#ifdef OSLO_AERO
+  ! OSLO_AERO begin
   subroutine chm_diags( lchnk, ncol, vmr, mmr, rxt_rates, invariants, depvel, depflx, mmr_tend, pdel, pmid, ltrop, &
                         wetdepflx, nhx_nitrogen_flx, noy_nitrogen_flx, pbuf)
-#else
-  subroutine chm_diags( lchnk, ncol, vmr, mmr, rxt_rates, invariants, depvel, depflx, mmr_tend, pdel, pmid, ltrop, &
-                        wetdepflx, nhx_nitrogen_flx, noy_nitrogen_flx)
-#endif
+  ! OSLO_AERO end
 
     !--------------------------------------------------------------------
     !	... utility routine to output chemistry diagnostic variables
@@ -564,7 +551,7 @@ contains
     use cam_history,  only : outfld
     use phys_grid,    only : get_area_all_p
     use species_sums_diags, only : species_sums_output
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     use constituents,   only : cnst_get_ind
     use phys_grid,      only : pcols
     use physics_buffer, only : pbuf_get_field, pbuf_get_index
@@ -572,7 +559,7 @@ contains
     !
     use oslo_aero_share,only : getCloudTracerIndexDirect, getCloudTracerName, aerosolType, isAerosol
     use oslo_aero_share,only : aerosol_type_name, N_AEROSOL_TYPES
-#endif
+    ! OSLO_AERO end
 !
 ! CCMI
 !
@@ -596,14 +583,14 @@ contains
     real(r8), intent(in)  :: wetdepflx(ncol, gas_pcnst)
     real(r8), intent(out) :: nhx_nitrogen_flx(ncol) ! kgN/m2/sec
     real(r8), intent(out) :: noy_nitrogen_flx(ncol) ! kgN/m2/sec
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     type(physics_buffer_desc), pointer :: pbuf(:)
-#endif
+    ! OSLO_AERO end
 
     !--------------------------------------------------------------------
     !	... local variables
     !--------------------------------------------------------------------
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     real(r8), dimension(:,:), pointer :: cloudTracerField
     integer                           :: cloudTracerIndex_direct
     character(len=20)                 :: cloudTracerName
@@ -611,7 +598,7 @@ contains
     real(r8)                          :: cb(pcols)
     real(r8)                          :: cb_aerosol_type(pcols,N_AEROSOL_TYPES)         !column burden aerosol types
     real(r8)                          :: mmr_aerosol_type(pcols,pver,N_AEROSOL_TYPES)   !concentration aerosol types
-#endif
+    ! OSLO_AERO end
     integer     :: i, k, m, n
     real(r8)    :: wrk(ncol,pver)
     !      real(r8)    :: tmp(ncol,pver)
@@ -627,9 +614,9 @@ contains
 
     real(r8) :: area(ncol), mass(ncol,pver)
     real(r8) :: wgt
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     character(len=16) :: spc_name
-#endif
+    ! OSLO_AERO end
 
     !--------------------------------------------------------------------
     !	... "diagnostic" groups
@@ -666,10 +653,10 @@ contains
     call outfld( 'AREA', area(:ncol),   ncol, lchnk )
     call outfld( 'MASS', mass(:ncol,:), ncol, lchnk )
 
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
    cb_aerosol_type(:,:) = 0.0_r8
    mmr_aerosol_type(:,:,:) = 0.0_r8
-#endif
+   ! OSLO_AERO end
     do m = 1,gas_pcnst
 
  !...FOY (counting Fluorines, not chlorines or bromines)
@@ -750,7 +737,7 @@ contains
           vmr_hox(:ncol,:) = vmr_hox(:ncol,:) +  wgt * vmr(:ncol,:,m)
        endif
 
-#ifdef OSLO_AERO
+       ! OSLO_AERO begin
        spc_name = trim(solsym(m))
        call cnst_get_ind(spc_name, n, abort=.false.)
 
@@ -793,15 +780,7 @@ contains
             mmr_aerosol_type(:ncol,:,aerosolType(n)) = mmr_aerosol_type(:ncol,:,aerosolType(n)) + mmr(:ncol,:,m)
          endif
        end if !Check if this is a chemistry tracer
-#else
-       if ( any( aer_species == m ) ) then
-          call outfld( solsym(m), mmr(:ncol,:,m), ncol ,lchnk )
-          call outfld( trim(solsym(m))//'_SRF', mmr(:ncol,pver,m), ncol ,lchnk )
-       else
-          call outfld( solsym(m), vmr(:ncol,:,m), ncol ,lchnk )
-          call outfld( trim(solsym(m))//'_SRF', vmr(:ncol,pver,m), ncol ,lchnk )
-       endif
-#endif
+       ! OSLO_AERO end
 
        call outfld( depvel_name(m), depvel(:ncol,m), ncol ,lchnk )
        call outfld( depflx_name(m), depflx(:ncol,m), ncol ,lchnk )
@@ -868,12 +847,12 @@ contains
 !
     enddo
 
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     do n=1,N_AEROSOL_TYPES
        call outfld("mmr_"//trim(aerosol_type_name(n)), mmr_aerosol_type(:ncol,:,n), ncol,lchnk)
        call outfld("cb_"//trim(aerosol_type_name(n)), cb_aerosol_type(:ncol,n), ncol,lchnk)
     enddo
-#endif
+    ! OSLO_AERO end
     call outfld( 'NOX',  vmr_nox  (:ncol,:), ncol, lchnk )
     call outfld( 'NOY',  vmr_noy  (:ncol,:), ncol, lchnk )
     call outfld( 'HOX',  vmr_hox  (:ncol,:), ncol, lchnk )
@@ -1003,11 +982,9 @@ contains
   subroutine het_diags( het_rates, mmr, pdel, lchnk, ncol )
 
     use cam_history,  only : outfld
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     use phys_grid,    only : get_wght_all_p, get_area_all_p
-#else
-    use phys_grid,    only : get_wght_all_p
-#endif
+    ! OSLO_AERO end
 
     integer,  intent(in)  :: lchnk
     integer,  intent(in)  :: ncol
@@ -1016,9 +993,9 @@ contains
     real(r8), intent(in)  :: pdel(ncol,pver)
 
     real(r8), dimension(ncol) :: noy_wk, sox_wk, nhx_wk, wrk_wd
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     real(r8), dimension(ncol) :: area
-#endif
+    ! OSLO_AERO end
     integer :: m, k
     real(r8) :: wght(ncol)
     !
@@ -1028,10 +1005,10 @@ contains
     sox_wk(:) = 0._r8
     nhx_wk(:) = 0._r8
 
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     call get_area_all_p(lchnk, ncol, area)
     area = area * rearth**2
-#endif
+    ! OSLO_AERO end
 
     call get_wght_all_p(lchnk, ncol, wght)
 
@@ -1048,9 +1025,9 @@ contains
        !
        if (gas_wetdep_method=='MOZ') then
           call outfld( wetdep_name(m), wrk_wd(:ncol),               ncol, lchnk )
-#ifdef OSLO_AERO
+          ! OSLO_AERO begin
           call outfld( wetdep_name_area(m), wrk_wd(:ncol)/area(:ncol)  ,ncol, lchnk )
-#endif
+          ! OSLO_AERO end
           call outfld( wtrate_name(m), het_rates(:ncol,:,m), ncol, lchnk )
 
           if ( any(noy_species == m ) ) then

--- a/src_cam/mo_drydep.F90
+++ b/src_cam/mo_drydep.F90
@@ -87,7 +87,7 @@ module mo_drydep
   logical :: o3a_dd, xpan_dd, xmpan_dd, xno2_dd, xhno3_dd, xonit_dd, xonitr_dd, xno_dd, xho2no2_dd, xnh4no3_dd
 
 !lke-TS1
-  integer :: phenooh_ndx, benzooh_ndx, c6h5ooh_ndx, bzooh_ndx, xylolooh_ndx, xylenooh_ndx 
+  integer :: phenooh_ndx, benzooh_ndx, c6h5ooh_ndx, bzooh_ndx, xylolooh_ndx, xylenooh_ndx
   integer :: terp2ooh_ndx, terprod1_ndx, terprod2_ndx, hmprop_ndx, mboooh_ndx, hpald_ndx, iepox_ndx
   integer :: noa_ndx, alknit_ndx, isopnita_ndx, isopnitb_ndx, honitr_ndx, isopnooh_ndx
   integer :: nc4cho_ndx, nc4ch2oh_ndx, terpnit_ndx, nterpooh_ndx
@@ -144,7 +144,7 @@ module mo_drydep
   integer, parameter :: n_land_type = 11
 
   integer, allocatable :: spc_ndx(:) ! nddvels
-  real(r8), public :: crb 
+  real(r8), public :: crb
 
   type lnd_dvel_type
      real(r8), pointer :: dvel(:,:)   ! deposition velocity over land (cm/s)
@@ -157,7 +157,7 @@ contains
 
   !---------------------------------------------------------------------------
   !---------------------------------------------------------------------------
-  subroutine dvel_inti_fromlnd 
+  subroutine dvel_inti_fromlnd
     use mo_chem_utls,         only : get_spc_ndx
     use cam_abortutils,       only : endrun
     use chem_mods,            only : adv_mass
@@ -188,11 +188,11 @@ contains
   !-------------------------------------------------------------------------------------
   subroutine drydep_update( state, cam_in )
     use physics_types,   only : physics_state
-    use camsrfexch,      only : cam_in_t     
+    use camsrfexch,      only : cam_in_t
     use seq_drydep_mod,  only : drydep_method, DD_XLND
 
     type(physics_state), intent(in) :: state           ! Physics state variables
-    type(cam_in_t),  intent(in) :: cam_in 
+    type(cam_in_t),  intent(in) :: cam_in
 
     if (nddvels<1) return
     if (drydep_method /= DD_XLND) return
@@ -207,15 +207,15 @@ contains
                              wind_speed, spec_hum, air_temp, pressure_10m, rain, &
                              snow, solar_flux, dvelocity, dflx, mmr, &
                              tv, soilw, rh, ncol, lonndx, latndx, lchnk )
-                          
+
     !-------------------------------------------------------------------------------------
-    ! combines the deposition velocities provided by the land model with deposition 
-    ! velocities over ocean and sea ice 
+    ! combines the deposition velocities provided by the land model with deposition
+    ! velocities over ocean and sea ice
     !-------------------------------------------------------------------------------------
 
     use ppgrid,         only : pcols
     use chem_mods,      only : gas_pcnst
-      
+
 #if (defined OFFLINE_DYN)
     use metdata, only: get_met_fields
 #endif
@@ -226,8 +226,8 @@ contains
     ! 	... dummy arguments
     !-------------------------------------------------------------------------------------
 
-    real(r8), intent(in)    :: icefrac(pcols)            
-    real(r8), intent(in)    :: ocnfrac(pcols)            
+    real(r8), intent(in)    :: icefrac(pcols)
+    real(r8), intent(in)    :: ocnfrac(pcols)
 
     integer, intent(in)   :: ncol
     integer, intent(in)   :: ncdate                   ! present date (yyyymmdd)
@@ -238,7 +238,7 @@ contains
     real(r8), intent(in)      :: rh(ncol,1)               ! relative humidity
     real(r8), intent(in)      :: air_temp(pcols)          ! surface air temperature (K)
     real(r8), intent(in)      :: pressure_10m(pcols)      ! 10 meter pressure (Pa)
-    real(r8), intent(in)      :: rain(pcols)              
+    real(r8), intent(in)      :: rain(pcols)
     real(r8), intent(in)      :: snow(pcols)              ! snow height (m)
     real(r8), intent(in)      :: soilw(pcols)             ! soil moisture fraction
     real(r8), intent(in)      :: solar_flux(pcols)        ! direct shortwave radiation at surface (W/m^2)
@@ -259,17 +259,17 @@ contains
 
     real(r8), dimension(ncol) :: term    ! work array
     integer  :: ispec
-    real(r8)  :: lndfrac(pcols)            
+    real(r8)  :: lndfrac(pcols)
 #if (defined OFFLINE_DYN)
     real(r8)  :: met_ocnfrac(pcols)
-    real(r8)  :: met_icefrac(pcols)            
+    real(r8)  :: met_icefrac(pcols)
 #endif
     integer :: i
 
     lndfrac(:ncol) = 1._r8 - ocnfrac(:ncol) - icefrac(:ncol)
 
-    where( lndfrac(:ncol) < 0._r8 ) 
-       lndfrac(:ncol) = 0._r8 
+    where( lndfrac(:ncol) < 0._r8 )
+       lndfrac(:ncol) = 0._r8
     endwhere
 
 #if (defined OFFLINE_DYN)
@@ -280,7 +280,7 @@ contains
     !   ... initialize
     !-------------------------------------------------------------------------------------
     dvelocity(:,:) = 0._r8
-    
+
     !-------------------------------------------------------------------------------------
     !   ... compute the dep velocities over ocean and sea ice
     !       land type 7 is used for ocean
@@ -305,7 +305,7 @@ contains
        dvelocity(:ncol,spc_ndx(ispec)) = lnd(lchnk)%dvel(:ncol,ispec)*lndfrac(:ncol) &
                                        + ocnice_dvel(:ncol,spc_ndx(ispec))
     enddo
-    
+
     !-------------------------------------------------------------------------------------
     !        ... special adjustments
     !-------------------------------------------------------------------------------------
@@ -328,10 +328,10 @@ contains
           dvelocity(:ncol,hcooh_ndx) = dvelocity(:ncol,ch3cooh_ndx)
        end if
     end if
-    
+
     !-------------------------------------------------------------------------------------
     !        ... assign CO tags to CO
-    ! put this kludge in for now ...  
+    ! put this kludge in for now ...
     !  -- should be able to set all these via the table mapping in seq_drydep_mod
     !-------------------------------------------------------------------------------------
     if( cohc_ndx>0 .and. co_ndx>0 ) then
@@ -540,11 +540,11 @@ contains
     nh3_dd     = has_drydep( 'NH3' )
     nh4no3_dd  = has_drydep( 'NH4NO3' )
     xnh4no3_dd = has_drydep( 'XNH4NO3' )
-    sa1_dd     = has_drydep( 'SA1' ) 
+    sa1_dd     = has_drydep( 'SA1' )
     sa2_dd     = has_drydep( 'SA2' )
-    sa3_dd     = has_drydep( 'SA3' ) 
+    sa3_dd     = has_drydep( 'SA3' )
     sa4_dd     = has_drydep( 'SA4' )
-    nh4_dd     = has_drydep( 'NH4' ) 
+    nh4_dd     = has_drydep( 'NH4' )
     pan_dd  = has_drydep( 'PAN')
     mpan_dd = has_drydep( 'MPAN')
     no2_dd  = has_drydep( 'NO2')
@@ -705,7 +705,7 @@ contains
     else
 #ifdef DEBUG
        if(masterproc) then
-          write(iulog,*) 'dvel_inti: Warning! depvel units unknown = ', to_lower(trim(units)) 
+          write(iulog,*) 'dvel_inti: Warning! depvel units unknown = ', to_lower(trim(units))
           write(iulog,*) '           ...      proceeding with scale_factor=1'
        end if
 #endif
@@ -953,7 +953,7 @@ contains
 
     real(r8), intent(in) :: icefrac(pcols)          ! sea-ice areal fraction
     real(r8), intent(in) :: ocnfrac(pcols)          ! ocean areal fraction
-    
+
     integer, intent(in)     :: lchnk
     !-----------------------------------------------------------------------
     ! 	... Local variables
@@ -961,7 +961,7 @@ contains
     integer :: m, i
     real(r8), dimension(ncol) :: vel, glace, temp_fac, wrk, tmp
     real(r8), dimension(ncol) :: o3_tab_dvel
-    real(r8), dimension(ncol) :: ocean 
+    real(r8), dimension(ncol) :: ocean
 
     real(r8), parameter :: pid2 = .5_r8 * pi
 
@@ -1345,61 +1345,61 @@ contains
        end if
     end if
 
-    if( xno2_dd ) then 
+    if( xno2_dd ) then
        if( map(xno2_ndx) == 0 ) then
           depvel(:ncol,xno2_ndx) = depvel(:ncol,no2_ndx)
           dflx(:ncol,xno2_ndx)   = wrk(:ncol) * depvel(:ncol,xno2_ndx) * q(:ncol,plev,xno2_ndx)
        end if
     endif
-    if( o3a_dd ) then 
+    if( o3a_dd ) then
        if( map(o3a_ndx) == 0 ) then
           depvel(:ncol,o3a_ndx) = depvel(:ncol,o3_ndx)
           dflx(:ncol,o3a_ndx)   = wrk(:ncol) * depvel(:ncol,o3a_ndx) * q(:ncol,plev,o3a_ndx)
        end if
     endif
-    if( xhno3_dd ) then 
+    if( xhno3_dd ) then
        if( map(xhno3_ndx) == 0 ) then
           depvel(:ncol,xhno3_ndx) = depvel(:ncol,hno3_ndx)
           dflx(:ncol,xhno3_ndx)   = wrk(:ncol) * depvel(:ncol,xhno3_ndx) * q(:ncol,plev,xhno3_ndx)
        end if
     endif
-    if( xnh4no3_dd ) then 
+    if( xnh4no3_dd ) then
        if( map(xnh4no3_ndx) == 0 ) then
           depvel(:ncol,xnh4no3_ndx) = depvel(:ncol,nh4no3_ndx)
           dflx(:ncol,xnh4no3_ndx)   = wrk(:ncol) * depvel(:ncol,xnh4no3_ndx) * q(:ncol,plev,xnh4no3_ndx)
        end if
     endif
-    if( xpan_dd ) then 
+    if( xpan_dd ) then
        if( map(xpan_ndx) == 0 ) then
           depvel(:ncol,xpan_ndx) = depvel(:ncol,pan_ndx)
           dflx(:ncol,xpan_ndx)   = wrk(:ncol) * depvel(:ncol,xpan_ndx) * q(:ncol,plev,xpan_ndx)
        end if
     endif
-    if( xmpan_dd ) then 
+    if( xmpan_dd ) then
        if( map(xmpan_ndx) == 0 ) then
           depvel(:ncol,xmpan_ndx) = depvel(:ncol,mpan_ndx)
           dflx(:ncol,xmpan_ndx)   = wrk(:ncol) * depvel(:ncol,xmpan_ndx) * q(:ncol,plev,xmpan_ndx)
        end if
     endif
-    if( xonit_dd ) then 
+    if( xonit_dd ) then
        if( map(xonit_ndx) == 0 ) then
           depvel(:ncol,xonit_ndx) = depvel(:ncol,onit_ndx)
           dflx(:ncol,xonit_ndx)   = wrk(:ncol) * depvel(:ncol,xonit_ndx) * q(:ncol,plev,xonit_ndx)
        end if
     endif
-    if( xonitr_dd ) then 
+    if( xonitr_dd ) then
        if( map(xonitr_ndx) == 0 ) then
           depvel(:ncol,xonitr_ndx) = depvel(:ncol,onitr_ndx)
           dflx(:ncol,xonitr_ndx)   = wrk(:ncol) * depvel(:ncol,xonitr_ndx) * q(:ncol,plev,xonitr_ndx)
        end if
     endif
-    if( xno_dd ) then 
+    if( xno_dd ) then
        if( map(xno_ndx) == 0 ) then
           depvel(:ncol,xno_ndx) = depvel(:ncol,no_ndx)
           dflx(:ncol,xno_ndx)   = wrk(:ncol) * depvel(:ncol,xno_ndx) * q(:ncol,plev,xno_ndx)
        end if
     endif
-    if( xho2no2_dd ) then 
+    if( xho2no2_dd ) then
        if( map(xho2no2_ndx) == 0 ) then
           depvel(:ncol,xho2no2_ndx) = depvel(:ncol,ho2no2_ndx)
           dflx(:ncol,xho2no2_ndx)   = wrk(:ncol) * depvel(:ncol,xho2no2_ndx) * q(:ncol,plev,xho2no2_ndx)
@@ -1572,7 +1572,7 @@ contains
     !-------------------------------------------------------------------------------------
     ! 	... dummy arguments
     !-------------------------------------------------------------------------------------
-    character(len=*), intent(in) :: depvel_lnd_file, clim_soilw_file, season_wes_file 
+    character(len=*), intent(in) :: depvel_lnd_file, clim_soilw_file, season_wes_file
 
     !-------------------------------------------------------------------------------------
     ! 	... local variables
@@ -1616,9 +1616,9 @@ contains
 
     ! determine if modal aerosols are active so that fraction_landuse array is initialized for modal aerosal dry dep
     call phys_getopts(prog_modal_aero_out=prog_modal_aero)
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     prog_modal_aero = .TRUE.
-#endif
+    ! OSLO_AERO end
 
     call dvel_inti_fromlnd()
 
@@ -1681,11 +1681,11 @@ contains
     oc2_dd     = has_drydep( 'OC2' )
     nh3_dd     = has_drydep( 'NH3' )
     nh4no3_dd  = has_drydep( 'NH4NO3' )
-    sa1_dd     = has_drydep( 'SA1' ) 
+    sa1_dd     = has_drydep( 'SA1' )
     sa2_dd     = has_drydep( 'SA2' )
-    sa3_dd     = has_drydep( 'SA3' ) 
+    sa3_dd     = has_drydep( 'SA3' )
     sa4_dd     = has_drydep( 'SA4' )
-    nh4_dd     = has_drydep( 'NH4' ) 
+    nh4_dd     = has_drydep( 'NH4' )
 !
     soam_ndx   = get_spc_ndx( 'SOAM' )
     soai_ndx   = get_spc_ndx( 'SOAI' )
@@ -2048,11 +2048,11 @@ contains
     use ncdio_atm, only : infld
     logical, intent(in) :: do_soilw
     logical :: readvar
-    
+
     type(file_desc_t) :: piofile
     character(len=shr_kind_cl) :: locfn
     logical :: lexist
-    
+
     call getfil (drydep_srf_file, locfn, 1, lexist)
     if(lexist) then
        call cam_pio_openfile(piofile, locfn, PIO_NOWRITE)
@@ -2162,7 +2162,7 @@ contains
           call shr_scam_getCloseLatLon(piofile%fh,scmlat,scmlon,closelat,closelon,latidx,lonidx)
           ploniop=size(loniop)
           platiop=size(latiop)
-       else 
+       else
           latidx=1
           lonidx=1
           ploniop=1
@@ -2226,7 +2226,7 @@ contains
     write(iulog,*) 'interp_map : mapping_ext ',mapping_ext
 #endif
     do j = 1,plon+1
-       lon1 = lon_edge(j) 
+       lon1 = lon_edge(j)
        do i = -veg_ext,nlon_veg+veg_ext
           dx = lon_veg_edge_ext(i  ) - lon1
           dy = lon_veg_edge_ext(i+1) - lon1
@@ -2260,17 +2260,17 @@ contains
           total_soilw_area = 0._r8
           do jj = ind_lat(j),ind_lat(j+1)
              y1 = max( lat_edge(j),lat_veg_edge(jj) )
-             y2 = min( lat_edge(j+1),lat_veg_edge(jj+1) ) 
+             y2 = min( lat_edge(j+1),lat_veg_edge(jj+1) )
              dy = (y2 - y1)/(lat_veg_edge(jj+1) - lat_veg_edge(jj))
              do ii =ind_lon(i),ind_lon(i+1)
                 i_ndx = mapping_ext(ii)
                 x1 = max( lon_edge(i),lon_veg_edge_ext(ii) )
-                x2 = min( lon_edge(i+1),lon_veg_edge_ext(ii+1) ) 
+                x2 = min( lon_edge(i+1),lon_veg_edge_ext(ii+1) )
                 dx = (x2 - x1)/(lon_veg_edge_ext(ii+1) - lon_veg_edge_ext(ii))
                 area = dx * dy
                 total_area = total_area + area
                 !-----------------------------------------------------------------
-                ! 	... special case for ocean grid point 
+                ! 	... special case for ocean grid point
                 !-----------------------------------------------------------------
                 if( nint(landmask(i_ndx,jj)) == 0 ) then
                    fraction(npft_veg+1) = fraction(npft_veg+1) + area
@@ -2352,7 +2352,7 @@ contains
     where (fraction_landuse > 1._r8) fraction_landuse = 1._r8
 
   end subroutine interp_map
-  
+
   !-------------------------------------------------------------------------------------
   !-------------------------------------------------------------------------------------
   subroutine drydep_xactive( ncdate, sfc_temp, pressure_sfc,  &
@@ -2398,7 +2398,7 @@ contains
     real(r8), intent(in)      :: rh(ncol,1)               ! relative humidity
     real(r8), intent(in)      :: air_temp(pcols)          ! surface air temperature (K)
     real(r8), intent(in)      :: pressure_10m(pcols)      ! 10 meter pressure (Pa)
-    real(r8), intent(in)      :: rain(pcols)              
+    real(r8), intent(in)      :: rain(pcols)
     real(r8), intent(in)      :: snow(pcols)              ! snow height (m)
     real(r8), intent(in)      :: soilw(pcols)             ! soil moisture fraction
     real(r8), intent(in)      :: solar_flux(pcols)        ! direct shortwave radiation at surface (W/m^2)
@@ -2414,8 +2414,8 @@ contains
     integer, intent(in), optional     ::  beglandtype
     integer, intent(in), optional     ::  endlandtype
 
-    real(r8), intent(in), optional      :: ocnfrc(pcols) 
-    real(r8), intent(in), optional      :: icefrc(pcols) 
+    real(r8), intent(in), optional      :: ocnfrc(pcols)
+    real(r8), intent(in), optional      :: icefrc(pcols)
 
     !-------------------------------------------------------------------------------------
     ! 	... local variables
@@ -2497,7 +2497,7 @@ contains
     logical  :: fr_lnduse(ncol,n_land_type)           ! wrking array
     real(r8) :: dewm                                  ! multiplier for rs when dew occurs
 
-    real(r8) :: lcl_frc_landuse(ncol,n_land_type) 
+    real(r8) :: lcl_frc_landuse(ncol,n_land_type)
 
     integer :: beglt, endlt
 
@@ -2511,16 +2511,16 @@ contains
                                 0.005_r8, 0.000_r8, 0.000_r8, 0.000_r8, 0.075_r8, 0.002_r8 /)
 
     if (present( beglandtype)) then
-      beglt = beglandtype 
+      beglt = beglandtype
     else
       beglt = 1
     endif
     if (present( endlandtype)) then
-      endlt = endlandtype 
+      endlt = endlandtype
     else
       endlt = n_land_type
     endif
-  
+
     !-------------------------------------------------------------------------------------
     ! initialize
     !-------------------------------------------------------------------------------------
@@ -2708,7 +2708,7 @@ contains
     !-------------------------------------------------------------------------------------
     ! revise calculation of friction velocity and z0 over water
     !-------------------------------------------------------------------------------------
-    lt = 7    
+    lt = 7
     do i = 1,ncol
        if( fr_lnduse(i,lt) ) then
           if( unstable(i) ) then
@@ -2969,7 +2969,7 @@ contains
                 if( lt == 7 ) then
                    where( fr_lnduse(:ncol,lt) )
                       ! assume no surface resistance for SO2 over water`
-                      wrk(:) = wrk(:) + lnd_frc(:)/(dep_ra(:ncol,lt,lchnk) + dep_rb(:ncol,lt,lchnk)) 
+                      wrk(:) = wrk(:) + lnd_frc(:)/(dep_ra(:ncol,lt,lchnk) + dep_rb(:ncol,lt,lchnk))
                    endwhere
                 else
                    where( fr_lnduse(:ncol,lt) )
@@ -3129,7 +3129,7 @@ contains
     integer :: lev, day, ierr
     type(file_desc_t) :: piofile
     type(var_desc_t) :: vid
-    
+
     integer :: dimid_lat, dimid_lon, dimid_time
     integer :: dates(12) = (/ 116, 214, 316, 415,  516,  615, &
                               716, 816, 915, 1016, 1115, 1216 /)
@@ -3198,7 +3198,7 @@ contains
     call cam_pio_closefile( piofile )
 
   end subroutine soilw_inti
-  
+
   !-------------------------------------------------------------------------------------
   !-------------------------------------------------------------------------------------
   subroutine chk_soilw( calday )

--- a/src_cam/mo_gas_phase_chemdr.F90
+++ b/src_cam/mo_gas_phase_chemdr.F90
@@ -6,11 +6,9 @@ module mo_gas_phase_chemdr
   use cam_history,      only : fieldname_len
   use chem_mods,        only : phtcnt, rxntot, gas_pcnst
   use chem_mods,        only : rxt_tag_cnt, rxt_tag_lst, rxt_tag_map, extcnt, num_rnts
-#ifdef OSLO_AERO  
+  ! OSLO_AERO begin
   use oslo_aero_dust,   only : dust_names, ndust => dust_nbin
-#else
-  use dust_model,       only : dust_names, ndust => dust_nbin
-#endif
+  ! OSLO_AERO end
   use ppgrid,           only : pcols, pver
   use phys_control,     only : phys_getopts
   use carma_flags_mod,  only : carma_hetchem_feedback
@@ -20,7 +18,7 @@ module mo_gas_phase_chemdr
   save
 
   private
-  public :: gas_phase_chemdr, gas_phase_chemdr_inti 
+  public :: gas_phase_chemdr, gas_phase_chemdr_inti
   public :: map2chm
 
   integer :: map2chm(pcnst) = 0           ! index map to/from chemistry/constituents list
@@ -30,10 +28,10 @@ module mo_gas_phase_chemdr
   integer :: het1_ndx
   integer :: ndx_cldfr, ndx_cmfdqr, ndx_nevapr, ndx_cldtop, ndx_prain
   integer :: ndx_h2so4
-#ifdef OSLO_AERO
+  ! OSLO_AERO begin
   logical :: inv_o3, inv_oh, inv_no3, inv_ho2
   integer :: id_o3, id_oh, id_no3, id_ho2
-#endif
+  ! OSLO_AERO end
 !
 ! CCMI
 !
@@ -61,11 +59,9 @@ contains
 
   subroutine gas_phase_chemdr_inti()
 
-#ifdef OSLO_AERO
+     ! OSLO_AERO begin
     use mo_chem_utls,      only : get_spc_ndx, get_extfrc_ndx, get_rxt_ndx, get_inv_ndx
-#else
-    use mo_chem_utls,      only : get_spc_ndx, get_extfrc_ndx, get_rxt_ndx
-#endif
+    ! OSLO_AERO end
     use cam_history,       only : addfld,add_default,horiz_only
     use mo_chm_diags,      only : chm_diags_inti
     use constituents,      only : cnst_get_ind
@@ -85,8 +81,8 @@ contains
     call phys_getopts( history_scwaccm_forcing_out = history_scwaccm_forcing )
 
     call phys_getopts( convproc_do_aer_out = convproc_do_aer, history_cesm_forcing_out=history_cesm_forcing )
-   
-#ifdef OSLO_AERO
+
+    ! OSLO_AERO begin
     inv_o3   = get_inv_ndx('O3') > 0
     inv_oh   = get_inv_ndx('OH') > 0
     inv_no3  = get_inv_ndx('NO3') > 0
@@ -103,7 +99,7 @@ contains
     if (inv_ho2) then
        id_ho2 = get_inv_ndx('HO2')
     endif
-#endif
+    ! OSLO_AERO end
 
     ndx_h2so4 = get_spc_ndx('H2SO4')
 !
@@ -134,12 +130,12 @@ contains
 
     pm25_srf_diag = cb1_ndx>0 .and. cb2_ndx>0 .and. oc1_ndx>0 .and. oc2_ndx>0 &
               .and. dst1_ndx>0 .and. dst2_ndx>0 .and. sslt1_ndx>0 .and. sslt2_ndx>0 &
-              .and. soa_ndx>0 
+              .and. soa_ndx>0
 
     pm25_srf_diag_soa = cb1_ndx>0 .and. cb2_ndx>0 .and. oc1_ndx>0 .and. oc2_ndx>0 &
               .and. dst1_ndx>0 .and. dst2_ndx>0 .and. sslt1_ndx>0 .and. sslt2_ndx>0 &
               .and. soam_ndx>0 .and. soai_ndx>0 .and. soat_ndx>0 .and. soab_ndx>0 .and. soax_ndx>0
-    
+
     if ( pm25_srf_diag .or. pm25_srf_diag_soa) then
        call addfld('PM25_SRF',horiz_only,'I','kg/kg','bottom layer PM2.5 mixing ratio' )
     endif
@@ -201,7 +197,7 @@ contains
     call addfld( 'DTANT',   horiz_only, 'I', ' ','photolysis diagnostic NH4SO4 OD' )
     call addfld( 'DTSAL',   horiz_only, 'I', ' ','photolysis diagnostic salt OD' )
     call addfld( 'DTDUST',  horiz_only, 'I', ' ','photolysis diagnostic dust OD' )
-    call addfld( 'DTTOTAL', horiz_only, 'I', ' ','photolysis diagnostic total aerosol OD' )   
+    call addfld( 'DTTOTAL', horiz_only, 'I', ' ','photolysis diagnostic total aerosol OD' )
     call addfld( 'FRACDAY', horiz_only, 'I', ' ','photolysis diagnostic fraction of day' )
 
     call addfld( 'QDSAD',      (/ 'lev' /), 'I', '/s',      'water vapor sad delta' )
@@ -231,7 +227,7 @@ contains
     call addfld( 'HCL_GAS',    (/ 'lev' /), 'I', 'mol/mol', 'gas-phase hcl' )
     call addfld( 'HCL_STS',    (/ 'lev' /), 'I', 'mol/mol', 'STS condensed HCL' )
 
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     ! Adding extra fields for oxi-output (before and after diurnal variations.)
     call addfld ('OH_bef    ',  (/ 'lev' /), 'A','unit', 'OH invariants before adding diurnal variations'           )
     call addfld ('HO2_bef   ',  (/ 'lev' /), 'A','unit', 'HO2 invariants before adding diurnal variations'          )
@@ -246,7 +242,7 @@ contains
     call add_default ('OH_aft       ', 1, ' ')
     call add_default ('HO2_aft      ', 1, ' ')
     call add_default ('NO3_aft      ', 1, ' ')
-#endif
+    ! OSLO_AERO end
 
     if (het1_ndx>0) then
        call addfld( 'het1_total', (/ 'lev' /), 'I', '/s', 'total N2O5 + H2O het rate constant' )
@@ -268,7 +264,7 @@ contains
     sad_pbf_ndx= pbuf_get_index('VOLC_SAD',errcode=err) ! prescribed  strat aerosols (volcanic)
     if (.not.sad_pbf_ndx>0) sad_pbf_ndx = pbuf_get_index('SADSULF',errcode=err) ! CARMA's version of strat aerosols
 
-    ele_temp_ndx = pbuf_get_index('TElec',errcode=err)! electron temperature index 
+    ele_temp_ndx = pbuf_get_index('TElec',errcode=err)! electron temperature index
     ion_temp_ndx = pbuf_get_index('TIon',errcode=err) ! ion temperature index
 
     ! diagnostics for stratospheric heterogeneous reactions
@@ -343,9 +339,9 @@ contains
     use mo_chm_diags,      only : chm_diags, het_diags
     use perf_mod,          only : t_startf, t_stopf
     use gas_wetdep_opts,   only : gas_wetdep_method
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     use oslo_aero_diurnal_var, only : set_diurnal_invariants
-#endif
+    ! OSLO_AERO end
     use physics_buffer,    only : physics_buffer_desc, pbuf_get_field, pbuf_old_tim_idx
     use infnan,            only : nan, assignment(=)
     use rate_diags,        only : rate_diags_calc
@@ -396,7 +392,7 @@ contains
     real(r8),       intent(in)    :: precc(pcols)                   !
     real(r8),       intent(in)    :: precl(pcols)                   !
     real(r8),       intent(in)    :: snowhland(pcols)               !
-    logical,        intent(in)    :: ghg_chem 
+    logical,        intent(in)    :: ghg_chem
     integer,        intent(in)    :: latmapback(pcols)
     integer,        intent(in)    :: troplev(pcols)                 ! trop/strat separation vertical index
     integer,        intent(in)    :: troplevchem(pcols)             ! trop/strat chemistry separation vertical index
@@ -496,7 +492,7 @@ contains
     real(r8) :: qh2o(pcols,pver)               ! specific humidity (kg/kg)
     real(r8) :: delta
 
-  ! for aerosol formation....  
+  ! for aerosol formation....
     real(r8) :: del_h2so4_gasprod(ncol,pver)
     real(r8) :: vmr0(ncol,pver,gas_pcnst)
 
@@ -534,9 +530,9 @@ contains
     reaction_rates(:,:,:) = nan
 
     delt_inverse = 1._r8 / delt
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
     !        ... Get chunck latitudes and longitudes
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
     call get_lat_all_p( lchnk, ncol, latndx )
     call get_lon_all_p( lchnk, ncol, lonndx )
     call get_rlat_all_p( lchnk, ncol, rlats )
@@ -552,20 +548,20 @@ contains
 
     dlats(:) = rlats(:)*rad2deg ! convert to degrees
 
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
     !        ... Calculate cosine of zenith angle
     !            then cast back to angle (radians)
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
     call zenith( calday, rlats, rlons, zen_angle, ncol , delt) !+tht delt
     zen_angle(:) = acos( zen_angle(:) )
 
     sza(:) = zen_angle(:) * rad2deg
     call outfld( 'SZA',   sza,    ncol, lchnk )
 
-    !-----------------------------------------------------------------------      
-    !        ... Xform geopotential height from m to km 
+    !-----------------------------------------------------------------------
+    !        ... Xform geopotential height from m to km
     !            and pressure from Pa to mb
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
     zsurf(:ncol) = rga * phis(:ncol)
     do k = 1,pver
        zintr(:ncol,k) = m2km * zi(:ncol,k)
@@ -577,9 +573,9 @@ contains
     zint(:ncol,pver+1) = m2km * (zi(:ncol,pver+1) + zsurf(:ncol))
     zintr(:ncol,pver+1)= m2km *  zi(:ncol,pver+1)
 
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
     !        ... map incoming concentrations to working array
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
     do m = 1,pcnst
        n = map2chm(m)
        if( n > 0 ) then
@@ -589,24 +585,24 @@ contains
 
     call get_short_lived_species( mmr, lchnk, ncol, pbuf )
 
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
     !        ... Set atmosphere mean mass
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
     call set_mean_mass( ncol, mmr, mbar )
 
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
     !        ... Xform from mmr to vmr
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
     call mmr2vmr( mmr(:ncol,:,:), vmr(:ncol,:,:), mbar(:ncol,:), ncol )
-    
+
 !
 ! CCMI
 !
 ! reset STE tracer to specific vmr of 200 ppbv
 !
-    if ( st80_25_ndx > 0 ) then 
+    if ( st80_25_ndx > 0 ) then
        where ( pmid(:ncol,:) < 80.e+2_r8 )
-          vmr(:ncol,:,st80_25_ndx) = 200.e-9_r8 
+          vmr(:ncol,:,st80_25_ndx) = 200.e-9_r8
        end where
     end if
 !
@@ -646,50 +642,50 @@ contains
     end if
 
     if (h2o_ndx>0) then
-       !-----------------------------------------------------------------------      
+       !-----------------------------------------------------------------------
        !        ... store water vapor in wrk variable
-       !-----------------------------------------------------------------------      
+       !-----------------------------------------------------------------------
        qh2o(:ncol,:) = mmr(:ncol,:,h2o_ndx)
        h2ovmr(:ncol,:) = vmr(:ncol,:,h2o_ndx)
     else
        qh2o(:ncol,:) = q(:ncol,:,1)
-       !-----------------------------------------------------------------------      
+       !-----------------------------------------------------------------------
        !        ... Xform water vapor from mmr to vmr and set upper bndy values
-       !-----------------------------------------------------------------------      
+       !-----------------------------------------------------------------------
        call h2o_to_vmr( q(:ncol,:,1), h2ovmr(:ncol,:), mbar(:ncol,:), ncol )
 
        call set_fstrat_h2o( h2ovmr, pmid, troplev, calday, ncol, lchnk )
 
     endif
 
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
     !        ... force ion/electron balance
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
     call charge_balance( ncol, vmr )
 
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
     !        ... Set the "invariants"
-    !-----------------------------------------------------------------------  
+    !-----------------------------------------------------------------------
     call setinv( invariants, tfld, h2ovmr, vmr, pmid, ncol, lchnk, pbuf )
 
-#ifdef OSLO_AERO
-    !-----------------------------------------------------------------------      
+    ! OSLO_AERO begin
+    !-----------------------------------------------------------------------
     !        ... Set the "day/night cycle for prescribed oxidants"
-    !----------------------------------------------------------------------- 
+    !-----------------------------------------------------------------------
     call outfld('OH_bef',    invariants(:,:,id_oh),  ncol, lchnk)
     call outfld('HO2_bef',   invariants(:,:,id_ho2), ncol, lchnk)
     call outfld('NO3_bef',   invariants(:,:,id_no3), ncol, lchnk)
 
     if (inv_oh.or.inv_ho2.or.inv_no3)  & !++IH: added inv_no3
       call set_diurnal_invariants(invariants,delt,ncol,lchnk,inv_oh,inv_ho2,id_oh,id_ho2,inv_no3,id_no3) !++IH: added inv_no3 and id_no3
-  
+
     call outfld('OH_aft',    invariants(:,:,id_oh),  ncol, lchnk)
     call outfld('HO2_aft',   invariants(:,:,id_ho2), ncol, lchnk)
     call outfld('NO3_aft',   invariants(:,:,id_no3), ncol, lchnk)
-#endif
-    !-----------------------------------------------------------------------      
+    ! OSLO_AERO end
+    !-----------------------------------------------------------------------
     !        ... stratosphere aerosol surface area
-    !-----------------------------------------------------------------------  
+    !-----------------------------------------------------------------------
     if (sad_pbf_ndx>0) then
        call pbuf_get_field(pbuf, sad_pbf_ndx, strato_sad)
     else
@@ -702,11 +698,11 @@ contains
     endif
 
     stratochem: if ( has_strato_chem ) then
-       !-----------------------------------------------------------------------      
+       !-----------------------------------------------------------------------
        !        ... initialize condensed and gas phases; all hno3 to gas
-       !-----------------------------------------------------------------------    
+       !-----------------------------------------------------------------------
        hcl_cond(:,:)      = 0.0_r8
-       hcl_gas (:,:)      = 0.0_r8  
+       hcl_gas (:,:)      = 0.0_r8
        do k = 1,pver
           hno3_gas(:,k)   = vmr(:,k,hno3_ndx)
           h2o_gas(:,k)    = h2ovmr(:,k)
@@ -726,9 +722,9 @@ contains
 
        call mmr2vmri( cldice(:ncol,:), h2o_cond(:ncol,:), mbar(:ncol,:), cnst_mw(cldice_ndx), ncol )
 
-       !-----------------------------------------------------------------------      
+       !-----------------------------------------------------------------------
        !        ... call SAD routine
-       !-----------------------------------------------------------------------      
+       !-----------------------------------------------------------------------
        call sad_strat_calc( lchnk, invariants(:ncol,:,indexm), pmb, tfld, hno3_gas, &
             hno3_cond, h2o_gas, h2o_cond, hcl_gas, hcl_cond, strato_sad(:ncol,:), radius_strat, &
             sad_strat, ncol, pbuf )
@@ -763,9 +759,9 @@ contains
        call outfld( 'HCL_GAS',    hcl_gas (:,:), ncol ,lchnk )
        call outfld( 'HCL_STS',    hcl_cond(:,:), ncol ,lchnk )
 
-       !-----------------------------------------------------------------------      
+       !-----------------------------------------------------------------------
        !        ... call aerosol reaction rates
-       !-----------------------------------------------------------------------      
+       !-----------------------------------------------------------------------
        call ratecon_sfstrat( ncol, invariants(:,:,indexm), pmid, tfld, &
             radius_strat(:,:,1), sad_strat(:,:,1), sad_strat(:,:,2), &
             sad_strat(:,:,3), h2ovmr, vmr, reaction_rates, &
@@ -782,22 +778,22 @@ contains
 
     endif stratochem
 
-!      NOTE: For gas-phase solver only. 
+!      NOTE: For gas-phase solver only.
 !            ratecon_sfstrat needs total hcl.
     if (hcl_ndx>0) then
        vmr(:,:,hcl_ndx)  = hcl_gas(:,:)
     endif
 
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
     !        ... Set the column densities at the upper boundary
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
     call set_ub_col( col_delta, vmr, invariants, pint(:,1), pdel, ncol, lchnk)
 
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
     !       ...  Set rates for "tabular" and user specified reactions
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
     call setrxt( reaction_rates, tfld, invariants(1,1,indexm), ncol )
-    
+
     sulfate(:,:) = 0._r8
     if ( .not. carma_hetchem_feedback ) then
        if( so4_ndx < 1 ) then ! get offline so4 field if not prognostic
@@ -806,7 +802,7 @@ contains
           sulfate(:,:) = vmr(:,:,so4_ndx)
        endif
     endif
-    
+
     !-----------------------------------------------------------------
     ! ... zero out sulfate above tropopause
     !-----------------------------------------------------------------
@@ -829,7 +825,7 @@ contains
        relhum(:,k) = .622_r8 * h2ovmr(:,k) / satq(:,k)
        relhum(:,k) = max( 0._r8,min( 1._r8,relhum(:,k) ) )
     end do
-    
+
     cwat(:ncol,:pver) = cldw(:ncol,:pver)
 
     call usrrxt( reaction_rates, tfld, ion_temp_fld, ele_temp_fld, invariants, h2ovmr, &
@@ -845,7 +841,7 @@ contains
     ! Add trop/strat components of effective radius for output
     reff(:ncol,:)=reff(:ncol,:)+reff_strat(:ncol,:)
     call outfld( 'REFF_AERO', reff(:ncol,:), ncol, lchnk )
-    
+
     if (het1_ndx>0) then
        call outfld( 'het1_total', reaction_rates(:,:,het1_ndx), ncol, lchnk )
     endif
@@ -862,15 +858,15 @@ contains
 
     !-----------------------------------------------------------------------
     !        ... Compute the photolysis rates at time = t(n+1)
-    !-----------------------------------------------------------------------      
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
+    !-----------------------------------------------------------------------
     !     	... Set the column densities
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
     call setcol( col_delta, col_dens, vmr, pdel,  ncol )
 
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
     !     	... Calculate the photodissociation rates
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
 
     esfact = 1._r8
     call shr_orb_decl( calday, eccen, mvelpp, lambm0, obliqr  , &
@@ -880,7 +876,7 @@ contains
     if ( xactive_prates ) then
        if ( dst_ndx > 0 ) then
           dust_vmr(:ncol,:,1:ndust) = vmr(:ncol,:,dst_ndx:dst_ndx+ndust-1)
-       else 
+       else
           dust_vmr(:ncol,:,:) = 0._r8
        endif
 
@@ -915,15 +911,15 @@ contains
        call outfld( tag_names(i), reaction_rates(:ncol,:,rxt_tag_map(i)), ncol, lchnk )
     enddo
 
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
     !     	... Adjust the photodissociation rates
-    !-----------------------------------------------------------------------  
+    !-----------------------------------------------------------------------
     call O1D_to_2OH_adj( reaction_rates, invariants, invariants(:,:,indexm), ncol, tfld )
     call phtadj( reaction_rates, invariants, invariants(:,:,indexm), ncol,pver )
 
     !-----------------------------------------------------------------------
     !        ... Compute the extraneous frcing at time = t(n+1)
-    !-----------------------------------------------------------------------    
+    !-----------------------------------------------------------------------
     if ( o2_ndx > 0 .and. o_ndx > 0 ) then
        do k = 1,pver
           o2mmr(:ncol,k) = mmr(:ncol,k,o2_ndx)
@@ -947,7 +943,7 @@ contains
 
     !-----------------------------------------------------------------------
     !        ... Form the washout rates
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
     if ( gas_wetdep_method=='MOZ' ) then
        call sethet( het_rates, pmid, zmid, phis, tfld, &
                     cmfdqr, prain, nevapr, delt, invariants(:,:,indexm), &
@@ -1035,17 +1031,17 @@ contains
                                 invariants(:,:,indexm), invariants, del_h2so4_gasprod,  &
                                 vmr0, vmr, pbuf )
 
-    if ( has_strato_chem ) then 
+    if ( has_strato_chem ) then
 
        wrk(:ncol,:) = (vmr(:ncol,:,h2o_ndx) - wrk(:ncol,:))*delt_inverse
        call outfld( 'QDCHEM',   wrk(:ncol,:),         ncol, lchnk )
        call outfld( 'HNO3_GAS', vmr(:ncol,:,hno3_ndx), ncol ,lchnk )
 
-       !-----------------------------------------------------------------------      
+       !-----------------------------------------------------------------------
        !         ... aerosol settling
        !             first settle hno3(2) using radius ice
        !             secnd settle hno3(3) using radius large nat
-       !-----------------------------------------------------------------------      
+       !-----------------------------------------------------------------------
        wrk(:,:) = vmr(:,:,h2o_ndx)
 #ifdef ALT_SETTL
        where( h2o_cond(:,:) > 0._r8 )
@@ -1068,17 +1064,17 @@ contains
             hno3_cond(1,1,2), radius_strat(1,1,2), ncol, lchnk, 2 )
 #endif
 
-       !-----------------------------------------------------------------------      
+       !-----------------------------------------------------------------------
        !	... reform total hno3 and hcl = gas + all condensed
-       !-----------------------------------------------------------------------      
+       !-----------------------------------------------------------------------
 !      NOTE: vmr for hcl and hno3 is gas-phase at this point.
 !            hno3_cond(:,k,1) = STS; hno3_cond(:,k,2) = NAT
-   
+
        do k = 1,pver
           vmr(:,k,hno3_ndx) = vmr(:,k,hno3_ndx) + hno3_cond(:,k,1) &
-               + hno3_cond(:,k,2) 
-          vmr(:,k,hcl_ndx)  = vmr(:,k,hcl_ndx)  + hcl_cond(:,k) 
-              
+               + hno3_cond(:,k,2)
+          vmr(:,k,hcl_ndx)  = vmr(:,k,hcl_ndx)  + hcl_cond(:,k)
+
        end do
 
        wrk(:,:) = (vmr(:,:,h2o_ndx) - wrk(:,:))*delt_inverse
@@ -1093,24 +1089,24 @@ contains
        call lin_strat_chem_solve( ncol, lchnk, vmr(:,:,o3_ndx), col_dens(:,:,1), tfld, zen_angle, pmid, delt, rlats, troplev )
     end if
 
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
     !         ... Check for negative values and reset to zero
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
     call negtrc( 'After chemistry ', vmr, ncol )
 
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
     !         ... Set upper boundary mmr values
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
     call set_fstrat_vals( vmr, pmid, pint, troplev, calday, ncol,lchnk )
 
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
     !         ... Set fixed lower boundary mmr values
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
     call flbc_set( vmr, ncol, lchnk, map2chm )
 
-    !----------------------------------------------------------------------- 
-    ! set NOy UBC     
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
+    ! set NOy UBC
+    !-----------------------------------------------------------------------
     call noy_ubc_set( lchnk, ncol, vmr )
 
     if ( ghg_chem ) then
@@ -1119,20 +1115,20 @@ contains
 
     !-----------------------------------------------------------------------
     ! force ion/electron balance -- ext forcings likely do not conserve charge
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
     call charge_balance( ncol, vmr )
 
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
     !         ... Xform from vmr to mmr
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
     call vmr2mmr( vmr(:ncol,:,:), mmr_tend(:ncol,:,:), mbar(:ncol,:), ncol )
 
     call set_short_lived_species( mmr_tend, lchnk, ncol, pbuf )
 
-    !-----------------------------------------------------------------------      
+    !-----------------------------------------------------------------------
     !         ... Form the tendencies
-    !----------------------------------------------------------------------- 
-    do m = 1,gas_pcnst 
+    !-----------------------------------------------------------------------
+    do m = 1,gas_pcnst
        mmr_new(:ncol,:,m) = mmr_tend(:ncol,:,m)
        mmr_tend(:ncol,:,m) = (mmr_tend(:ncol,:,m) - mmr(:ncol,:,m))*delt_inverse
     enddo
@@ -1140,7 +1136,7 @@ contains
     do m = 1,pcnst
        n = map2chm(m)
        if( n > 0 ) then
-          qtend(:ncol,:,m) = qtend(:ncol,:,m) + mmr_tend(:ncol,:,n) 
+          qtend(:ncol,:,m) = qtend(:ncol,:,m) + mmr_tend(:ncol,:,n)
        end if
     end do
 
@@ -1183,17 +1179,12 @@ contains
        endif
     end do
 
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     call chm_diags( lchnk, ncol, vmr(:ncol,:,:), mmr_new(:ncol,:,:), &
                     reaction_rates(:ncol,:,:), invariants(:ncol,:,:), depvel(:ncol,:),  sflx(:ncol,:), &
                     mmr_tend(:ncol,:,:), pdel(:ncol,:), pmid(:ncol,:), troplev(:ncol), wetdepflx_diag(:ncol,:), &
                     nhx_nitrogen_flx(:ncol), noy_nitrogen_flx(:ncol), pbuf )
-#else
-    call chm_diags( lchnk, ncol, vmr(:ncol,:,:), mmr_new(:ncol,:,:), &
-                    reaction_rates(:ncol,:,:), invariants(:ncol,:,:), depvel(:ncol,:),  sflx(:ncol,:), &
-                    mmr_tend(:ncol,:,:), pdel(:ncol,:), pmid(:ncol,:), troplev(:ncol), wetdepflx_diag(:ncol,:), &
-                    nhx_nitrogen_flx(:ncol), noy_nitrogen_flx(:ncol) )
-#endif
+    ! OSLO_AERO end
     call rate_diags_calc( reaction_rates(:,:,:), vmr(:,:,:), invariants(:,:,indexm), ncol, lchnk )
 !
 ! jfl

--- a/src_cam/mo_neu_wetdep.F90
+++ b/src_cam/mo_neu_wetdep.F90
@@ -14,10 +14,10 @@ module mo_neu_wetdep
   use cam_abortutils,   only : endrun
   use seq_drydep_mod,   only : n_species_table, species_name_table, dheff
   use gas_wetdep_opts,  only : gas_wetdep_method, gas_wetdep_list, gas_wetdep_cnt
-#ifdef OSLO_AERO
+  ! OSLO_AERO begin
   use mo_constants, only: rgrav
   use phys_control, only: phys_getopts
-#endif
+  ! OSLO_AERO end
 !
   implicit none
 !
@@ -281,10 +281,10 @@ subroutine neu_wetdep_tend(lchnk,ncol,mmr,pmid,pdel,zint,tfld,delt, &
   real(r8) :: pi
   real(r8) :: lats(pcols)
 
-#ifdef OSLO_AERO
+  ! OSLO_AERO begin
   real(r8) :: wrk_wd(pcols)
   logical history_aerosol
-#endif
+  ! OSLO_AERO end
 !
 ! from cam/src/physics/cam/stratiform.F90
 !
@@ -483,7 +483,7 @@ subroutine neu_wetdep_tend(lchnk,ncol,mmr,pmid,pdel,zint,tfld,delt, &
 
 !This is output normally in mo_chm_diags, but
 !if neu wetdep, we have to output it here!
-#ifdef OSLO_AERO
+   ! OSLO_AERO begin
    call phys_getopts( history_aerosol_out = history_aerosol)
    if(history_aerosol)then
       do m=1,gas_wetdep_cnt
@@ -496,7 +496,7 @@ subroutine neu_wetdep_tend(lchnk,ncol,mmr,pmid,pdel,zint,tfld,delt, &
          call outfld('WD_A_'//trim(gas_wetdep_list(m)),wrk_wd(:ncol),ncol,lchnk)
       end do
    end if
-#endif
+   ! OSLO_AERO end
 !
   if ( do_diag ) then
     call outfld('QT_RAIN_HNO3', qt_rain, ncol, lchnk )

--- a/src_cam/mo_photo.F90
+++ b/src_cam/mo_photo.F90
@@ -1,0 +1,1783 @@
+module mo_photo
+  !----------------------------------------------------------------------
+  !	... photolysis interp table and related arrays
+  !----------------------------------------------------------------------
+
+  use shr_kind_mod,     only : r8 => shr_kind_r8
+  use ppgrid,           only : pcols, pver, pverp, begchunk, endchunk
+  use cam_abortutils,   only : endrun
+  use mo_constants,     only : pi,r2d,boltz,d2r
+  use ref_pres,         only : num_pr_lev, ptop_ref
+  use pio
+  use cam_pio_utils,    only : cam_pio_openfile
+  use spmd_utils,       only : masterproc
+  use cam_logfile,      only : iulog
+  use phys_control,     only : waccmx_is
+  use solar_parms_data, only : f107=>solar_parms_f107, f107a=>solar_parms_f107a
+
+  implicit none
+
+  private
+
+  public :: photo_inti, table_photo, xactive_photo
+  public :: set_ub_col
+  public :: setcol
+  public :: photo_timestep_init
+  public :: photo_register
+
+  save
+
+  real(r8), parameter :: kg2g = 1.e3_r8
+  integer, parameter  :: pverm = pver - 1
+
+  integer ::  jno_ndx
+  integer ::  jonitr_ndx
+  integer ::  jho2no2_ndx
+  integer ::  jch3cho_a_ndx, jch3cho_b_ndx, jch3cho_c_ndx
+  integer ::  jo2_a_ndx, jo2_b_ndx
+  integer ::  ox_ndx, o3_ndx, o3_inv_ndx, o3rad_ndx
+  integer ::  oc1_ndx, oc2_ndx
+  integer ::  cb1_ndx, cb2_ndx
+  integer ::  soa_ndx
+  integer ::  ant_ndx
+  integer ::  so4_ndx
+  integer ::  sa1_ndx, sa2_ndx, sa3_ndx, sa4_ndx
+  integer ::  n2_ndx, no_ndx, o2_ndx, o_ndx
+  integer, allocatable :: lng_indexer(:)
+  integer, allocatable :: sht_indexer(:)
+  integer, allocatable :: euv_indexer(:)
+
+  integer              :: ki
+  integer              :: last
+  integer              :: next
+  integer              :: n_exo_levs
+  real(r8)                 :: delp
+  real(r8)                 :: dels
+  real(r8), allocatable    :: days(:)
+  real(r8), allocatable    :: levs(:)
+  real(r8), allocatable    :: o2_exo_coldens(:,:,:,:)
+  real(r8), allocatable    :: o3_exo_coldens(:,:,:,:)
+  logical              :: o_is_inv
+  logical              :: o2_is_inv
+  logical              :: n2_is_inv
+  logical              :: o3_is_inv
+  logical              :: no_is_inv
+  logical              :: has_o2_col
+  logical              :: has_o3_col
+  logical              :: has_fixed_press
+  real(r8) :: max_zen_angle       ! degrees
+
+  integer :: jo1d_ndx, jo3p_ndx, jno2_ndx, jn2o5_ndx
+  integer :: jhno3_ndx, jno3_ndx, jpan_ndx, jmpan_ndx
+
+  integer :: jo1da_ndx, jo3pa_ndx, jno2a_ndx, jn2o5a_ndx, jn2o5b_ndx
+  integer :: jhno3a_ndx, jno3a_ndx, jpana_ndx, jmpana_ndx, jho2no2a_ndx
+  integer :: jonitra_ndx
+
+  integer :: jppi_ndx, jepn1_ndx, jepn2_ndx, jepn3_ndx, jepn4_ndx, jepn6_ndx
+  integer :: jepn7_ndx, jpni1_ndx, jpni2_ndx, jpni3_ndx, jpni4_ndx, jpni5_ndx
+  logical :: do_jeuv = .false.
+  logical :: do_jshort = .false.
+#ifdef DEBUG
+  logical :: do_diag = .false.
+#endif
+  integer :: ion_rates_idx = -1
+
+contains
+
+
+  !----------------------------------------------------------------------
+  !----------------------------------------------------------------------
+  subroutine photo_register
+    use mo_jeuv,      only : nIonRates
+    use physics_buffer,only : pbuf_add_field, dtype_r8
+
+    ! add photo-ionization rates to phys buffer for waccmx ionosphere module
+
+    call pbuf_add_field('IonRates' , 'physpkg', dtype_r8, (/pcols,pver,nIonRates/), ion_rates_idx) ! Ionization rates for O+,O2+,N+,N2+,NO+
+
+  endsubroutine photo_register
+
+  !----------------------------------------------------------------------
+  !----------------------------------------------------------------------
+  subroutine photo_inti( xs_coef_file, xs_short_file, xs_long_file, rsf_file, &
+       photon_file, electron_file, &
+       exo_coldens_file, tuv_xsect_file, o2_xsect_file, xactive_prates )
+    !----------------------------------------------------------------------
+    !	... initialize photolysis module
+    !----------------------------------------------------------------------
+
+    use mo_photoin,    only : photoin_inti
+    use mo_tuv_inti,   only : tuv_inti
+    use mo_tuv_inti,   only : nlng
+    use mo_seto2,      only : o2_xsect_inti
+    use interpolate_data, only: lininterp_init, lininterp, lininterp_finish, interp_type
+    use chem_mods,     only : phtcnt
+    use chem_mods,     only : ncol_abs => nabscol
+    use chem_mods,     only : rxt_tag_lst, pht_alias_lst, pht_alias_mult
+    use time_manager,  only : get_calday
+    use ioFileMod,     only : getfil
+    use mo_chem_utls,  only : get_spc_ndx, get_rxt_ndx, get_inv_ndx
+    use mo_jlong,      only : jlong_init
+    ! OSLO_AERO begin
+    use oslo_aero_seasalt, only : sslt_names=>seasalt_names, sslt_ncnst=>seasalt_nbin
+    ! OSLO_AERO end
+    use mo_jshort,     only : jshort_init
+    use mo_jeuv,       only : jeuv_init, neuv
+    use phys_grid,     only : get_ncols_p, get_rlat_all_p
+    use solar_irrad_data,only : has_spectrum
+    use photo_bkgrnd,  only : photo_bkgrnd_init
+    use cam_history,   only : addfld
+
+    implicit none
+
+    !----------------------------------------------------------------------
+    !	... dummy arguments
+    !----------------------------------------------------------------------
+    character(len=*), intent(in) :: xs_long_file, rsf_file
+    character(len=*), intent(in) :: exo_coldens_file
+    character(len=*), intent(in) :: tuv_xsect_file
+    character(len=*), intent(in) :: o2_xsect_file
+    logical, intent(in)          :: xactive_prates
+    ! waccm
+    character(len=*), intent(in) :: xs_coef_file
+    character(len=*), intent(in) :: xs_short_file
+    character(len=*), intent(in) :: photon_file
+    character(len=*), intent(in) :: electron_file
+
+    !----------------------------------------------------------------------
+    !	... local variables
+    !----------------------------------------------------------------------
+    real(r8), parameter   :: hPa2Pa = 100._r8
+    integer           :: k, n
+    type(file_desc_t) :: ncid
+    type(var_desc_t)  :: vid
+    type(interp_type) :: lat_wgts
+    integer           :: dimid
+    integer           :: nlat
+    integer           :: ntimes
+    integer           :: astat
+    integer           :: ndx
+    integer           :: spc_ndx
+    integer           :: ierr
+    integer           :: c, ncols
+    integer, allocatable :: dates(:)
+    real(r8)              :: pinterp
+    real(r8), allocatable :: lats(:)
+    real(r8), allocatable :: coldens(:,:,:)
+    character(len=256)    :: locfn
+    character(len=256)    :: filespec
+    real(r8), parameter :: trop_thrshld = 1._r8 ! Pa
+    real(r8) :: to_lats(pcols)
+
+
+    if( phtcnt < 1 ) then
+       return
+    end if
+
+    !----------------------------------------------------------------------------
+    !  Need a larger maximum zenith angle for WACCM-X extended to high altitudes
+    !----------------------------------------------------------------------------
+    if ( waccmx_is('ionosphere') .or. waccmx_is('neutral') ) then
+       max_zen_angle = 116._r8
+    else if ( ptop_ref < 10._r8 ) then
+       max_zen_angle = 97.01_r8 ! degrees
+    else
+       max_zen_angle = 88.85_r8 ! degrees
+    endif
+
+    ! jeuv_1,,, jeuv_25 --> need euv calculations --> must be waccm
+    ! how to determine if shrt calc is needed ?? -- use top level pressure => waccm = true ? false
+
+    if ( .not. has_spectrum ) then
+       write(iulog,*) 'photo_inti: solar_irrad_data file needs to contain irradiance spectrum'
+       call endrun('photo_inti: ERROR -- solar irradiance spectrum is missing')
+    endif
+
+    !----------------------------------------------------------------------
+    !	... allocate indexers
+    !----------------------------------------------------------------------
+    allocate( lng_indexer(phtcnt),stat=astat )
+    if( astat /= 0 ) then
+       write(iulog,*) 'photo_inti: lng_indexer allocation error = ',astat
+       call endrun
+    end if
+    lng_indexer(:) = 0
+    allocate( sht_indexer(phtcnt),stat=astat )
+    if( astat /= 0 ) then
+       write(iulog,*) 'photo_inti: Failed to allocate sht_indexer; error = ',astat
+       call endrun
+    end if
+    sht_indexer(:) = 0
+    allocate( euv_indexer(neuv),stat=astat )
+    if( astat /= 0 ) then
+       write(iulog,*) 'photo_inti: Failed to allocate euv_indexer; error = ',astat
+       call endrun
+    end if
+    euv_indexer(:) = 0
+
+    jno_ndx     = get_rxt_ndx( 'jno' )
+    jo2_a_ndx   = get_rxt_ndx( 'jo2_a' )
+    jo2_b_ndx   = get_rxt_ndx( 'jo2_b' )
+
+    jo1da_ndx = get_rxt_ndx( 'jo1da' )
+    jo3pa_ndx = get_rxt_ndx( 'jo3pa' )
+    jno2a_ndx = get_rxt_ndx( 'jno2a' )
+    jn2o5a_ndx = get_rxt_ndx( 'jn2o5a' )
+    jn2o5b_ndx = get_rxt_ndx( 'jn2o5b' )
+    jhno3a_ndx = get_rxt_ndx( 'jhno3a' )
+    jno3a_ndx = get_rxt_ndx( 'jno3a' )
+    jpana_ndx = get_rxt_ndx( 'jpana' )
+    jmpana_ndx = get_rxt_ndx( 'jmpana' )
+    jho2no2a_ndx  = get_rxt_ndx( 'jho2no2a' )
+    jonitra_ndx = get_rxt_ndx( 'jonitra' )
+
+    jo1d_ndx = get_rxt_ndx( 'jo1d' )
+    jo3p_ndx = get_rxt_ndx( 'jo3p' )
+    jno2_ndx = get_rxt_ndx( 'jno2' )
+    jn2o5_ndx = get_rxt_ndx( 'jn2o5' )
+    jn2o5_ndx = get_rxt_ndx( 'jn2o5' )
+    jhno3_ndx = get_rxt_ndx( 'jhno3' )
+    jno3_ndx = get_rxt_ndx( 'jno3' )
+    jpan_ndx = get_rxt_ndx( 'jpan' )
+    jmpan_ndx = get_rxt_ndx( 'jmpan' )
+    jho2no2_ndx  = get_rxt_ndx( 'jho2no2' )
+    jonitr_ndx = get_rxt_ndx( 'jonitr' )
+
+    jppi_ndx = get_rxt_ndx( 'jppi' )
+    jepn1_ndx = get_rxt_ndx( 'jepn1' )
+    jepn2_ndx = get_rxt_ndx( 'jepn2' )
+    jepn3_ndx = get_rxt_ndx( 'jepn3' )
+    jepn4_ndx = get_rxt_ndx( 'jepn4' )
+    jepn6_ndx = get_rxt_ndx( 'jepn6' )
+    jepn7_ndx = get_rxt_ndx( 'jepn7' )
+    jpni1_ndx = get_rxt_ndx( 'jpni1' )
+    jpni2_ndx = get_rxt_ndx( 'jpni2' )
+    jpni3_ndx = get_rxt_ndx( 'jpni3' )
+    jpni4_ndx = get_rxt_ndx( 'jpni4' )
+    ! added to v02
+    jpni5_ndx = get_rxt_ndx( 'jpni5' )
+    ox_ndx     = get_spc_ndx( 'OX' )
+    if( ox_ndx < 1 ) then
+       ox_ndx  = get_spc_ndx( 'O3' )
+    end if
+    o3_ndx     = get_spc_ndx( 'O3' )
+    o3rad_ndx  = get_spc_ndx( 'O3RAD' )
+    o3_inv_ndx = get_inv_ndx( 'O3' )
+
+    n2_ndx     = get_inv_ndx( 'N2' )
+    n2_is_inv  = n2_ndx > 0
+    if( .not. n2_is_inv ) then
+       n2_ndx = get_spc_ndx( 'N2' )
+    end if
+    o2_ndx     = get_inv_ndx( 'O2' )
+    o2_is_inv  = o2_ndx > 0
+    if( .not. o2_is_inv ) then
+       o2_ndx = get_spc_ndx( 'O2' )
+    end if
+    no_ndx     = get_spc_ndx( 'NO' )
+    no_is_inv  = no_ndx < 1
+    if( no_is_inv ) then
+       no_ndx = get_inv_ndx( 'NO' )
+    end if
+    o3_is_inv  = o3_ndx < 1
+
+    o_ndx     = get_spc_ndx( 'O' )
+    o_is_inv  = o_ndx < 1
+    if( o_is_inv ) then
+       o_ndx = get_inv_ndx( 'O' )
+    end if
+
+    do_jshort = o_ndx>0 .and. o2_ndx>0 .and. (o3_ndx>0.or.o3_inv_ndx>0) .and. n2_ndx>0 .and. no_ndx>0
+
+    call jeuv_init( photon_file, electron_file, euv_indexer )
+    do_jeuv = any(euv_indexer(:)>0)
+
+    !----------------------------------------------------------------------
+    !	... call module initializers
+    !----------------------------------------------------------------------
+    is_xactive : if( xactive_prates ) then
+       do_jshort = .false.
+       jch3cho_a_ndx = get_rxt_ndx( 'jch3cho_a' )
+       jch3cho_b_ndx = get_rxt_ndx( 'jch3cho_b' )
+       jch3cho_c_ndx = get_rxt_ndx( 'jch3cho_c' )
+       jonitr_ndx    = get_rxt_ndx( 'jonitr' )
+       jho2no2_ndx   = get_rxt_ndx( 'jho2no2' )
+       call tuv_inti( pverp, tuv_xsect_file, lng_indexer )
+    else is_xactive
+       call jlong_init( xs_long_file, rsf_file, lng_indexer )
+       if (do_jeuv) then
+          call photo_bkgrnd_init()
+          call addfld('Qbkgndtot', (/ 'lev' /), 'A','cm-3 sec-1', 'background ionization rate ' )
+          call addfld('Qbkgnd_o1', (/ 'lev' /), 'A','cm-3 sec-1', 'background ionization rate ' )
+          call addfld('Qbkgnd_o2', (/ 'lev' /), 'A','cm-3 sec-1', 'background ionization rate ' )
+          call addfld('Qbkgnd_n2', (/ 'lev' /), 'A','cm-3 sec-1', 'background ionization rate ' )
+          call addfld('Qbkgnd_n1', (/ 'lev' /), 'A','cm-3 sec-1', 'background ionization rate ' )
+          call addfld('Qbkgnd_no', (/ 'lev' /), 'A','cm-3 sec-1', 'background ionization rate ' )
+       endif
+       if (do_jshort) then
+          call jshort_init( xs_coef_file, xs_short_file, sht_indexer )
+       endif
+       jho2no2_ndx = get_rxt_ndx( 'jho2no2_b' )
+    end if is_xactive
+
+    !----------------------------------------------------------------------
+    !        ... check that each photorate is in short or long datasets
+    !----------------------------------------------------------------------
+    if( any( ( abs(sht_indexer(:)) + abs(lng_indexer(:)) ) == 0 ) ) then
+       write(iulog,*) ' '
+       write(iulog,*) 'photo_inti: the following photorate(s) are not in'
+       write(iulog,*) '            either the short or long datasets'
+       write(iulog,*) ' '
+       do ndx = 1,phtcnt
+          if( abs(sht_indexer(ndx)) + abs(lng_indexer(ndx)) == 0 ) then
+             write(iulog,*) '           ',trim( rxt_tag_lst(ndx) )
+          end if
+       end do
+       call endrun
+    end if
+
+    !----------------------------------------------------------------------
+    !        ... output any aliased photorates
+    !----------------------------------------------------------------------
+    if( masterproc ) then
+       if( any( pht_alias_lst(:,1) /= ' ' ) ) then
+          write(iulog,*) ' '
+          write(iulog,*) 'photo_inti: the following short photorate(s) are aliased'
+          write(iulog,*) ' '
+          do ndx = 1,phtcnt
+             if( pht_alias_lst(ndx,1) /= ' ' ) then
+                if( pht_alias_mult(ndx,1) == 1._r8 ) then
+                   write(iulog,*) '           ',trim(rxt_tag_lst(ndx)),' -> ',trim(pht_alias_lst(ndx,1))
+                else
+                   write(iulog,*) '           ',trim(rxt_tag_lst(ndx)),' -> ',pht_alias_mult(ndx,1),'*',trim(pht_alias_lst(ndx,1))
+                end if
+             end if
+          end do
+       end if
+       if( any( pht_alias_lst(:,2) /= ' ' ) ) then
+          write(iulog,*) ' '
+          write(iulog,*) 'photo_inti: the following long photorate(s) are aliased'
+          write(iulog,*) ' '
+          do ndx = 1,phtcnt
+             if( pht_alias_lst(ndx,2) /= ' ' ) then
+                if( pht_alias_mult(ndx,2) == 1._r8 ) then
+                   write(iulog,*) '           ',trim(rxt_tag_lst(ndx)),' -> ',trim(pht_alias_lst(ndx,2))
+                else
+                   write(iulog,*) '           ',trim(rxt_tag_lst(ndx)),' -> ',pht_alias_mult(ndx,2),'*',trim(pht_alias_lst(ndx,2))
+                end if
+             end if
+          end do
+       end if
+
+       write(iulog,*) ' '
+       write(iulog,*) '*********************************************'
+       write(iulog,*) 'photo_inti: euv_indexer'
+       write(iulog,'(10i6)') euv_indexer(:)
+       write(iulog,*) 'photo_inti: sht_indexer'
+       write(iulog,'(10i6)') sht_indexer(:)
+       write(iulog,*) 'photo_inti: lng_indexer'
+       write(iulog,'(10i6)') lng_indexer(:)
+       write(iulog,*) '*********************************************'
+       write(iulog,*) ' '
+    endif
+
+    if( xactive_prates ) then
+       call o2_xsect_inti( o2_xsect_file )
+       call photoin_inti( nlng, lng_indexer )
+    end if
+
+    !----------------------------------------------------------------------
+    !	... check for o2, o3 absorber columns
+    !----------------------------------------------------------------------
+    if( ncol_abs > 0 ) then
+       spc_ndx = ox_ndx
+       if( spc_ndx < 1 ) then
+          spc_ndx = o3_ndx
+       end if
+       if( spc_ndx > 0 ) then
+          has_o3_col = .true.
+       else
+          has_o3_col = .false.
+       end if
+       if( ncol_abs > 1 ) then
+          if( o2_ndx > 1 ) then
+             has_o2_col = .true.
+          else
+             has_o2_col = .false.
+          end if
+       else
+          has_o2_col = .false.
+       end if
+    else
+       has_o2_col = .false.
+       has_o3_col = .false.
+    end if
+
+    if ( len_trim(exo_coldens_file) == 0 ) then
+       has_o2_col = .false.
+       has_o3_col = .false.
+    endif
+
+    oc1_ndx = get_spc_ndx( 'OC1' )
+    oc2_ndx = get_spc_ndx( 'OC2' )
+    cb1_ndx = get_spc_ndx( 'CB1' )
+    cb2_ndx = get_spc_ndx( 'CB2' )
+    soa_ndx = get_spc_ndx( 'SOA' )
+    ant_ndx = get_spc_ndx( 'NH4NO3' )
+    so4_ndx = get_spc_ndx( 'SO4' )
+    if (sslt_ncnst == 4) then
+       sa1_ndx = get_spc_ndx( sslt_names(1) )
+       sa2_ndx = get_spc_ndx( sslt_names(2) )
+       sa3_ndx = get_spc_ndx( sslt_names(3) )
+       sa4_ndx = get_spc_ndx( sslt_names(4) )
+    endif
+
+    has_abs_columns : if( has_o2_col .or. has_o3_col ) then
+       !-----------------------------------------------------------------------
+       !	... open exo coldens file
+       !-----------------------------------------------------------------------
+       filespec = trim( exo_coldens_file )
+       call getfil( filespec, locfn, 0 )
+       call cam_pio_openfile( ncid, trim(locfn), PIO_NOWRITE )
+
+       !-----------------------------------------------------------------------
+       !       ... get grid dimensions from file
+       !-----------------------------------------------------------------------
+       !       ... timing
+       !-----------------------------------------------------------------------
+       ierr = pio_inq_dimid( ncid, 'month', dimid )
+       ierr = pio_inq_dimlen( ncid, dimid, ntimes )
+
+       if( ntimes /= 12 ) then
+          call endrun('photo_inti: exo coldens is not annual period')
+       end if
+       allocate( dates(ntimes),days(ntimes),stat=astat )
+       if( astat /= 0 ) then
+          write(iulog,*) 'photo_inti: dates,days allocation error = ',astat
+          call endrun
+       end if
+       dates(:) = (/ 116, 214, 316, 415,  516,  615, &
+            716, 816, 915, 1016, 1115, 1216 /)
+       !-----------------------------------------------------------------------
+       !	... initialize the monthly day of year times
+       !-----------------------------------------------------------------------
+       do n = 1,ntimes
+          days(n) = get_calday( dates(n), 0 )
+       end do
+       deallocate( dates )
+       !-----------------------------------------------------------------------
+       !       ... latitudes
+       !-----------------------------------------------------------------------
+       ierr = pio_inq_dimid( ncid, 'lat', dimid )
+       ierr = pio_inq_dimlen( ncid, dimid, nlat )
+       allocate( lats(nlat), stat=astat )
+       if( astat /= 0 ) then
+          write(iulog,*) 'photo_inti: lats allocation error = ',astat
+          call endrun
+       end if
+       ierr = pio_inq_varid( ncid, 'lat', vid )
+       ierr = pio_get_var( ncid, vid, lats )
+       lats(:nlat) = lats(:nlat) * d2r
+       !-----------------------------------------------------------------------
+       !       ... levels
+       !-----------------------------------------------------------------------
+       ierr = pio_inq_dimid( ncid, 'lev', dimid )
+       ierr = pio_inq_dimlen( ncid, dimid, n_exo_levs )
+       allocate( levs(n_exo_levs), stat=astat )
+       if( astat /= 0 ) then
+          write(iulog,*) 'photo_inti: levs allocation error = ',astat
+          call endrun
+       end if
+       ierr = pio_inq_varid( ncid, 'lev', vid )
+       ierr = pio_get_var( ncid, vid, levs )
+       levs(:n_exo_levs) = levs(:n_exo_levs) * hPa2Pa
+       !-----------------------------------------------------------------------
+       !       ... set up regridding
+       !-----------------------------------------------------------------------
+
+       allocate( coldens(nlat,n_exo_levs,ntimes),stat=astat )
+       if( astat /= 0 ) then
+          write(iulog,*) 'photo_inti: coldens allocation error = ',astat
+          call endrun
+       end if
+       if( has_o2_col ) then
+          allocate( o2_exo_coldens(n_exo_levs,pcols,begchunk:endchunk,ntimes),stat=astat )
+          if( astat /= 0 ) then
+             write(iulog,*) 'photo_inti: o2_exo_coldens allocation error = ',astat
+             call endrun
+          end if
+          ierr = pio_inq_varid( ncid, 'O2_column_density', vid )
+          ierr = pio_get_var( ncid, vid,coldens )
+
+          do c=begchunk,endchunk
+             ncols = get_ncols_p(c)
+             call get_rlat_all_p(c, pcols, to_lats)
+             call lininterp_init(lats, nlat, to_lats, ncols, 1, lat_wgts)
+             do n=1,ntimes
+                do k = 1,n_exo_levs
+                   call lininterp(coldens(:,k,n), nlat, o2_exo_coldens(k,:,c,n), ncols, lat_wgts)
+                end do
+             end do
+             call lininterp_finish(lat_wgts)
+          enddo
+
+
+       end if
+       if( has_o3_col ) then
+          allocate( o3_exo_coldens(n_exo_levs,pcols,begchunk:endchunk,ntimes),stat=astat )
+          if( astat /= 0 ) then
+             write(iulog,*) 'photo_inti: o3_exo_coldens allocation error = ',astat
+             call endrun
+          end if
+          ierr = pio_inq_varid( ncid, 'O3_column_density', vid )
+          ierr = pio_get_var( ncid, vid,coldens )
+
+          do c=begchunk,endchunk
+             ncols = get_ncols_p(c)
+             call get_rlat_all_p(c, pcols, to_lats)
+             call lininterp_init(lats, nlat, to_lats, ncols, 1, lat_wgts)
+             do n=1,ntimes
+                do k = 1,n_exo_levs
+                   call lininterp(coldens(:,k,n), nlat, o3_exo_coldens(k,:,c,n), ncols, lat_wgts)
+                end do
+             end do
+             call lininterp_finish(lat_wgts)
+          enddo
+       end if
+       call pio_closefile (ncid)
+       deallocate( coldens,stat=astat )
+       if( astat /= 0 ) then
+          write(iulog,*) 'photo_inti: failed to deallocate coldens; error = ',astat
+          call endrun
+       end if
+       has_fixed_press = (num_pr_lev .ne. 0)
+       !-----------------------------------------------------------------------
+       !	... setup the pressure interpolation
+       !-----------------------------------------------------------------------
+       if( has_fixed_press ) then
+          pinterp =  ptop_ref
+          if( pinterp <= levs(1) ) then
+             ki   = 1
+             delp = 0._r8
+          else
+             do ki = 2,n_exo_levs
+                if( pinterp <= levs(ki) ) then
+                   delp = log( pinterp/levs(ki-1) )/log( levs(ki)/levs(ki-1) )
+                   exit
+                end if
+             end do
+          end if
+#ifdef DEBUG
+          if (masterproc) then
+             write(iulog,*) '-----------------------------------'
+             write(iulog,*) 'photo_inti: diagnostics'
+             write(iulog,*) 'ki, delp = ',ki,delp
+             if (ki>1) then
+                write(iulog,*) 'pinterp,levs(ki-1:ki) = ',pinterp,levs(ki-1:ki)
+             else
+                write(iulog,*) 'pinterp,levs(ki) = ',pinterp,levs(ki)
+             end if
+             write(iulog,*) '-----------------------------------'
+          endif
+#endif
+       end if
+    end if has_abs_columns
+
+  end subroutine photo_inti
+
+  subroutine table_photo( photos, pmid, pdel, temper, zmid, zint, &
+                          col_dens, zen_angle, srf_alb, lwc, clouds, &
+                          esfact, vmr, invariants, ncol, lchnk, pbuf )
+!-----------------------------------------------------------------
+!   	... table photorates for wavelengths > 200nm
+!-----------------------------------------------------------------
+
+    use chem_mods,   only : ncol_abs => nabscol, phtcnt, gas_pcnst, nfs
+    use chem_mods,   only : pht_alias_mult, indexm
+    use mo_jshort,   only : nsht => nj, jshort
+    use mo_jlong,    only : nlng => numj, jlong
+    use mo_jeuv,     only : neuv, jeuv, nIonRates
+    use physics_buffer, only : physics_buffer_desc, pbuf_get_field
+    use photo_bkgrnd, only : photo_bkgrnd_calc
+    use cam_history, only : outfld
+    use infnan,      only : nan, assignment(=)
+
+    implicit none
+
+!-----------------------------------------------------------------
+!   	... dummy arguments
+!-----------------------------------------------------------------
+    integer,  intent(in)    :: lchnk
+    integer,  intent(in)    :: ncol
+    real(r8), intent(in)    :: esfact                       ! earth sun distance factor
+    real(r8), intent(in)    :: vmr(ncol,pver,max(1,gas_pcnst)) ! vmr
+    real(r8), intent(in)    :: col_dens(ncol,pver,ncol_abs) ! column densities (molecules/cm^2)
+    real(r8), intent(in)    :: zen_angle(ncol)              ! solar zenith angle (radians)
+    real(r8), intent(in)    :: srf_alb(pcols)               ! surface albedo
+    real(r8), intent(in)    :: lwc(ncol,pver)               ! liquid water content (kg/kg)
+    real(r8), intent(in)    :: clouds(ncol,pver)            ! cloud fraction
+    real(r8), intent(in)    :: pmid(pcols,pver)             ! midpoint pressure (Pa)
+    real(r8), intent(in)    :: pdel(pcols,pver)             ! pressure delta about midpoint (Pa)
+    real(r8), intent(in)    :: temper(pcols,pver)           ! midpoint temperature (K)
+    real(r8), intent(in)    :: zmid(ncol,pver)              ! midpoint height (km)
+    real(r8), intent(in)    :: zint(ncol,pver)              ! interface height (km)
+    real(r8), intent(in)    :: invariants(ncol,pver,max(1,nfs)) ! invariant densities (molecules/cm^3)
+    real(r8), intent(inout) :: photos(ncol,pver,phtcnt)     ! photodissociation rates (1/s)
+    type(physics_buffer_desc),pointer :: pbuf(:)
+
+!-----------------------------------------------------------------
+!    	... local variables
+!-----------------------------------------------------------------
+    real(r8), parameter :: Pa2mb         = 1.e-2_r8       ! pascals to mb
+
+    integer ::  i, k, m                    ! indicies
+    integer ::  astat
+    real(r8) ::  sza
+    real(r8) ::  alias_factor
+    real(r8) ::  fac1(pver)                ! work space for j(no) calc
+    real(r8) ::  fac2(pver)                ! work space for j(no) calc
+    real(r8) ::  colo3(pver)               ! vertical o3 column density
+    real(r8) ::  parg(pver)                ! vertical pressure array (hPa)
+
+    real(r8) ::  cld_line(pver)            ! vertical cloud array
+    real(r8) ::  lwc_line(pver)            ! vertical lwc array
+    real(r8) ::  eff_alb(pver)             ! effective albedo from cloud modifications
+    real(r8) ::  cld_mult(pver)            ! clould multiplier
+    real(r8), allocatable ::  lng_prates(:,:) ! photorates matrix (1/s)
+    real(r8), allocatable ::  sht_prates(:,:) ! photorates matrix (1/s)
+    real(r8), allocatable ::  euv_prates(:,:) ! photorates matrix (1/s)
+
+
+    real(r8), allocatable :: zarg(:)
+    real(r8), allocatable :: tline(:)               ! vertical temperature array
+    real(r8), allocatable :: o_den(:)               ! o density (molecules/cm^3)
+    real(r8), allocatable :: o2_den(:)              ! o2 density (molecules/cm^3)
+    real(r8), allocatable :: o3_den(:)              ! o3 density (molecules/cm^3)
+    real(r8), allocatable :: no_den(:)              ! no density (molecules/cm^3)
+    real(r8), allocatable :: n2_den(:)              ! n2 density (molecules/cm^3)
+    real(r8), allocatable :: jno_sht(:)             ! no short photorate
+    real(r8), allocatable :: jo2_sht(:,:)           ! o2 short photorate
+
+    real(r8), pointer     :: ionRates(:,:,:)        ! Pointer to ionization rates for O+,O2+,N+,N2+,NO+ in pbuf (s-1 from modules mo_jeuv and mo_jshort)
+
+    integer :: n_jshrt_levs, p1, p2
+    real(r8) :: ideltaZkm
+
+    real(r8) :: qbktot(ncol,pver)
+    real(r8) :: qbko1(ncol,pver)
+    real(r8) :: qbko2(ncol,pver)
+    real(r8) :: qbkn2(ncol,pver)
+    real(r8) :: qbkn1(ncol,pver)
+    real(r8) :: qbkno(ncol,pver)
+
+    qbktot(:,:) = nan
+    qbko1(:,:) = nan
+    qbko2(:,:) = nan
+    qbkn2(:,:) = nan
+    qbkn1(:,:) = nan
+    qbkno(:,:) = nan
+
+    if( phtcnt < 1 ) then
+       return
+    end if
+
+    if ((.not.do_jshort) .or. (ptop_ref < 10._r8)) then
+       n_jshrt_levs = pver
+       p1 = 1
+       p2 = pver
+    else
+       n_jshrt_levs = pver+1
+       p1 = 2
+       p2 = pver+1
+    endif
+
+    allocate( zarg(n_jshrt_levs) )
+    allocate( tline(n_jshrt_levs) )
+    if (do_jshort) then
+       allocate( o_den(n_jshrt_levs) )
+       allocate( o2_den(n_jshrt_levs) )
+       allocate( o3_den(n_jshrt_levs) )
+       allocate( no_den(n_jshrt_levs) )
+       allocate( n2_den(n_jshrt_levs) )
+       allocate( jno_sht(n_jshrt_levs) )
+       allocate( jo2_sht(n_jshrt_levs,2) )
+    endif
+
+!-----------------------------------------------------------------
+!	... allocate short, long temp arrays
+!-----------------------------------------------------------------
+    if ( do_jeuv ) then
+       if (neuv>0) then
+          allocate( euv_prates(pver,neuv),stat=astat )
+          if( astat /= 0 ) then
+             write(iulog,*) 'photo: Failed to allocate euv_prates; error = ',astat
+             call endrun
+          end if
+       endif
+    endif
+
+    if (nsht>0) then
+       allocate( sht_prates(n_jshrt_levs,nsht),stat=astat )
+       if( astat /= 0 ) then
+          write(iulog,*) 'photo: Failed to allocate sht_prates; error = ',astat
+          call endrun
+       end if
+    endif
+
+    if (nlng>0) then
+       allocate( lng_prates(nlng,pver),stat=astat )
+       if( astat /= 0 ) then
+          write(iulog,*) 'photo: Failed to allocate lng_prates; error = ',astat
+          call endrun
+       end if
+    endif
+
+!-----------------------------------------------------------------
+!	... zero all photorates
+!-----------------------------------------------------------------
+    do m = 1,max(1,phtcnt)
+       do k = 1,pver
+          photos(:,k,m) = 0._r8
+       end do
+    end do
+
+!------------------------------------------------------------------------------------------------------------
+!  Point to production rates array in physics buffer where rates will be stored for ionosphere module
+!  access.  Also, initialize rates to zero before column loop since only daylight values are filled
+!------------------------------------------------------------------------------------------------------------
+    if (ion_rates_idx>0) then
+      call pbuf_get_field(pbuf, ion_rates_idx, ionRates)
+      ionRates(:,:,:) = 0._r8
+    endif
+
+    col_loop : do i = 1,ncol
+       if (do_jshort) then
+
+          if ( o_is_inv ) then
+             o_den(p1:p2) = invariants(i,:pver,o_ndx)
+          else
+             o_den(p1:p2) = vmr(i,:pver,o_ndx) * invariants(i,:pver,indexm)
+          endif
+          if ( o2_is_inv ) then
+             o2_den(p1:p2) = invariants(i,:pver,o2_ndx)
+          else
+             o2_den(p1:p2) = vmr(i,:pver,o2_ndx) * invariants(i,:pver,indexm)
+          endif
+          if ( o3_is_inv ) then
+             o3_den(p1:p2) = invariants(i,:pver,o3_inv_ndx)
+          else
+             o3_den(p1:p2) = vmr(i,:,o3_ndx) * invariants(i,:pver,indexm)
+          endif
+          if ( n2_is_inv ) then
+             n2_den(p1:p2) = invariants(i,:,n2_ndx)
+          else
+             n2_den(p1:p2) = vmr(i,:pver,n2_ndx) * invariants(i,:pver,indexm)
+          endif
+          if ( no_is_inv ) then
+             no_den(p1:p2) = invariants(i,:pver,no_ndx)
+          else
+             no_den(p1:p2) = vmr(i,:pver,no_ndx) * invariants(i,:pver,indexm)
+          endif
+
+       endif
+       sza = zen_angle(i)*r2d
+       daylight : if( sza >= 0._r8 .and. sza < max_zen_angle ) then
+          parg(:)     = Pa2mb*pmid(i,:)
+          colo3(:)    = col_dens(i,:,1)
+          fac1(:)     = pdel(i,:)
+          lwc_line(:) = lwc(i,:)
+          cld_line(:) = clouds(i,:)
+
+
+          tline(p1:p2) = temper(i,:pver)
+
+          zarg(p1:p2) = zmid(i,:pver)
+
+         if ( ptop_ref > 10._r8 ) then
+            if (jppi_ndx > 0 )  photos(i,:,jppi_ndx) = photos(i,:,jppi_ndx) +  esfact * 0.42_r8
+            if (jepn1_ndx > 0 ) photos(i,:,jepn1_ndx) = photos(i,:,jepn1_ndx) + esfact * 1.4_r8
+            if (jepn2_ndx > 0 ) photos(i,:,jepn2_ndx) = photos(i,:,jepn2_ndx) + esfact * 3.8e-1_r8
+            if (jepn3_ndx > 0 ) photos(i,:,jepn3_ndx) = photos(i,:,jepn3_ndx) + esfact * 4.7e-2_r8
+            if (jepn4_ndx > 0 ) photos(i,:,jepn4_ndx) = photos(i,:,jepn4_ndx) + esfact * 1.1_r8
+            if (jepn6_ndx > 0 ) photos(i,:,jepn6_ndx) = photos(i,:,jepn6_ndx) + esfact * 8.0e-4_r8
+            if (jepn7_ndx > 0 ) photos(i,:,jepn7_ndx) = photos(i,:,jepn7_ndx) + esfact * 5.2e-2_r8
+            if (jpni1_ndx > 0 ) photos(i,:,jpni1_ndx) = photos(i,:,jpni1_ndx) + esfact * 0.47_r8
+            if (jpni2_ndx > 0 ) photos(i,:,jpni2_ndx) = photos(i,:,jpni2_ndx) + esfact * 0.24_r8
+            if (jpni3_ndx > 0 ) photos(i,:,jpni3_ndx) = photos(i,:,jpni3_ndx) + esfact * 0.15_r8
+            if (jpni4_ndx > 0 ) photos(i,:,jpni4_ndx) = photos(i,:,jpni4_ndx) + esfact * 6.2e-3_r8
+            ! added to v02
+            if (jpni5_ndx > 0 ) photos(i,:,jpni5_ndx) = photos(i,:,jpni5_ndx) + esfact * 1.0_r8
+        endif
+          if (do_jshort) then
+             if ( ptop_ref > 10._r8 ) then
+                !-----------------------------------------------------------------
+                ! Only for lower lid versions of CAM (i.e., not for WACCM)
+                ! Column O3 and O2 above the top of the model
+                ! DEK 20110224
+                !-----------------------------------------------------------------
+                ideltaZkm = 1._r8/(zint(i,1) - zint(i,2))
+
+                !-----------------------------------------------------------------
+                !... set density (units: molecules cm-3)
+                !... used for jshort
+                !....... Assuming a scale height of 7km for ozone
+                !....... Assuming a scale height of 7km for O2
+                !-----------------------------------------------------------------
+                o3_den(1)        = o3_den(2)*7.0_r8 * ideltaZkm
+
+                o2_den(1)        = o2_den(2)*7.0_r8 * ideltaZkm
+
+                no_den(1)        = no_den(2)*0.9_r8
+
+                n2_den(1)        = n2_den(2)*0.9_r8
+
+                tline(1)         = tline(2) + 5.0_r8
+
+                zarg(1)          = zarg(2) + (zint(i,1) - zint(i,2))
+
+             endif
+
+             !-----------------------------------------------------------------
+             !	... short wave length component
+             !-----------------------------------------------------------------
+             call jshort( n_jshrt_levs, sza, n2_den, o2_den, o3_den, &
+                  no_den, tline, zarg, jo2_sht, jno_sht, sht_prates )
+
+             do m = 1,phtcnt
+                if( sht_indexer(m) > 0 ) then
+                   alias_factor = pht_alias_mult(m,1)
+                   if( alias_factor == 1._r8 ) then
+                      photos(i,pver:1:-1,m) = sht_prates(1:pver,sht_indexer(m))
+                   else
+                      photos(i,pver:1:-1,m) = alias_factor * sht_prates(1:pver,sht_indexer(m))
+                   end if
+                end if
+             end do
+
+             if( jno_ndx > 0 )   photos(i,pver:1:-1,jno_ndx)   = jno_sht(1:pver)
+             if( jo2_a_ndx > 0 ) photos(i,pver:1:-1,jo2_a_ndx) = jo2_sht(1:pver,2)
+             if( jo2_b_ndx > 0 ) photos(i,pver:1:-1,jo2_b_ndx) = jo2_sht(1:pver,1)
+          endif
+
+          if ( do_jeuv ) then
+             !-----------------------------------------------------------------
+             !	... euv photorates do not include cloud effects ??
+             !-----------------------------------------------------------------
+             call jeuv( pver, sza, o_den, o2_den, n2_den,  zarg, euv_prates )
+             do m = 1,neuv
+                if( euv_indexer(m) > 0 ) then
+                   photos(i,:,euv_indexer(m)) = esfact * euv_prates(:,m)
+                endif
+             enddo
+          endif
+
+          !-----------------------------------------------------------------
+          !     ... compute eff_alb and cld_mult -- needs to be before jlong
+          !-----------------------------------------------------------------
+          call cloud_mod( zen_angle(i), cld_line, lwc_line, fac1, srf_alb(i), &
+                          eff_alb, cld_mult )
+          cld_mult(:) = esfact * cld_mult(:)
+
+          !-----------------------------------------------------------------
+          !	... long wave length component
+          !-----------------------------------------------------------------
+          call jlong( pver, sza, eff_alb, parg, tline, colo3, lng_prates )
+          do m = 1,phtcnt
+             if( lng_indexer(m) > 0 ) then
+                alias_factor = pht_alias_mult(m,2)
+                if( alias_factor == 1._r8 ) then
+                   photos(i,:,m) = (photos(i,:,m) + lng_prates(lng_indexer(m),:))*cld_mult(:)
+                else
+                   photos(i,:,m) = (photos(i,:,m) + alias_factor * lng_prates(lng_indexer(m),:))*cld_mult(:)
+                end if
+             end if
+          end do
+
+          !-----------------------------------------------------------------
+          !	... calculate j(no) from formula
+          !-----------------------------------------------------------------
+          if( (jno_ndx > 0) .and. (.not.do_jshort)) then
+             if( has_o2_col .and. has_o3_col ) then
+                fac1(:) = 1.e-8_r8 * (abs(col_dens(i,:,2)/cos(zen_angle(i))))**.38_r8
+                fac2(:) = 5.e-19_r8 * abs(col_dens(i,:,1)/cos(zen_angle(i)))
+                photos(i,:,jno_ndx) = photos(i,:,jno_ndx) + 4.5e-6_r8 * exp( -(fac1(:) + fac2(:)) )
+             end if
+          end if
+
+          !-----------------------------------------------------------------
+          ! 	... add near IR correction to ho2no2
+          !-----------------------------------------------------------------
+          if( jho2no2_ndx > 0 ) then
+             photos(i,:,jho2no2_ndx) = photos(i,:,jho2no2_ndx) + 1.e-5_r8*cld_mult(:)
+          endif
+
+          !  Save photo-ionization rates to physics buffer accessed in ionosphere module for WACCMX
+          if (ion_rates_idx>0) then
+
+                ionRates(i,1:pver,1:nIonRates) = esfact * euv_prates(1:pver,1:nIonRates)
+
+          endif
+
+       end if daylight
+
+       if (do_jeuv) then
+          !-----------------------------------------------------------------
+          ! include background ionization ...
+          ! outside daylight block so this is applied in all columns
+          !-----------------------------------------------------------------
+          call photo_bkgrnd_calc( f107, o_den, o2_den, n2_den, no_den, zint(i,:),&
+                    photos(i,:,:), qbko1_out=qbko1(i,:), qbko2_out=qbko2(i,:), &
+                    qbkn2_out=qbkn2(i,:), qbkn1_out=qbkn1(i,:), qbkno_out=qbkno(i,:) )
+       endif
+
+    end do col_loop
+
+    if ( do_jeuv ) then
+       qbktot(:ncol,:) = qbko1(:ncol,:)+qbko2(:ncol,:)+qbkn2(:ncol,:)+qbkn1(:ncol,:)+qbkno(:ncol,:)
+       call outfld( 'Qbkgndtot', qbktot(:ncol,:),ncol, lchnk )
+       call outfld( 'Qbkgnd_o1', qbko1(:ncol,:), ncol, lchnk )
+       call outfld( 'Qbkgnd_o2', qbko2(:ncol,:), ncol, lchnk )
+       call outfld( 'Qbkgnd_n2', qbkn2(:ncol,:), ncol, lchnk )
+       call outfld( 'Qbkgnd_n1', qbkn1(:ncol,:), ncol, lchnk )
+       call outfld( 'Qbkgnd_no', qbkno(:ncol,:), ncol, lchnk )
+    endif
+
+    if ( allocated(lng_prates) ) deallocate( lng_prates )
+    if ( allocated(sht_prates) ) deallocate( sht_prates )
+    if ( allocated(euv_prates) ) deallocate( euv_prates )
+
+    if ( allocated(zarg) )    deallocate( zarg )
+    if ( allocated(tline) )   deallocate( tline )
+    if ( allocated(o_den) )   deallocate( o_den )
+    if ( allocated(o2_den) )  deallocate( o2_den )
+    if ( allocated(o3_den) )  deallocate( o3_den )
+    if ( allocated(no_den) )  deallocate( no_den )
+    if ( allocated(n2_den) )  deallocate( n2_den )
+    if ( allocated(jno_sht) ) deallocate( jno_sht )
+    if ( allocated(jo2_sht) ) deallocate( jo2_sht )
+
+    call set_xnox_photo( photos, ncol  )
+
+  end subroutine table_photo
+
+  subroutine xactive_photo( photos, vmr, temper, cwat, cldfr, &
+                            pmid, zmid, col_dens, zen_angle, srf_alb, &
+                            tdens, ps, ts, esfact, relhum, dust_vmr, &
+                            dt_diag, fracday, &
+                            ncol, lchnk )
+    !-----------------------------------------------------------------
+    !   	... fast online photo rates
+    !-----------------------------------------------------------------
+
+    use ppgrid,       only : pver, pverp
+    use chem_mods,    only : ncol_abs => nabscol, pcnstm1 => gas_pcnst, phtcnt
+    use chem_mods,    only : pht_alias_mult
+    use mo_params,    only : kw
+    use mo_wavelen,   only : nw
+    use mo_photoin,   only : photoin
+    use mo_tuv_inti,  only : nlng
+    use time_manager, only : get_curr_date
+    ! OSLO_AERO begin
+    use oslo_aero_dust, only : dust_nbin
+    ! OSLO_AERO end
+    use phys_grid,    only : get_rlat_all_p, get_rlon_all_p
+
+    implicit none
+
+    !----------------------------------------------------------------
+    !   	... dummy arguments
+    !-----------------------------------------------------------------
+    integer,  intent(in)    :: ncol, lchnk
+    real(r8), intent(in)    :: esfact                       ! earth sun distance factor
+    real(r8), intent(in)    :: ps(pcols)                    ! surface pressure (Pa)
+    real(r8), intent(in)    :: ts(ncol)                     ! surface temperature (K)
+    real(r8), intent(in)    :: col_dens(ncol,pver,ncol_abs) ! column densities (molecules/cm^2)
+    real(r8), intent(in)    :: zen_angle(ncol)              ! solar zenith angle (radians)
+    real(r8), intent(in)    :: srf_alb(pcols)               ! surface albedo
+    real(r8), intent(in)    :: tdens(ncol,pver)             ! total atms density (molecules/cm^3)
+    real(r8), intent(in)    :: vmr(ncol,pver,pcnstm1)       ! species concentration (mol/mol)
+    real(r8), intent(in)    :: pmid(pcols,pver)             ! midpoint pressure (Pa)
+    real(r8), intent(in)    :: zmid(ncol,pver)              ! midpoint height (m)
+    real(r8), intent(in)    :: temper(pcols,pver)           ! midpoint temperature (K)
+    real(r8), intent(in)    :: relhum(ncol,pver)            ! relative humidity
+    real(r8), intent(in)    :: cwat(ncol,pver)              ! cloud water (kg/kg)
+    real(r8), intent(in)    :: cldfr(ncol,pver)             ! cloud fraction
+    real(r8), intent(in)    :: dust_vmr(ncol,pver,dust_nbin)! dust concentration (mol/mol)
+    real(r8), intent(inout) :: photos(ncol,pver,phtcnt)     ! photodissociation rates (1/s)
+    real(r8), intent(out)   :: dt_diag(pcols,8)              ! od diagnostics
+    real(r8), intent(out)   :: fracday(pcols)                ! fraction of day
+    !-----------------------------------------------------------------
+    !    	... local variables
+    !-----------------------------------------------------------------
+    integer, parameter  ::  k_diag = 3
+    real(r8), parameter :: secant_limit = 50._r8
+
+    integer  ::  astat
+    integer  ::  i                      ! index
+    integer  ::  k                      ! index
+    integer  ::  m                      ! index
+    integer  ::  ndx                    ! index
+    integer  ::  spc_ndx                ! index
+    integer  ::  yr, mon, day, tod      ! time of day (seconds past 0Z)
+    integer  ::  ncdate                 ! current date(yyyymmdd)
+
+    real(r8)    ::   sza
+    real(r8)    ::   secant
+    real(r8)    ::   alias_factor
+    real(r8)    ::   alat
+    real(r8)    ::   along
+    real(r8)    ::   ut
+    real(r8)    ::   fac1(pver)                    ! work space for j(no) calc
+    real(r8)    ::   fac2(pver)                    ! work space for j(no) calc
+    real(r8)    ::   tlay(pver)                    ! vertical temperature array at layer midpoint
+    real(r8)    ::   tline(pverp)                  ! vertical temperature array
+    real(r8)    ::   xlwc(pverp)                   ! cloud water (kg/kg)
+    real(r8)    ::   xfrc(pverp)                   ! cloud fraction      xuexi
+    real(r8)    ::   airdens(pverp)                ! atmospheric density
+    real(r8)    ::   o3line(pverp)                 ! vertical o3 vmr
+    real(r8)    ::   aerocs1(pverp)
+    real(r8)    ::   aerocs2(pverp)
+    real(r8)    ::   aercbs1(pverp)
+    real(r8)    ::   aercbs2(pverp)
+    real(r8)    ::   aersoa(pverp)
+    real(r8)    ::   aerant(pverp)
+    real(r8)    ::   aerso4(pverp)
+    real(r8)    ::   aerds(4,pverp)
+    real(r8)    ::   rh(pverp)
+    real(r8)    ::   zarg(pverp)                   ! vertical height array
+    real(r8)    ::   aersal(pverp,4)
+    real(r8)    ::   albedo(kw)                    ! wavelenght dependent albedo
+    real(r8)    ::   dt_xdiag(8)                   ! wrk array
+    real(r8), allocatable :: prates(:,:)           ! photorates matrix
+
+    logical  ::  zagtz(ncol)                       ! zenith angle > 0 flag array
+    real(r8), dimension(ncol)  :: rlats, rlons     ! chunk latitudes and longitudes (radians)
+
+    call get_rlat_all_p( lchnk, ncol, rlats )
+    call get_rlon_all_p( lchnk, ncol, rlons )
+
+    !-----------------------------------------------------------------
+    !	... any photorates ?
+    !-----------------------------------------------------------------
+    if( phtcnt < 1 ) then
+       return
+    end if
+
+    !-----------------------------------------------------------------
+    !	... zero all photorates
+    !-----------------------------------------------------------------
+    do m = 1,phtcnt
+       do k = 1,pver
+          photos(:,k,m) = 0._r8
+       end do
+    end do
+
+!-----------------------------------------------------------------
+!	... allocate "working" rate array
+!-----------------------------------------------------------------
+      allocate( prates(pverp,nlng), stat=astat )
+      if( astat /= 0 ) then
+         write(iulog,*) 'xactive_photo: failed to allocate prates; error = ',astat
+         call endrun
+      end if
+
+    zagtz(:) = zen_angle(:) < .99_r8*pi/2._r8 .and. zen_angle(:) > 0._r8 !! daylight
+    fracday(:) = 0._r8
+    dt_diag(:,:) = 0._r8
+
+    call get_curr_date(yr, mon, day, tod, 0)
+    ncdate = yr*10000 + mon*100 + day
+    ut   = real(tod)/3600._r8
+#ifdef DEBUG
+    if (masterproc) then
+       write(iulog,*) 'photo: nj = ',nlng
+       write(iulog,*) 'photo: esfact = ',esfact
+    endif
+#endif
+    col_loop : do i = 1,ncol
+daylight : &
+       if( zagtz(i) ) then
+          sza    = zen_angle(i)*r2d
+          secant = 1._r8 / cos( zen_angle(i) )
+secant_in_bounds : &
+          if( secant <= secant_limit ) then
+             fracday(i) = 1._r8
+             zarg(pverp:2:-1)     = zmid(i,:)
+             zarg(1)              = 0._r8
+             airdens(pverp:2:-1)  = tdens(i,:)
+             airdens(1)           = 10._r8 * ps(i) / (boltz*ts(i))
+             if( o3rad_ndx > 0 ) then
+                spc_ndx = o3rad_ndx
+             else
+                spc_ndx = ox_ndx
+             end if
+             if( spc_ndx < 1 ) then
+                spc_ndx = o3_ndx
+             end if
+             if( spc_ndx > 0 ) then
+                o3line(pverp:2:-1) = vmr(i,:,spc_ndx)
+             else
+                o3line(pverp:2:-1) = 0._r8
+             end if
+             o3line(1)            = o3line(2)
+             tline(pverp:2:-1)    = temper(i,:)
+             tline(1)             = tline(2)
+             rh(pverp:2:-1)       = relhum(i,:)
+             rh(1)                = rh(2)
+             xlwc(pverp:2:-1)     = cwat(i,:) * pmid(i,:)/(temper(i,:)*287._r8) * kg2g  !! TIE
+             xlwc(1)              = xlwc(2)
+             xfrc(pverp:2:-1)     = cldfr(i,:)                      ! cloud fraction
+             xfrc(1)              = xfrc(2)
+             tlay(1:pver)         = .5_r8*(tline(1:pver) + tline(2:pverp))
+             albedo(1:nw)       = srf_alb(i)
+
+             alat = rlats(i)
+             along= rlons(i)
+
+             if( oc1_ndx > 0 ) then
+                aerocs1(pverp:2:-1) = vmr(i,:,oc1_ndx)
+             else
+                aerocs1(pverp:2:-1) = 0._r8
+             end if
+             aerocs1(1)            = aerocs1(2)
+             if( oc2_ndx > 0 ) then
+                aerocs2(pverp:2:-1) = vmr(i,:,oc2_ndx)
+             else
+                aerocs2(pverp:2:-1) = 0._r8
+             end if
+             aerocs2(1)          = aerocs2(2)
+             if( cb1_ndx > 0 ) then
+                aercbs1(pverp:2:-1) = vmr(i,:,cb1_ndx)
+             else
+                aercbs1(pverp:2:-1) = 0._r8
+             end if
+             aercbs1(1)          = aercbs1(2)
+             if( cb2_ndx > 0 ) then
+                aercbs2(pverp:2:-1) = vmr(i,:,cb2_ndx)
+             else
+                aercbs2(pverp:2:-1) = 0._r8
+             end if
+             aercbs2(1)          = aercbs2(2)
+             if( soa_ndx > 0 ) then
+                aersoa(pverp:2:-1) = vmr(i,:,soa_ndx)
+             else
+                aersoa(pverp:2:-1) = 0._r8
+             end if
+             aersoa(1)          = aersoa(2)
+             if( ant_ndx > 0 ) then
+                aerant(pverp:2:-1) = vmr(i,:,ant_ndx)
+             else
+                aerant(pverp:2:-1) = 0._r8
+             end if
+             aerant(1)            = aerant(2)
+             if( so4_ndx > 0 ) then
+                aerso4(pverp:2:-1) = vmr(i,:,so4_ndx)
+             else
+                aerso4(pverp:2:-1) = 0._r8
+             end if
+             aerso4(1)            = aerso4(2)
+             if ( dust_nbin == 4 ) then
+                do ndx = 1,4
+                   aerds(ndx,pverp:2:-1) = dust_vmr(i,:,ndx)
+                end do
+             else
+                do ndx = 1,4
+                   aerds(ndx,pverp:2:-1) = 0._r8
+                end do
+             endif
+             aerds(1,1)          = aerds(1,2)
+             aerds(2,1)          = aerds(2,2)
+             aerds(3,1)          = aerds(3,2)
+             aerds(4,1)          = aerds(4,2)
+             if( sa1_ndx > 0 ) then
+                aersal(pverp:2:-1,1) = vmr(i,:,sa1_ndx)
+             else
+                aersal(pverp:2:-1,1) = 0._r8
+             end if
+             if( sa2_ndx > 0 ) then
+                aersal(pverp:2:-1,2) = vmr(i,:,sa2_ndx)
+             else
+                aersal(pverp:2:-1,2) = 0._r8
+             end if
+             if( sa3_ndx > 0 ) then
+                aersal(pverp:2:-1,3) = vmr(i,:,sa3_ndx)
+             else
+                aersal(pverp:2:-1,3) = 0._r8
+             end if
+             if( sa4_ndx > 0 ) then
+                aersal(pverp:2:-1,4) = vmr(i,:,sa4_ndx)
+             else
+                aersal(pverp:2:-1,4) = 0._r8
+             end if
+             aersal(1,:) = aersal(2,:)
+             call photoin( ncdate, alat, along, &
+                           ut, esfact, col_dens(i,1,1), col_dens(i,1,2), albedo, &
+                           zarg, tline, tlay, xlwc, xfrc, &
+                           airdens, aerocs1, aerocs2, aercbs1, aercbs2, &
+                           aersoa, aerant, aerso4, aersal, aerds, o3line, rh, &
+                           prates, sza, nw, dt_xdiag )
+             dt_diag(i,:) = dt_xdiag(:)
+
+             do m = 1,phtcnt
+                if( lng_indexer(m) > 0 ) then
+                   alias_factor = pht_alias_mult(m,2)
+                   if( alias_factor == 1._r8 ) then
+                      photos(i,:,m) = prates(1:pver,lng_indexer(m))
+                   else
+                      photos(i,:,m) = alias_factor * prates(1:pver,lng_indexer(m))
+                   end if
+                end if
+
+#ifdef DEBUG
+                if( do_diag ) then
+                   write(iulog,'(''xactive_photo: prates('',i2,'',.)'')') m
+                   write(iulog,'(1p,5e21.13)') photos(i,:pver,m)
+                   write(iulog,*) ' '
+                end if
+#endif
+
+             end do
+!-----------------------------------------------------------------
+!	... set j(onitr)
+!-----------------------------------------------------------------
+               if( jonitr_ndx > 0 ) then
+                  if( jch3cho_a_ndx > 0 ) then
+                     photos(i,1:pver,jonitr_ndx) = photos(i,1:pver,jch3cho_a_ndx)
+                  end if
+                  if( jch3cho_b_ndx > 0 ) then
+                     photos(i,1:pver,jonitr_ndx) = photos(i,1:pver,jonitr_ndx) + photos(i,1:pver,jch3cho_b_ndx)
+                  end if
+                  if( jch3cho_c_ndx > 0 ) then
+                     photos(i,1:pver,jonitr_ndx) = photos(i,1:pver,jonitr_ndx) + photos(i,1:pver,jch3cho_c_ndx)
+                  end if
+               end if
+!-----------------------------------------------------------------
+!	... calculate j(no) from formula
+!-----------------------------------------------------------------
+               if( jno_ndx > 0 ) then
+                  if( has_o2_col .and. has_o3_col ) then
+                     fac1(:) = 1.e-8_r8 * (col_dens(i,:,2)/cos(zen_angle(i)))**.38_r8
+                     fac2(:) = 5.e-19_r8 * col_dens(i,:,1) / cos(zen_angle(i))
+                     photos(i,:,jno_ndx) = 4.5e-6_r8 * exp( -(fac1(:) + fac2(:)) )
+                  end if
+               end if
+!-----------------------------------------------------------------
+! 	... add near IR correction to j(ho2no2)
+!-----------------------------------------------------------------
+               if( jho2no2_ndx > 0 ) then
+                  photos(i,:,jho2no2_ndx) = photos(i,:,jho2no2_ndx) + 1.e-5_r8
+               endif
+          end if secant_in_bounds
+       end if daylight
+    end do col_loop
+
+    call set_xnox_photo( photos, ncol  )
+
+    deallocate( prates )
+
+  end subroutine xactive_photo
+
+  subroutine cloud_mod( zen_angle, clouds, lwc, delp, srf_alb, &
+                        eff_alb, cld_mult )
+    !-----------------------------------------------------------------------
+    ! 	... cloud alteration factors for photorates and albedo
+    !-----------------------------------------------------------------------
+
+    implicit none
+
+    !-----------------------------------------------------------------------
+    ! 	... dummy arguments
+    !-----------------------------------------------------------------------
+    real(r8), intent(in)    ::  zen_angle         ! zenith angle
+    real(r8), intent(in)    ::  srf_alb           ! surface albedo
+    real(r8), intent(in)    ::  clouds(pver)       ! cloud fraction
+    real(r8), intent(in)    ::  lwc(pver)          ! liquid water content (mass mr)
+    real(r8), intent(in)    ::  delp(pver)         ! del press about midpoint in pascals
+    real(r8), intent(out)   ::  eff_alb(pver)      ! effective albedo
+    real(r8), intent(out)   ::  cld_mult(pver)     ! photolysis mult factor
+
+    !-----------------------------------------------------------------------
+    ! 	... local variables
+    !-----------------------------------------------------------------------
+    integer :: k
+    real(r8)    :: coschi
+    real(r8)    :: del_lwp(pver)
+    real(r8)    :: del_tau(pver)
+    real(r8)    :: above_tau(pver)
+    real(r8)    :: below_tau(pver)
+    real(r8)    :: above_cld(pver)
+    real(r8)    :: below_cld(pver)
+    real(r8)    :: above_tra(pver)
+    real(r8)    :: below_tra(pver)
+    real(r8)    :: fac1(pver)
+    real(r8)    :: fac2(pver)
+
+    real(r8), parameter :: rgrav = 1._r8/9.80616_r8
+
+    !---------------------------------------------------------
+    !	... modify lwc for cloud fraction and form
+    !	    liquid water path for each layer
+    !---------------------------------------------------------
+    where( clouds(:) /= 0._r8 )
+       del_lwp(:) = rgrav * lwc(:) * delp(:) * 1.e3_r8 / clouds(:)
+    elsewhere
+       del_lwp(:) = 0._r8
+    endwhere
+    !---------------------------------------------------------
+    !    	... form tau for each model layer
+    !---------------------------------------------------------
+    where( clouds(:) /= 0._r8 )
+       del_tau(:) = del_lwp(:) *.155_r8 * clouds(:)**1.5_r8
+    elsewhere
+       del_tau(:) = 0._r8
+    end where
+    !---------------------------------------------------------
+    !    	... form integrated tau from top down
+    !---------------------------------------------------------
+    above_tau(1) = 0._r8
+    do k = 1,pverm
+       above_tau(k+1) = del_tau(k) + above_tau(k)
+    end do
+    !---------------------------------------------------------
+    !    	... form integrated tau from bottom up
+    !---------------------------------------------------------
+    below_tau(pver) = 0._r8
+    do k = pverm,1,-1
+       below_tau(k) = del_tau(k+1) + below_tau(k+1)
+    end do
+    !---------------------------------------------------------
+    !	... form vertically averaged cloud cover above and below
+    !---------------------------------------------------------
+    above_cld(1) = 0._r8
+    do k = 1,pverm
+       above_cld(k+1) = clouds(k) * del_tau(k) + above_cld(k)
+    end do
+    do k = 2,pver
+       if( above_tau(k) /= 0._r8 ) then
+          above_cld(k) = above_cld(k) / above_tau(k)
+       else
+          above_cld(k) = above_cld(k-1)
+       end if
+    end do
+    below_cld(pver) = 0._r8
+    do k = pverm,1,-1
+       below_cld(k) = clouds(k+1) * del_tau(k+1) + below_cld(k+1)
+    end do
+    do k = pverm,1,-1
+       if( below_tau(k) /= 0._r8 ) then
+          below_cld(k) = below_cld(k) / below_tau(k)
+       else
+          below_cld(k) = below_cld(k+1)
+       end if
+    end do
+    !---------------------------------------------------------
+    !	... modify above_tau and below_tau via jfm
+    !---------------------------------------------------------
+    where( above_cld(2:pver) /= 0._r8 )
+       above_tau(2:pver) = above_tau(2:pver) / above_cld(2:pver)
+    end where
+    where( below_cld(:pverm) /= 0._r8 )
+       below_tau(:pverm) = below_tau(:pverm) / below_cld(:pverm)
+    end where
+    where( above_tau(2:pver) < 5._r8 )
+       above_cld(2:pver) = 0._r8
+    end where
+    where( below_tau(:pverm) < 5._r8 )
+       below_cld(:pverm) = 0._r8
+    end where
+    !---------------------------------------------------------
+    !	... form transmission factors
+    !---------------------------------------------------------
+    above_tra(:) = 11.905_r8 / (9.524_r8 + above_tau(:))
+    below_tra(:) = 11.905_r8 / (9.524_r8 + below_tau(:))
+    !---------------------------------------------------------
+    !	... form effective albedo
+    !---------------------------------------------------------
+    where( below_cld(:) /= 0._r8 )
+       eff_alb(:) = srf_alb + below_cld(:) * (1._r8 - below_tra(:)) &
+                  * (1._r8 - srf_alb)
+    elsewhere
+       eff_alb(:) = srf_alb
+    end where
+    coschi = max( cos( zen_angle ),.5_r8 )
+    where( del_lwp(:)*.155_r8 < 5._r8 )
+       fac1(:) = 0._r8
+    elsewhere
+       fac1(:) = 1.4_r8 * coschi - 1._r8
+    end where
+    fac2(:)     = min( 0._r8,1.6_r8*coschi*above_tra(:) - 1._r8 )
+    cld_mult(:) = 1._r8 + fac1(:) * clouds(:) + fac2(:) * above_cld(:)
+    cld_mult(:) = max( .05_r8,cld_mult(:) )
+
+  end subroutine cloud_mod
+
+  subroutine set_ub_col( col_delta, vmr, invariants, ptop, pdel, ncol, lchnk )
+    !---------------------------------------------------------------
+    !        ... set the column densities at the upper boundary
+    !---------------------------------------------------------------
+
+    use chem_mods, only : nfs, ncol_abs=>nabscol, indexm
+    use chem_mods, only : nabscol, gas_pcnst, indexm
+    use chem_mods, only : gas_pcnst
+
+    implicit none
+
+    !---------------------------------------------------------------
+    !        ... dummy args
+    !---------------------------------------------------------------
+    real(r8), intent(in)    ::  ptop(pcols)                            ! top pressure (Pa)
+    integer,  intent(in)    ::  ncol                                   ! number of columns in current chunk
+    integer,  intent(in)    ::  lchnk                                  ! latitude indicies in chunk
+    real(r8), intent(in)    ::  vmr(ncol,pver,gas_pcnst)               ! xported species vmr
+    real(r8), intent(in)    ::  pdel(pcols,pver)                       ! pressure delta about midpoints (Pa)
+    real(r8), intent(in)    ::  invariants(ncol,pver,nfs)
+    real(r8), intent(out)   ::  col_delta(ncol,0:pver,max(1,nabscol))  ! /cm**2 o2,o3 col dens above model
+
+    !---------------------------------------------------------------
+    !        ... local variables
+    !---------------------------------------------------------------
+    !---------------------------------------------------------------
+    !        note: xfactor = 10.*r/(k*g) in cgs units.
+    !              the factor 10. is to convert pdel
+    !              from pascals to dyne/cm**2.
+    !---------------------------------------------------------------
+    real(r8), parameter :: xfactor = 2.8704e21_r8/(9.80616_r8*1.38044_r8)
+    integer :: k, kl, spc_ndx
+    real(r8)    :: tint_vals(2)
+    real(r8)    :: o2_exo_col(ncol)
+    real(r8)    :: o3_exo_col(ncol)
+    integer :: i
+
+    !---------------------------------------------------------------
+    !        ... assign column density at the upper boundary
+    !            the first column is o3 and the second is o2.
+    !            add 10 du o3 column above top of model.
+    !---------------------------------------------------------------
+    !---------------------------------------------------------------
+    !	... set exo absorber columns
+    !---------------------------------------------------------------
+    has_abs_cols : if( has_o2_col .and. has_o3_col ) then
+       if( has_fixed_press ) then
+          kl = ki - 1
+          if( has_o2_col ) then
+             do i = 1,ncol
+                if ( kl > 0 ) then
+                   tint_vals(1) = o2_exo_coldens(kl,i,lchnk,last) &
+                        + delp * (o2_exo_coldens(ki,i,lchnk,last) &
+                        - o2_exo_coldens(kl,i,lchnk,last))
+                   tint_vals(2) = o2_exo_coldens(kl,i,lchnk,next) &
+                        + delp * (o2_exo_coldens(ki,i,lchnk,next) &
+                        - o2_exo_coldens(kl,i,lchnk,next))
+                else
+                   tint_vals(1) = o2_exo_coldens( 1,i,lchnk,last)
+                   tint_vals(2) = o2_exo_coldens( 1,i,lchnk,next)
+                endif
+                o2_exo_col(i) = tint_vals(1) + dels * (tint_vals(2) - tint_vals(1))
+             end do
+          else
+             o2_exo_col(:) = 0._r8
+          end if
+          if( has_o3_col ) then
+             do i = 1,ncol
+                if ( kl > 0 ) then
+                   tint_vals(1) = o3_exo_coldens(kl,i,lchnk,last) &
+                        + delp * (o3_exo_coldens(ki,i,lchnk,last) &
+                        - o3_exo_coldens(kl,i,lchnk,last))
+                   tint_vals(2) = o3_exo_coldens(kl,i,lchnk,next) &
+                        + delp * (o3_exo_coldens(ki,i,lchnk,next) &
+                        - o3_exo_coldens(kl,i,lchnk,next))
+                else
+                   tint_vals(1) = o3_exo_coldens( 1,i,lchnk,last)
+                   tint_vals(2) = o3_exo_coldens( 1,i,lchnk,next)
+                endif
+                o3_exo_col(i) = tint_vals(1) + dels * (tint_vals(2) - tint_vals(1))
+             end do
+          else
+             o3_exo_col(:) = 0._r8
+          end if
+#ifdef DEBUG
+          write(iulog,*) '-----------------------------------'
+          write(iulog,*) 'o2_exo_col'
+          write(iulog,'(1p,5g15.7)') o2_exo_col(:)
+          write(iulog,*) 'o3_exo_col'
+          write(iulog,'(1p,5g15.7)') o3_exo_col(:)
+          write(iulog,*) '-----------------------------------'
+#endif
+       else
+          !---------------------------------------------------------------
+          !	... do pressure interpolation
+          !---------------------------------------------------------------
+          call p_interp( lchnk, ncol, ptop, o2_exo_col, o3_exo_col )
+       end if
+    else
+       o2_exo_col(:) = 0._r8
+       o3_exo_col(:) = 0._r8
+    end if has_abs_cols
+
+    if( o3rad_ndx > 0 ) then
+       spc_ndx = o3rad_ndx
+    else
+       spc_ndx = ox_ndx
+    end if
+    if( spc_ndx < 1 ) then
+       spc_ndx = o3_ndx
+    end if
+    if( spc_ndx > 0 ) then
+       col_delta(:,0,1) = o3_exo_col(:)
+       do k = 1,pver
+          col_delta(:ncol,k,1) = xfactor * pdel(:ncol,k) * vmr(:ncol,k,spc_ndx)
+       end do
+    else if( o3_inv_ndx > 0 ) then
+       col_delta(:,0,1) = o3_exo_col(:)
+       do k = 1,pver
+          col_delta(:ncol,k,1) = xfactor * pdel(:ncol,k) * invariants(:ncol,k,o3_inv_ndx)/invariants(:ncol,k,indexm)
+       end do
+    else
+       col_delta(:,:,1) = 0._r8
+    end if
+    if( ncol_abs > 1 ) then
+       if( o2_ndx > 1 ) then
+          col_delta(:,0,2) = o2_exo_col(:)
+          if( o2_is_inv ) then
+             do k = 1,pver
+                col_delta(:ncol,k,2) = xfactor * pdel(:ncol,k) * invariants(:ncol,k,o2_ndx)/invariants(:ncol,k,indexm)
+             end do
+          else
+             do k = 1,pver
+                col_delta(:ncol,k,2) = xfactor * pdel(:ncol,k) * vmr(:ncol,k,o2_ndx)
+             end do
+          endif
+       else
+          col_delta(:,:,2) = 0._r8
+       end if
+    end if
+
+  end subroutine set_ub_col
+
+  subroutine p_interp( lchnk, ncol, ptop, o2_exo_col, o3_exo_col )
+    !---------------------------------------------------------------
+    !     	... pressure interpolation for exo col density
+    !---------------------------------------------------------------
+
+    implicit none
+
+    !---------------------------------------------------------------
+    !     	... dummy arguments
+    !---------------------------------------------------------------
+    integer, intent(in)     :: ncol                      ! no. of columns
+    real(r8), intent(out)   :: o2_exo_col(ncol)          ! exo model o2 column density (molecules/cm^2)
+    real(r8), intent(out)   :: o3_exo_col(ncol)          ! exo model o3 column density (molecules/cm^2)
+    integer, intent(in)     :: lchnk                     ! latitude  indicies in chunk
+    real(r8)                :: ptop(pcols)               ! top pressure (Pa)
+
+    !---------------------------------------------------------------
+    !     	... local variables
+    !---------------------------------------------------------------
+    integer  :: i, ki, kl
+    real(r8) :: pinterp
+    real(r8) :: delp
+    real(r8) :: tint_vals(2)
+
+    do i = 1,ncol
+       pinterp = ptop(i)
+       if( pinterp < levs(1) ) then
+          ki   = 0
+          delp = 0._r8
+       else
+          do ki = 2,n_exo_levs
+             if( pinterp <= levs(ki) ) then
+                delp = log( pinterp/levs(ki-1) )/log( levs(ki)/levs(ki-1) )
+                exit
+             end if
+          end do
+       end if
+       kl = ki - 1
+       if( has_o2_col ) then
+          tint_vals(1) = o2_exo_coldens(kl,i,lchnk,last) &
+                         + delp * (o2_exo_coldens(ki,i,lchnk,last) &
+                                 - o2_exo_coldens(kl,i,lchnk,last))
+          tint_vals(2) = o2_exo_coldens(kl,i,lchnk,next) &
+                         + delp * (o2_exo_coldens(ki,i,lchnk,next) &
+                         - o2_exo_coldens(kl,i,lchnk,next))
+          o2_exo_col(i) = tint_vals(1) + dels * (tint_vals(2) - tint_vals(1))
+       else
+          o2_exo_col(i) = 0._r8
+       end if
+       if( has_o3_col ) then
+          tint_vals(1) = o3_exo_coldens(kl,i,lchnk,last) &
+                         + delp * (o3_exo_coldens(ki,i,lchnk,last) &
+                         - o3_exo_coldens(kl,i,lchnk,last))
+          tint_vals(2) = o3_exo_coldens(kl,i,lchnk,next) &
+                         + delp * (o3_exo_coldens(ki,i,lchnk,next) &
+                         - o3_exo_coldens(kl,i,lchnk,next))
+          o3_exo_col(i) = tint_vals(1) + dels * (tint_vals(2) - tint_vals(1))
+       else
+          o3_exo_col(i) = 0._r8
+       end if
+    end do
+
+  end subroutine p_interp
+
+  subroutine setcol( col_delta, col_dens, vmr, pdel,  ncol )
+    !---------------------------------------------------------------
+    !     	... set the column densities
+    !---------------------------------------------------------------
+
+    use chem_mods, only : ncol_abs=>nabscol, gas_pcnst
+
+    implicit none
+
+    !---------------------------------------------------------------
+    !     	... dummy arguments
+    !---------------------------------------------------------------
+    integer,  intent(in)    :: ncol                              ! no. of columns in current chunk
+    real(r8), intent(in)    :: vmr(ncol,pver,gas_pcnst)          ! xported species vmr
+    real(r8), intent(in)    :: pdel(pcols,pver)                  ! delta about midpoints
+    real(r8), intent(in)    :: col_delta(:,0:,:)                 ! layer column densities (molecules/cm^2)
+    real(r8), intent(out)   :: col_dens(:,:,:)                   ! column densities ( /cm**2 )
+
+    !---------------------------------------------------------------
+    !        the local variables
+    !---------------------------------------------------------------
+    integer  :: k, km1, m      ! long, alt indicies
+
+    !---------------------------------------------------------------
+    !        note: xfactor = 10.*r/(k*g) in cgs units.
+    !              the factor 10. is to convert pdel
+    !              from pascals to dyne/cm**2.
+    !---------------------------------------------------------------
+    real(r8), parameter :: xfactor = 2.8704e21_r8/(9.80616_r8*1.38044_r8)
+
+    !---------------------------------------------------------------
+    !   	... compute column densities down to the
+    !           current eta index in the calling routine.
+    !           the first column is o3 and the second is o2.
+    !---------------------------------------------------------------
+    do m = 1,ncol_abs
+       col_dens(:,1,m) = col_delta(:,0,m) + .5_r8 * col_delta(:,1,m)
+       do k = 2,pver
+          km1 = k - 1
+          col_dens(:,k,m) = col_dens(:,km1,m) + .5_r8 * (col_delta(:,km1,m) + col_delta(:,k,m))
+       end do
+    enddo
+
+  end subroutine setcol
+
+  subroutine photo_timestep_init( calday )
+    use euvac,          only : euvac_set_etf
+    use mo_jshort,      only : jshort_timestep_init
+    use mo_jlong,       only : jlong_timestep_init
+    use solar_euv_data, only : solar_euv_data_active
+
+    !-----------------------------------------------------------------------------
+    !	... setup the time interpolation
+    !-----------------------------------------------------------------------------
+
+    implicit none
+
+    !-----------------------------------------------------------------------------
+    !	... dummy arguments
+    !-----------------------------------------------------------------------------
+    real(r8), intent(in)    ::  calday                                   ! day of year at end of present time step
+
+    !-----------------------------------------------------------------------------
+    !	... local variables
+    !-----------------------------------------------------------------------------
+    integer :: m
+
+    if ( do_jeuv ) then
+       if (.not.solar_euv_data_active) then
+          call euvac_set_etf( f107, f107a )
+       end if
+    endif
+
+    if( has_o2_col .or. has_o3_col ) then
+       if( calday < days(1) ) then
+          next = 1
+          last = 12
+          dels = (365._r8 + calday - days(12)) / (365._r8 + days(1) - days(12))
+       else if( calday >= days(12) ) then
+          next = 1
+          last = 12
+          dels = (calday - days(12)) / (365._r8 + days(1) - days(12))
+       else
+          do m = 11,1,-1
+             if( calday >= days(m) ) then
+                exit
+             end if
+          end do
+          last = m
+          next = m + 1
+          dels = (calday - days(m)) / (days(m+1) - days(m))
+       end if
+#ifdef DEBUG
+       if (masterproc) then
+          write(iulog,*) '-----------------------------------'
+          write(iulog,*) 'photo_timestep_init: diagnostics'
+          write(iulog,*) 'calday, last, next, dels = ',calday,last,next,dels
+          write(iulog,*) '-----------------------------------'
+       endif
+#endif
+    end if
+
+    !-----------------------------------------------------------------------
+    ! Set jlong etf
+    !-----------------------------------------------------------------------
+    call jlong_timestep_init
+
+    if ( do_jshort ) then
+       !-----------------------------------------------------------------------
+       ! Set jshort etf
+       !-----------------------------------------------------------------------
+       call jshort_timestep_init
+    endif
+
+  end subroutine photo_timestep_init
+
+  !--------------------------------------------------------------------------
+  !--------------------------------------------------------------------------
+  subroutine set_xnox_photo( photos, ncol )
+    use chem_mods,    only : phtcnt
+    implicit none
+    integer, intent(in)     :: ncol
+    real(r8), intent(inout) :: photos(ncol,pver,phtcnt)     ! photodissociation rates (1/s)
+
+    if( jno2a_ndx > 0 .and. jno2_ndx > 0 ) then
+       photos(:,:,jno2a_ndx) = photos(:,:,jno2_ndx)
+    end if
+    if( jn2o5a_ndx > 0 .and. jn2o5_ndx > 0 ) then
+       photos(:,:,jn2o5a_ndx) = photos(:,:,jn2o5_ndx)
+    end if
+    if( jn2o5b_ndx > 0 .and. jn2o5_ndx > 0 ) then
+       photos(:,:,jn2o5b_ndx) = photos(:,:,jn2o5_ndx)
+    end if
+    if( jhno3a_ndx > 0 .and. jhno3_ndx > 0 ) then
+       photos(:,:,jhno3a_ndx) = photos(:,:,jhno3_ndx)
+    end if
+
+    if( jno3a_ndx > 0 .and. jno3_ndx > 0 ) then
+       photos(:,:,jno3a_ndx) = photos(:,:,jno3_ndx)
+    end if
+    if( jho2no2a_ndx > 0 .and. jho2no2_ndx > 0 ) then
+       photos(:,:,jho2no2a_ndx) = photos(:,:,jho2no2_ndx)
+    end if
+    if( jmpana_ndx > 0 .and. jmpan_ndx > 0 ) then
+       photos(:,:,jmpana_ndx) = photos(:,:,jmpan_ndx)
+    end if
+    if( jpana_ndx > 0 .and. jpan_ndx > 0 ) then
+       photos(:,:,jpana_ndx) = photos(:,:,jpan_ndx)
+    end if
+    if( jonitra_ndx > 0 .and. jonitr_ndx > 0 ) then
+       photos(:,:,jonitra_ndx) = photos(:,:,jonitr_ndx)
+    end if
+    if( jo1da_ndx > 0 .and. jo1d_ndx > 0 ) then
+       photos(:,:,jo1da_ndx) = photos(:,:,jo1d_ndx)
+    end if
+    if( jo3pa_ndx > 0 .and. jo3p_ndx > 0 ) then
+       photos(:,:,jo3pa_ndx) = photos(:,:,jo3p_ndx)
+    end if
+
+  endsubroutine set_xnox_photo
+
+end module mo_photo

--- a/src_cam/mo_setaer.F90
+++ b/src_cam/mo_setaer.F90
@@ -10,7 +10,7 @@
 
       save
 
-      real(r8), parameter :: qext_so4(8,17) = reshape( (/  &                      ! m^2/gram (NH4)_2(SO4) 
+      real(r8), parameter :: qext_so4(8,17) = reshape( (/  &                      ! m^2/gram (NH4)_2(SO4)
             7.15_r8,  10.29_r8,  12.86_r8,  15.45_r8,  21.52_r8,  30.97_r8,  50.30_r8,  72.31_r8, &
             7.15_r8,  10.30_r8,  12.87_r8,  15.48_r8,  21.58_r8,  31.07_r8,  50.43_r8,  72.49_r8, &
             7.14_r8,  10.29_r8,  12.88_r8,  15.51_r8,  21.68_r8,  31.23_r8,  50.67_r8,  72.78_r8, &
@@ -57,7 +57,7 @@
       real(r8), parameter :: asm_so4(8,17) = reshape( (/ &
         0.67_r8,   0.68_r8,   0.68_r8,   0.68_r8,   0.69_r8,   0.70_r8,   0.71_r8,   0.73_r8, &
         0.67_r8,   0.68_r8,   0.68_r8,   0.68_r8,   0.69_r8,   0.70_r8,   0.72_r8,   0.73_r8, &
-        0.67_r8,   0.68_r8,   0.69_r8,   0.69_r8,   0.70_r8,   0.70_r8,   0.72_r8,   0.73_r8, & 
+        0.67_r8,   0.68_r8,   0.69_r8,   0.69_r8,   0.70_r8,   0.70_r8,   0.72_r8,   0.73_r8, &
         0.67_r8,   0.69_r8,   0.69_r8,   0.70_r8,   0.70_r8,   0.71_r8,   0.72_r8,   0.74_r8, &
         0.67_r8,   0.69_r8,   0.70_r8,   0.70_r8,   0.71_r8,   0.71_r8,   0.73_r8,   0.74_r8, &
         0.67_r8,   0.69_r8,   0.70_r8,   0.71_r8,   0.71_r8,   0.72_r8,   0.73_r8,   0.74_r8, &
@@ -95,7 +95,7 @@
          3.28_r8,   5.11_r8,   6.70_r8,   8.23_r8,  13.80_r8,  24.05_r8,  47.93_r8,  76.67_r8, &
          2.41_r8,   3.79_r8,   5.04_r8,   6.24_r8,  10.83_r8,  19.88_r8,  42.13_r8,  70.46_r8  &
             /),(/8,17/))
- 
+
       real(r8), parameter :: qext_dant(7,17) = qext_ant(2:8,:) - qext_ant(1:7,:)
 
       real(r8), parameter :: ssa_ant(8,17) = reshape( (/ &
@@ -119,7 +119,7 @@
             /),(/8,17/))
 
       real(r8), parameter :: ssa_dant(7,17) = ssa_ant(2:8,:) - ssa_ant(1:7,:)
- 
+
       real(r8), parameter :: asm_ant(8,17) = reshape( (/ &
         0.67_r8,   0.68_r8,   0.68_r8,   0.68_r8,   0.69_r8,   0.70_r8,   0.71_r8,   0.73_r8, &
         0.67_r8,   0.68_r8,   0.68_r8,   0.68_r8,   0.69_r8,   0.70_r8,   0.72_r8,   0.73_r8, &
@@ -206,7 +206,7 @@
 !--------------------------------------------------------------------
 ! black carbon
 !--------------------------------------------------------------------
-      real(r8), parameter :: qext_cbs(8,17) = reshape( (/ & 
+      real(r8), parameter :: qext_cbs(8,17) = reshape( (/ &
       26.47_r8,  26.47_r8,  26.47_r8,  68.55_r8,  54.51_r8,  68.55_r8,  93.69_r8, 128.49_r8, &
       26.35_r8,  26.35_r8,  26.35_r8,  67.19_r8,  53.53_r8,  67.19_r8,  91.62_r8, 125.62_r8, &
       26.15_r8,  26.15_r8,  26.15_r8,  65.24_r8,  52.13_r8,  65.24_r8,  88.62_r8, 121.44_r8, &
@@ -228,7 +228,7 @@
 
       real(r8), parameter :: qext_dcbs(7,17) = qext_cbs(2:8,:) - qext_cbs(1:7,:)
 
-      real(r8), parameter :: ssa_cbs(8,17) = reshape( (/ & 
+      real(r8), parameter :: ssa_cbs(8,17) = reshape( (/ &
       0.30538_r8,0.30538_r8,0.30538_r8,0.58171_r8,0.52858_r8,0.58171_r8,0.66772_r8,0.73300_r8, &
       0.30531_r8,0.30531_r8,0.30531_r8,0.57816_r8,0.52490_r8,0.57816_r8,0.66490_r8,0.73116_r8, &
       0.30524_r8,0.30524_r8,0.30524_r8,0.57281_r8,0.51947_r8,0.57281_r8,0.66041_r8,0.72800_r8, &
@@ -275,7 +275,7 @@
 !--------------------------------------------------------------------
 ! organic carbon
 !--------------------------------------------------------------------
-      real(r8), parameter :: qext_ocs(8,17) = reshape( (/ & 
+      real(r8), parameter :: qext_ocs(8,17) = reshape( (/ &
       5.38_r8,   8.22_r8,  11.03_r8,  13.09_r8,  14.66_r8,  18.31_r8,  25.39_r8,  28.27_r8, &
       5.37_r8,   8.20_r8,  11.00_r8,  13.06_r8,  14.63_r8,  18.29_r8,  25.39_r8,  28.28_r8, &
       5.35_r8,   8.16_r8,  10.95_r8,  13.02_r8,  14.59_r8,  18.26_r8,  25.39_r8,  28.29_r8, &
@@ -297,7 +297,7 @@
 
       real(r8), parameter :: qext_docs(7,17) = qext_ocs(2:8,:) - qext_ocs(1:7,:)
 
-      real(r8), parameter :: ssa_ocs(8,17) = reshape( (/ & 
+      real(r8), parameter :: ssa_ocs(8,17) = reshape( (/ &
       0.67508_r8,0.73829_r8,0.78690_r8,0.80446_r8,0.82190_r8,0.84991_r8,0.87960_r8,0.88715_r8, &
       0.67840_r8,0.74179_r8,0.79056_r8,0.80819_r8,0.82564_r8,0.85366_r8,0.88338_r8,0.89096_r8, &
       0.68373_r8,0.74715_r8,0.79586_r8,0.81346_r8,0.83078_r8,0.85852_r8,0.88777_r8,0.89520_r8, &
@@ -629,18 +629,18 @@
 !-----------------------------------------------------------------------------
 !   	... calculate aerosol optical depth
 !-----------------------------------------------------------------------------
-!   AEROSOL TYPES: 
+!   AEROSOL TYPES:
 !   ocs1, ocs2, cbs1, cbs2, ant, so4, ds1-ds4,soa, sal
 !   where 1=hydrophobic, 2=hydrophilic;
 !
-!   PARAMETERS:                                                              
+!   PARAMETERS:
 !   NZ      - INTEGER, number of specified altitude levels in the working
-!             grid                                                           
+!             grid
 !   Z       - REAL, specified altitude working grid (km)
 !   axxx     aerosoling mix ratio (where xxx is aerosol type)
 !
 !   dtxxx    REAL, optical depth (absorption)
-!   omxxx    REAL, single albedo             
+!   omxxx    REAL, single albedo
 !   gxxx   asysmetry factor
 !
 !-----------------------------------------------------------------------------
@@ -655,13 +655,10 @@
       use chem_mods,        only : adv_mass
       use mo_constants,     only : avogadro
       use mo_chem_utls,     only : get_spc_ndx
-#ifdef OSLO_AERO
+      ! OSLO_AERO begin
       use oslo_aero_dust,    only : dust_names
       use oslo_aero_seasalt, only : sslt_names=>seasalt_names
-#else
-      use dust_model,       only : dust_names
-      use seasalt_model,    only : sslt_names=>seasalt_names
-#endif
+      ! OSLO_AERO end
 
       implicit none
 
@@ -765,9 +762,9 @@
 !    729.00- 743.60
 !
 ! For aerosol types so4 and  ant data tabulated for CAM is used in wavelength bins for which it exists
-! This data has been created by  D. Fillmore in the file aerOptics.nc 
+! This data has been created by  D. Fillmore in the file aerOptics.nc
 ! Data is weighted by wavelength bin
-! 
+!
 ! Otherwise, tables have been recreated by P. Hess
 !
 ! Refractive indices and other DATA is mostly from OPAC dataset Hess et al., .....
@@ -778,7 +775,7 @@
 !              sigma = alog10(2.00)           ! standard deviation of distribution
 !              rmin = 0.005                   ! minimum radius microns
 !              rmax = 20.0                    ! maximum radius microns
-!              rho = 1.76                     ! grams / cm^3 
+!              rho = 1.76                     ! grams / cm^3
 !        PARAMETERS NEEDED FOR CALCULATING KOHLER CURVES for calculating growth with relative humidity
 !              nu_s = 3.0
 !              rho_u = rho
@@ -800,9 +797,9 @@
 !     1.48, 1.47, 1.47, 1.47, 1.46, 1.46, 1.45, 1.44, 1.42, $
 !     1.40, 1.33, 1.27, 1.39, 1.49, 1.48, 1.56, 1.61, 1.61, $
 !     1.60, 1.62, 1.63, 1.56, 1.53, 1.49, 1.48, 1.44]
-!  
+!
 !  IMAGINARY
-!    1.0e-7, 1.0e-7, 1.0e-7, 1.0e-7, 1.0e-7, 1.0e-7, 3.5e-7, 2.4e-6, 
+!    1.0e-7, 1.0e-7, 1.0e-7, 1.0e-7, 1.0e-7, 1.0e-7, 3.5e-7, 2.4e-6,
 !    9.5e-7, 3.4e-6, 1.7e-5, 1.1e-5, 3.4e-5, 2.1e-4, 1.9e-4, 9.0e-5, 7.6e-5, $
 !    1.5e-4, 1.0e-3, 1.5e-3, 3.4e-3, 1.7e-3, 7.7e-4, 4.5e-4, 3.5e-4, 9.0e-4, $
 !    5.0e-3, 5.0e-2, 2.3e-1, 3.3e-1, 2.7e-1, 2.4e-1, 2.7e-1, 2.4e-1, 1.7e-1, $
@@ -811,44 +808,44 @@
 !
 ! NH4NO3
 !
-! treated the same as sulphate except 
+! treated the same as sulphate except
 ! rho=1.73 (Lowenthal, 1999, Atmospheric Environment).
-! 
+!
 ! DUST
 !
 ! dust is treated as 4 size distributions
 ! 0.05 - 0.5; 0.5 - 1.25; 1.25 - 2.5; 2.5 - 5.0 microns
 ! each bin is part of a distribution with median number r_m = 2.524 * exp(- 3.0 * log(2.00)^2) / 2 [number median radius]
 ! r_m = 0.298, sigma = 2.00, rho = 2.650
-! 
+!
 ! note this treatment of dust is somewhat different than that made in CAM, where each size bin
 ! has a different number median radius
 !
-! dust is not assumed to take up water. 
+! dust is not assumed to take up water.
 !
 ! refractive indexes are as in CAM (Fillmore...)
 !
 ! ORGANIC CARBON
 !
-! In absence of data for organic aerosol 
-! refractive indexes are taken as for WASO: based on Fillmore (and OPAC). This is similar to 
-! the formulation used in Liao and Seinfeld, 2004, JGR. 
+! In absence of data for organic aerosol
+! refractive indexes are taken as for WASO: based on Fillmore (and OPAC). This is similar to
+! the formulation used in Liao and Seinfeld, 2004, JGR.
 ! The growth of organic carbon with relative humidity is assumed constant at all radii following
 ! hygrscopic growth given in Chen et al. : rel. hum: 0, 50, 70, 80, 90, 95, 98, 99
 ! multiplier for radius: 1,  1.2,  1.4,  1.5, 1.6, 1.8, 2.1 , 2.2
 !
-! SOA 
+! SOA
 !
 ! Treated the same as organic aerosol.
 !
 ! SOOT
 !
-! Refractive index are taken from Fillmore based on OPAC. 
+! Refractive index are taken from Fillmore based on OPAC.
 ! In a different formulation than that followed in CAM we let hydrophillic soot grow.
 !  The growth of organic carbon with relative humidity is assumed constant at all radii following
 ! hygrscopic growth given in Chen et al. : rel. hum: 0, 50, 70, 80, 90, 95, 98, 99
 ! multiplier for radius: (1,  1,  1,  1.2, 1.4,  1.5, 1.7, 1.9]
-! 
+!
 !
 ! SEA SALT
 !
@@ -887,10 +884,10 @@
 !-----------------------------------------------------------------------------
 !      	... so4
 !-----------------------------------------------------------------------------
-      ndx = get_spc_ndx('SO4') 
+      ndx = get_spc_ndx('SO4')
       if( ndx > 0 ) then
          mw = adv_mass( ndx )
-         gpm2(:) = s2as * dz(:) * aso4(:pver) * mw 
+         gpm2(:) = s2as * dz(:) * aso4(:pver) * mw
          do wn = 1,nw
             do k = 1,pver
                rh_l  = rh_ndx(k)
@@ -910,11 +907,11 @@
 
 !-----------------------------------------------------------------------------
 !   	... ant:  nh4no3
-!-----------------------------------------------------------------------------    
+!-----------------------------------------------------------------------------
       ndx = get_spc_ndx('NH4NO3')
       if( ndx > 0 ) then
          mw = adv_mass( ndx )
-         gpm2(:) = dz(:) * aant(:pver) * mw 
+         gpm2(:) = dz(:) * aant(:pver) * mw
          do wn = 1,nw
             do k = 1,pver
                rh_l  = rh_ndx(k)
@@ -938,10 +935,10 @@
        ndx = get_spc_ndx('CB1')
        if( ndx > 0 ) then
           mw = adv_mass( ndx )
-          gpm2(:) = dz(:) * acbs1(:pver) * mw 
+          gpm2(:) = dz(:) * acbs1(:pver) * mw
           do wn = 1,nw
              dtcbs1(:,wn) = gpm2(:)*qext_cbs(1,wn)
-             omcbs1(:,wn) = ssa_cbs(1,wn) 
+             omcbs1(:,wn) = ssa_cbs(1,wn)
              gcbs1(:,wn)  = asm_cbs(1,wn)
           end do
       else
@@ -954,7 +951,7 @@
 
        ndx = get_spc_ndx('CB2')
        if( ndx > 0 ) then
-          gpm2(:) = dz(:) * acbs2(:pver) * mw 
+          gpm2(:) = dz(:) * acbs2(:pver) * mw
           do wn = 1,nw
              do k = 1,pver
                rh_l  = rh_ndx(k)
@@ -978,10 +975,10 @@
        ndx = get_spc_ndx('OC1')
        if( ndx > 0 ) then
           mw = adv_mass( ndx )
-          gpm2(:) = dz(:) * aocs1(:pver) * mw 
+          gpm2(:) = dz(:) * aocs1(:pver) * mw
           do wn = 1,nw
              dtocs1(:,wn) =  gpm2(:)*qext_ocs(1,wn)
-             omocs1(:,wn) =  ssa_ocs(1,wn) 
+             omocs1(:,wn) =  ssa_ocs(1,wn)
              gocs1(:,wn)  =  asm_ocs(1,wn)
           end do
       else
@@ -991,10 +988,10 @@
             gocs1(:,wn)  = 0._r8
          end do
        end if
- 
+
        ndx = get_spc_ndx('OC2')
        if( ndx > 0 ) then
-          gpm2(:) = dz(:) * aocs2(:pver) * mw 
+          gpm2(:) = dz(:) * aocs2(:pver) * mw
           do wn = 1,nw
             do k = 1,pver
                rh_l  = rh_ndx(k)
@@ -1020,7 +1017,7 @@
           ndx = get_spc_ndx('OC2')
           if( ndx > 0 ) then
              mw = adv_mass( ndx )
-             gpm2(:) = dz(:) * asoa(:pver) * mw 
+             gpm2(:) = dz(:) * asoa(:pver) * mw
              do wn = 1,nw
                 do k = 1,pver
                    rh_l  = rh_ndx(k)
@@ -1041,10 +1038,10 @@
        ndx = get_spc_ndx(dust_names(1))
        if (ndx >0) then
           mw = adv_mass( ndx )
-          gpm2(:) = dz(:) * ads(1,:pver) * mw 
+          gpm2(:) = dz(:) * ads(1,:pver) * mw
           do wn = 1,nw
              dtds1(:,wn) = gpm2(:)*qext_ds1(wn)
-             omds1(:,wn) = ssa_ds1(wn) 
+             omds1(:,wn) = ssa_ds1(wn)
              gds1(:,wn)  = asm_ds1(wn)
           end do
        else
@@ -1057,10 +1054,10 @@
        ndx = get_spc_ndx(dust_names(2))
        if (ndx >0) then
           mw = adv_mass( ndx )
-          gpm2(:) = dz(:) * ads(2,:pver) * mw 
+          gpm2(:) = dz(:) * ads(2,:pver) * mw
           do wn = 1,nw
              dtds2(:,wn) = gpm2(:)*qext_ds2(wn)
-             omds2(:,wn) = ssa_ds2(wn) 
+             omds2(:,wn) = ssa_ds2(wn)
              gds2(:,wn)  = asm_ds2(wn)
           end do
        else
@@ -1073,10 +1070,10 @@
        ndx = get_spc_ndx(dust_names(3))
        if (ndx >0) then
           mw = adv_mass( ndx )
-          gpm2(:) = dz(:) * ads(3,:pver) * mw 
+          gpm2(:) = dz(:) * ads(3,:pver) * mw
           do wn = 1,nw
              dtds3(:,wn) = gpm2(:)*qext_ds3(wn)
-             omds3(:,wn) = ssa_ds3(wn) 
+             omds3(:,wn) = ssa_ds3(wn)
              gds3(:,wn)  = asm_ds3(wn)
           end do
        else
@@ -1089,10 +1086,10 @@
        ndx = get_spc_ndx(dust_names(4))
        if (ndx >0) then
           mw = adv_mass( ndx )
-          gpm2(:) = dz(:) * ads(4,:pver) * mw 
+          gpm2(:) = dz(:) * ads(4,:pver) * mw
           do wn = 1,nw
              dtds4(:,wn) = gpm2(:)*qext_ds4(wn)
-             omds4(:,wn) = ssa_ds4(wn) 
+             omds4(:,wn) = ssa_ds4(wn)
              gds4(:,wn)  = asm_ds4(wn)
           end do
        else
@@ -1107,10 +1104,10 @@
 !  	... sea salts
 !-----------------------------------------------------------------------------
        ndx = get_spc_ndx(sslt_names(1))
-   
+
        if( ndx > 0 ) then
           mw = adv_mass( ndx )
-          gpm2(:) = dz(:) * asal(:pver,1) * mw 
+          gpm2(:) = dz(:) * asal(:pver,1) * mw
           do wn = 1,nw
             do k = 1,pver
                rh_l  = rh_ndx(k)
@@ -1127,11 +1124,11 @@
             gsal(:,wn,1)  = 0._r8
          end do
        end if
- 
+
        ndx = get_spc_ndx(sslt_names(2))
        if( ndx > 0 ) then
           mw = adv_mass( ndx )
-          gpm2(:) = dz(:) * asal(:pver,2) * mw 
+          gpm2(:) = dz(:) * asal(:pver,2) * mw
           do wn = 1,nw
             do k = 1,pver
                rh_l  = rh_ndx(k)
@@ -1152,7 +1149,7 @@
        ndx = get_spc_ndx(sslt_names(3))
        if( ndx > 0 ) then
           mw = adv_mass( ndx )
-          gpm2(:) = dz(:) * asal(:pver,3) * mw 
+          gpm2(:) = dz(:) * asal(:pver,3) * mw
           do wn = 1,nw
             do k = 1,pver
                rh_l  = rh_ndx(k)
@@ -1173,7 +1170,7 @@
       ndx = get_spc_ndx(sslt_names(4))
       if( ndx > 0 ) then
           mw = adv_mass( ndx )
-          gpm2(:) = dz(:) * asal(:pver,4) * mw 
+          gpm2(:) = dz(:) * asal(:pver,4) * mw
           do wn = 1,nw
             do k = 1,pver
                rh_l  = rh_ndx(k)

--- a/src_cam/mo_setsox.F90
+++ b/src_cam/mo_setsox.F90
@@ -33,23 +33,19 @@ contains
     use mo_chem_utls, only : get_spc_ndx, get_inv_ndx
     use spmd_utils,   only : masterproc
     use phys_control, only : phys_getopts
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     use oslo_aero_sox_cldaero, only : sox_cldaero_init
-#else
-    use sox_cldaero_mod, only : sox_cldaero_init
-#endif
+    ! OSLO_AERO_END
     implicit none
 
 
     call phys_getopts( &
          prog_modal_aero_out=modal_aerosols )
 
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
    cloud_borne = .true.
    modal_aerosols = .true.
-#else
-   cloud_borne = modal_aerosols
-#endif
+   ! OSLO_AERO end
 
     !-----------------------------------------------------------------
     !       ... get species indicies
@@ -183,13 +179,10 @@ contains
     use chem_mods,    only : adv_mass
     use physconst,    only : mwdry, gravit
     use mo_constants, only : pi
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     use oslo_aero_sox_cldaero, only : sox_cldaero_update, sox_cldaero_create_obj, sox_cldaero_destroy_obj
     use oslo_aero_sox_cldaero, only : cldaero_conc_t
-#else
-    use sox_cldaero_mod, only : sox_cldaero_update, sox_cldaero_create_obj, sox_cldaero_destroy_obj
-    use cldaero_mod,     only : cldaero_conc_t
-#endif
+    ! OSLO_AERO end
 
     !
     implicit none

--- a/src_cam/mo_usrrxt.F90
+++ b/src_cam/mo_usrrxt.F90
@@ -3,9 +3,9 @@ module mo_usrrxt
   use shr_kind_mod,     only : r8 => shr_kind_r8
   use cam_logfile,      only : iulog
   use ppgrid,           only : pver, pcols
-#ifdef OSLO_AERO
-   use oslo_aero_share, only: nmodes_oslo=> nmodes
-#endif
+  ! OSLO_AERO begin
+  use oslo_aero_share,  only : nmodes_oslo=> nmodes
+  ! OSLO_AERO end
 
   implicit none
 
@@ -33,14 +33,14 @@ module mo_usrrxt
   integer :: usr_DMS_OH_ndx
   integer :: usr_HO2_aer_ndx
   integer :: usr_GLYOXAL_aer_ndx
-  
+
   integer :: tag_NO2_NO3_ndx
   integer :: tag_NO2_OH_ndx
   integer :: tag_NO2_HO2_ndx
   integer :: tag_C2H4_OH_ndx
   integer :: tag_C3H6_OH_ndx
   integer :: tag_CH3CO3_NO2_ndx
-  
+
 !lke-TS1
   integer :: usr_PBZNIT_M_ndx
   integer :: tag_ACBZO2_NO2_ndx
@@ -65,21 +65,21 @@ module mo_usrrxt
   integer :: usr_XPAN_M_ndx
   integer :: usr_XMPAN_M_ndx
   integer :: usr_MCO3_XNO2_ndx
-  
+
   integer :: usr_C2O3_NO2_ndx
   integer :: usr_C2H4_OH_ndx
   integer :: usr_XO2N_HO2_ndx
   integer :: usr_C2O3_XNO2_ndx
-  
+
   integer :: tag_XO2N_NO_ndx
   integer :: tag_XO2_HO2_ndx
   integer :: tag_XO2_NO_ndx
-  
+
   integer :: usr_O_O_ndx
   integer :: usr_CL2O2_M_ndx
   integer :: usr_SO3_H2O_ndx
   integer :: tag_CLO_CLO_M_ndx
-  
+
   integer :: ion1_ndx, ion2_ndx, ion3_ndx, ion11_ndx
   integer :: elec1_ndx, elec2_ndx, elec3_ndx
   integer :: elec4_ndx, elec5_ndx, elec6_ndx
@@ -94,7 +94,7 @@ module mo_usrrxt
   integer, parameter :: nedn = 2
   integer :: edn_ndx(nedn)
   integer, parameter :: nnir = 13
-  integer :: nir_ndx(nnir)  
+  integer :: nir_ndx(nnir)
   integer, parameter :: niira = 112
   integer :: iira_ndx(niira)
   integer, parameter :: niirb = 14
@@ -207,7 +207,7 @@ contains
     tag_NO2_HO2_ndx      = get_rxt_ndx( 'tag_NO2_HO2' )
     tag_C2H4_OH_ndx      = get_rxt_ndx( 'tag_C2H4_OH' )
     tag_C3H6_OH_ndx      = get_rxt_ndx( 'tag_C3H6_OH' )
-    tag_CH3CO3_NO2_ndx   = get_rxt_ndx( 'tag_CH3CO3_NO2' )     
+    tag_CH3CO3_NO2_ndx   = get_rxt_ndx( 'tag_CH3CO3_NO2' )
 !lke-TS1
     usr_PBZNIT_M_ndx     = get_rxt_ndx( 'usr_PBZNIT_M' )
     tag_ACBZO2_NO2_ndx   = get_rxt_ndx( 'tag_ACBZO2_NO2' )
@@ -251,7 +251,7 @@ contains
     usr_O_O_ndx          = get_rxt_ndx( 'usr_O_O' )
     usr_CL2O2_M_ndx      = get_rxt_ndx( 'usr_CL2O2_M' )
     usr_SO3_H2O_ndx      = get_rxt_ndx( 'usr_SO3_H2O' )
-!    
+!
     tag_CLO_CLO_M_ndx      = get_rxt_ndx( 'tag_CLO_CLO_M' )
     if (tag_CLO_CLO_M_ndx<0) then ! for backwards compatibility
        tag_CLO_CLO_M_ndx   = get_rxt_ndx( 'tag_CLO_CLO' )
@@ -287,7 +287,7 @@ contains
     het1_ndx             = get_rxt_ndx( 'het1' )
 !
 ! ion chemistry
-!   
+!
     ion1_ndx  = get_rxt_ndx( 'ion_Op_O2' )
     ion2_ndx  = get_rxt_ndx( 'ion_Op_N2' )
     ion3_ndx  = get_rxt_ndx( 'ion_N2p_Oa' )
@@ -369,7 +369,7 @@ contains
     usr_oh_dms_ndx  = get_rxt_ndx( 'usr_oh_dms' )
     aq_so2_h2o2_ndx  = get_rxt_ndx( 'aq_so2_h2o2' )
     aq_so2_o3_ndx  = get_rxt_ndx( 'aq_so2_o3' )
-    
+
 !lke++
 ! CO tags
 !
@@ -440,7 +440,7 @@ contains
 !-----------------------------------------------------------------
 !        ... set the user specified reaction rates
 !-----------------------------------------------------------------
-    
+
     use mo_constants,  only : pi, avo => avogadro, boltz_cgs, rgas
     use chem_mods,     only : nfs, rxntot, gas_pcnst, inv_m_ndx=>indexm
     use mo_setinv,     only : inv_o2_ndx=>o2_ndx, inv_h2o_ndx=>h2o_ndx
@@ -478,24 +478,24 @@ contains
 !-----------------------------------------------------------------
 !        ... local variables
 !-----------------------------------------------------------------
-    
+
     real(r8), parameter :: dg = 0.1_r8            ! mole diffusion =0.1 cm2/s (Dentener, 1993)
 
 !-----------------------------------------------------------------
 ! 	... reaction probabilities for heterogeneous reactions
 !-----------------------------------------------------------------
     real(r8), parameter :: gamma_n2o5 = 0.10_r8         ! from Jacob, Atm Env, 34, 2131, 2000
-    real(r8), parameter :: gamma_ho2  = 0.20_r8         ! 
-    real(r8), parameter :: gamma_no2  = 0.0001_r8       ! 
-    real(r8), parameter :: gamma_no3  = 0.001_r8        ! 
+    real(r8), parameter :: gamma_ho2  = 0.20_r8         !
+    real(r8), parameter :: gamma_no2  = 0.0001_r8       !
+    real(r8), parameter :: gamma_no3  = 0.001_r8        !
     real(r8), parameter :: gamma_glyoxal  = 2.0e-4_r8   !  Washenfelder et al, JGR, 2011
 !TS1 species
     real(r8), parameter :: gamma_isopnita  = 0.005_r8        ! from Fisher et al., ACP, 2016
-    real(r8), parameter :: gamma_isopnitb  = 0.005_r8        ! 
-    real(r8), parameter :: gamma_onitr     = 0.005_r8        ! 
-    real(r8), parameter :: gamma_honitr    = 0.005_r8        ! 
-    real(r8), parameter :: gamma_terpnit   = 0.01_r8         ! 
-    real(r8), parameter :: gamma_nterpooh  = 0.01_r8         ! 
+    real(r8), parameter :: gamma_isopnitb  = 0.005_r8        !
+    real(r8), parameter :: gamma_onitr     = 0.005_r8        !
+    real(r8), parameter :: gamma_honitr    = 0.005_r8        !
+    real(r8), parameter :: gamma_terpnit   = 0.01_r8         !
+    real(r8), parameter :: gamma_nterpooh  = 0.01_r8         !
     real(r8), parameter :: gamma_nc4cho    = 0.005_r8        !
     real(r8), parameter :: gamma_nc4ch2oh  = 0.005_r8        !
 
@@ -504,20 +504,20 @@ contains
     integer  ::  l
     real(r8) ::  tp(ncol)                       ! 300/t
     real(r8) ::  tinv(ncol)                     ! 1/t
-    real(r8) ::  ko(ncol)   
+    real(r8) ::  ko(ncol)
     real(r8) ::  term1(ncol)
     real(r8) ::  term2(ncol)
-    real(r8) ::  kinf(ncol)   
-    real(r8) ::  fc(ncol)   
-    real(r8) ::  xr(ncol)   
-    real(r8) ::  sur(ncol)   
+    real(r8) ::  kinf(ncol)
+    real(r8) ::  fc(ncol)
+    real(r8) ::  xr(ncol)
+    real(r8) ::  sur(ncol)
     real(r8) ::  sqrt_t(ncol)                   ! sqrt( temp )
     real(r8) ::  sqrt_t_58(ncol)                ! sqrt( temp / 58.)
     real(r8) ::  exp_fac(ncol)                  ! vector exponential
-    real(r8) ::  lwc(ncol)   
-    real(r8) ::  ko_m(ncol)   
-    real(r8) ::  k0(ncol)   
-    real(r8) ::  kinf_m(ncol)   
+    real(r8) ::  lwc(ncol)
+    real(r8) ::  ko_m(ncol)
+    real(r8) ::  k0(ncol)
+    real(r8) ::  kinf_m(ncol)
     real(r8) ::  o2(ncol)
     real(r8) ::  c_n2o5, c_ho2, c_no2, c_no3, c_glyoxal
 !TS1 species
@@ -533,7 +533,7 @@ contains
     real(r8), parameter :: den  = 1.15_r8                 ! each molecule of SO4(aer) density g/cm3
     !-------------------------------------------------
     ! 	... volume of sulfate particles
-    !           assuming mean rm 
+    !           assuming mean rm
     !           continient 0.05um  0.07um  0.09um
     !           ocean      0.09um  0.25um  0.37um
     !                      0.16um                  Blake JGR,7195, 1995
@@ -567,19 +567,16 @@ contains
     real(r8), parameter  :: ER2_AQ        =  5.28e+03_r8
 
     real(r8), parameter  :: pH            =  4.5e+00_r8
-    
+
     real(r8), pointer :: sfc(:), dm_aer(:)
     integer :: ntot_amode
 
     real(r8), pointer :: sfc_array(:,:,:), dm_array(:,:,:)
-    
-#ifdef OSLO_AERO
+
+    ! OSLO_AERO begin
     ntot_amode = nmodes_oslo
-#else
-    ! get info about the modal aerosols
-    ! get ntot_amode
-    call rad_cnst_get_info(0, nmodes=ntot_amode)
-#endif
+    ! OSLO_AERO end
+
     if (ntot_amode>0) then
        allocate(sfc_array(pcols,pver,ntot_amode), dm_array(pcols,pver,ntot_amode) )
     else
@@ -590,10 +587,10 @@ contains
     dm_array(:,:,:) = 0._r8
     sad_trop(:,:) = 0._r8
     reff_trop(:,:) = 0._r8
-        
+
     if( usr_NO2_aer_ndx > 0 .or. usr_NO3_aer_ndx > 0 .or. usr_N2O5_aer_ndx > 0 .or. usr_HO2_aer_ndx > 0 ) then
 
-! sad_trop should be set outside of usrrxt ?? 
+! sad_trop should be set outside of usrrxt ??
        if( carma_hetchem_feedback ) then
           sad_trop(:ncol,:pver)=strato_sad(:ncol,:pver)
        else
@@ -627,24 +624,24 @@ contains
        if ( usr_O_O_ndx > 0 ) then
           rxt(:,k,usr_O_O_ndx) = 2.76e-34_r8 * exp( 720.0_r8*tinv(:) )
        end if
-         
+
 !-----------------------------------------------------------------
 ! 	... cl2o2 + m -> 2*clo + m  (JPL15-10)
 !-----------------------------------------------------------------
        if ( usr_CL2O2_M_ndx > 0 ) then
           if ( tag_CLO_CLO_M_ndx > 0 ) then
              ko(:)            = 2.16e-27_r8 * exp( 8537.0_r8* tinv(:) )
-             rxt(:,k,usr_CL2O2_M_ndx) = rxt(:,k,tag_CLO_CLO_M_ndx)/ko(:)         
+             rxt(:,k,usr_CL2O2_M_ndx) = rxt(:,k,tag_CLO_CLO_M_ndx)/ko(:)
           else
              rxt(:,k,usr_CL2O2_M_ndx) = 0._r8
           end if
        end if
-       
+
 !-----------------------------------------------------------------
 !       ... so3 + 2*h2o --> h2so4 + h2o
 !       Note: this reaction proceeds by the 2 intermediate steps below
 !           so3 + h2o --> adduct
-!           adduct + h2o --> h2so4 + h2o  
+!           adduct + h2o --> h2so4 + h2o
 !               (Lovejoy et al., JCP, pp. 19911-19916, 1996)
 !	The first order rate constant used here is recommended by JPL 2011.
 !	This rate involves the water vapor number density.
@@ -659,7 +656,7 @@ contains
           end if
           rxt(:,k,usr_SO3_H2O_ndx) = 1.0e-20_r8 * fc(:)
        end if
-         
+
 !-----------------------------------------------------------------
 !	... n2o5 + m --> no2 + no3 + m (JPL15-10)
 !-----------------------------------------------------------------
@@ -859,7 +856,7 @@ contains
 !-----------------------------------------------------------------
        if( usr_SO2_OH_ndx > 0 ) then
           fc(:) = 3.0e-31_r8 *(300._r8*tinv(:))**3.3_r8
-          ko(:) = fc(:)*m(:,k)/(1._r8 + fc(:)*m(:,k)/1.5e-12_r8) 
+          ko(:) = fc(:)*m(:,k)/(1._r8 + fc(:)*m(:,k)/1.5e-12_r8)
           rxt(:,k,usr_SO2_OH_ndx) = ko(:)*.6_r8**(1._r8 + (log10(fc(:)*m(:,k)/1.5e-12_r8))**2._r8)**(-1._r8)
        end if
 !
@@ -883,10 +880,10 @@ contains
        if ( usr_XO2N_HO2_ndx > 0 ) then
           rxt(:,k,usr_XO2N_HO2_ndx) = rxt(:,k,tag_XO2N_NO_ndx)*rxt(:,k,tag_XO2_HO2_ndx)/(rxt(:,k,tag_XO2_NO_ndx)+1.e-36_r8)
        end if
-       
+
 !
 ! hydrolysis reactions on wetted aerosols
-!      
+!
        if( usr_NO2_aer_ndx > 0 .or. usr_NO3_aer_ndx > 0 .or. usr_N2O5_aer_ndx > 0 .or. usr_HO2_aer_ndx > 0 &
          .or. usr_GLYOXAL_aer_ndx > 0 ) then
 
@@ -902,7 +899,7 @@ contains
              c_glyoxal = 1.455e4_r8 * sqrt_t_58(i)  ! mean molecular speed of ho2
              c_isopnita = 1.20e3_r8 * sqrt_t(i)         ! mean molecular speed of isopnita
              c_isopnitb = 1.20e3_r8 * sqrt_t(i)         ! mean molecular speed of isopnitb
-             c_onitr    = 1.20e3_r8 * sqrt_t(i)         ! mean molecular speed of onitr 
+             c_onitr    = 1.20e3_r8 * sqrt_t(i)         ! mean molecular speed of onitr
              c_honitr   = 1.26e3_r8 * sqrt_t(i)         ! mean molecular speed of honitr
              c_terpnit  = 0.992e3_r8 * sqrt_t(i)        ! mean molecular speed of terpnit
              c_nterpooh = 0.957e3_r8 * sqrt_t(i)        ! mean molecular speed of nterpooh
@@ -951,7 +948,7 @@ contains
                 rxt(i,k,usr_HO2_aer_ndx) = hetrxtrate( sfc, dm_aer, dg, c_ho2, gamma_ho2 )
              end if
              !-------------------------------------------------------------------------
-             !  ... glyoxal ->  soag1  (on sulfate, nh4no3, oc2, soa)  
+             !  ... glyoxal ->  soag1  (on sulfate, nh4no3, oc2, soa)
              ! first order uptake, Fuchs and Sutugin, 1971,  dCg = 1/4 * gamma * ! A * |v_mol| * Cg * dt
              !-------------------------------------------------------------------------
              if( usr_GLYOXAL_aer_ndx > 0 ) then
@@ -1171,7 +1168,7 @@ contains
 
      endif
     end do level_loop
-    
+
 !-----------------------------------------------------------------
 ! 	... the ionic rates
 !-----------------------------------------------------------------
@@ -1204,7 +1201,7 @@ contains
      endif
 
      ! quenching of O+(2P) and O+(2D) by e to produce O+
-     ! See TABLE 1 of Roble (1995) 
+     ! See TABLE 1 of Roble (1995)
      ! drm 2015-07-27
      if (elec4_ndx > 0 .and. elec5_ndx > 0 .and. elec6_ndx > 0) then
          do k=1,pver
@@ -1212,7 +1209,7 @@ contains
             rxt(:,k,elec4_ndx) = 1.5e-7_r8 * tp(:)
             rxt(:,k,elec5_ndx) = 4.0e-8_r8 * tp(:)
             rxt(:,k,elec6_ndx) = 6.6e-8_r8 * tp(:)
-         end do 
+         end do
      endif
 
 !-----------------------------------------------------------------
@@ -1245,7 +1242,7 @@ contains
 !       where velo = sqrt[ 8*bk*T/pi/(w/av) ]
 !             bk = 1.381e-16
 !             av = 6.02e23
-!             w  = 108 (n2o5)  HO2(33)  CH2O (30)  NH3(15)  
+!             w  = 108 (n2o5)  HO2(33)  CH2O (30)  NH3(15)
 !
 !       so that velo = 1.40e3*sqrt(T)  (n2o5)   gama=0.1
 !       so that velo = 2.53e3*sqrt(T)  (HO2)    gama>0.2
@@ -1440,7 +1437,7 @@ contains
       real(r8), intent(in)    :: m(ncol,pver)                 ! total atm density (1/cm^3)
       real(r8), intent(in)    :: h2ovmr(ncol,pver)            ! water vapor (vmr)
       real(r8), intent(inout) :: rxt(ncol,pver,rxntot)        ! gas phase rates
-      
+
 !-----------------------------------------------------------------
 !        ... local variables
 !-----------------------------------------------------------------
@@ -1516,7 +1513,7 @@ contains
     real(r8), intent(out) :: x(:)
     real(r8), intent(in)  :: y(:)
     integer,  intent(in)  :: n
-    
+
 #ifdef IBM
     call vexp( x, y, n )
 #else

--- a/src_cam/radiation.F90
+++ b/src_cam/radiation.F90
@@ -42,14 +42,14 @@ module radiation
   use error_messages,      only: handle_err
   use perf_mod,            only: t_startf, t_stopf
   use cam_logfile,         only: iulog
-#ifdef OSLO_AERO
+  ! OSLO_AERO begin
   use prescribed_volcaero,      only: has_prescribed_volcaero, has_prescribed_volcaero_cmip6, solar_bands, terrestrial_bands
   use oslo_aero_optical_params, only: oslo_aero_optical_params_calc
   use oslo_aero_share,          only: nmodes_oslo=>nmodes, nbmodes
 #ifdef AEROCOM
   use oslo_aero_aerocom,        only: dod440,dod550,dod870,abs550,abs550alt
 #endif
-#endif
+  ! OSLO_AERO end
 
   implicit none
   private
@@ -133,19 +133,19 @@ module radiation
   logical :: spectralflux = .false. ! calculate fluxes (up and down) per band.
 
   ! Physics buffer indices
-  integer :: qrs_idx      = 0 
-  integer :: qrl_idx      = 0 
-  integer :: su_idx       = 0 
-  integer :: sd_idx       = 0 
-  integer :: lu_idx       = 0 
-  integer :: ld_idx       = 0 
+  integer :: qrs_idx      = 0
+  integer :: qrl_idx      = 0
+  integer :: su_idx       = 0
+  integer :: sd_idx       = 0
+  integer :: lu_idx       = 0
+  integer :: ld_idx       = 0
   integer :: fsds_idx     = 0
   integer :: fsns_idx     = 0
   integer :: fsnt_idx     = 0
   integer :: flns_idx     = 0
   integer :: flnt_idx     = 0
-  integer :: cldfsnow_idx = 0 
-  integer :: cld_idx      = 0 
+  integer :: cldfsnow_idx = 0
+  integer :: cld_idx      = 0
   integer :: volc_idx     = 0
 
   character(len=4) :: diag(0:N_DIAG) =(/'    ','_d1 ','_d2 ','_d3 ','_d4 ','_d5 ','_d6 ','_d7 ','_d8 ','_d9 ','_d10'/)
@@ -211,7 +211,7 @@ contains
     if (iradlw      < 0) iradlw      = nint((-iradlw     *3600._r8)/dtime)
     if (irad_always < 0) irad_always = nint((-irad_always*3600._r8)/dtime)
 
-    !----------------------------------------------------------------------- 
+    !-----------------------------------------------------------------------
     ! Print runtime options to log.
     !-----------------------------------------------------------------------
 
@@ -237,8 +237,8 @@ contains
     use physics_buffer, only: pbuf_add_field, dtype_r8
     use radiation_data, only: rad_data_register
 
-    call pbuf_add_field('QRS' , 'global',dtype_r8,(/pcols,pver/), qrs_idx) ! shortwave radiative heating rate 
-    call pbuf_add_field('QRL' , 'global',dtype_r8,(/pcols,pver/), qrl_idx) ! longwave  radiative heating rate 
+    call pbuf_add_field('QRS' , 'global',dtype_r8,(/pcols,pver/), qrs_idx) ! shortwave radiative heating rate
+    call pbuf_add_field('QRL' , 'global',dtype_r8,(/pcols,pver/), qrl_idx) ! longwave  radiative heating rate
 
     call pbuf_add_field('FSDS' , 'global',dtype_r8,(/pcols/), fsds_idx) ! Surface solar downward flux
     call pbuf_add_field('FSNS' , 'global',dtype_r8,(/pcols/), fsns_idx) ! Surface net shortwave flux
@@ -306,10 +306,10 @@ contains
 
     ! Local variables
     integer :: nstep      ! timestep counter
-    logical :: dosw       ! true => do shosrtwave calc   
+    logical :: dosw       ! true => do shosrtwave calc
     integer :: offset     ! offset for calendar day calculation
     integer :: dTime      ! integer timestep size
-    real(r8):: calday     ! calendar day of 
+    real(r8):: calday     ! calendar day of
     !-----------------------------------------------------------------------
 
     radiation_nextsw_cday = -1._r8
@@ -321,7 +321,7 @@ contains
        nstep = nstep + 1
        offset = offset + dtime
        if (radiation_do('sw', nstep)) then
-          radiation_nextsw_cday = get_curr_calday(offset=offset) 
+          radiation_nextsw_cday = get_curr_calday(offset=offset)
           dosw = .true.
        end if
     end do
@@ -412,7 +412,7 @@ contains
     if (is_first_restart_step()) then
        cosp_cnt(begchunk:endchunk) = cosp_cnt_init
     else
-       cosp_cnt(begchunk:endchunk) = 0     
+       cosp_cnt(begchunk:endchunk) = 0
     end if
 
     call addfld('O3colAbove',    horiz_only,   'A', 'DU', 'Column O3 above model top', sampling_seq='rad_lwsw')
@@ -513,10 +513,10 @@ contains
        end if
     end do
 
-#ifdef OSLO_AERO
-    call addfld('FDSCDRF', (/ 'ilev' /), 'A', 'W/m2', 'Shortwave clear-sky downward flux')   
+    ! OSLO_AERO begin
+    call addfld('FDSCDRF', (/ 'ilev' /), 'A', 'W/m2', 'Shortwave clear-sky downward flux')
     call addfld('FUSCDRF', (/ 'ilev' /), 'A', 'W/m2', 'Shortwave clear-sky upward flux')
-#endif
+    ! OSLO_AERO end
 
     if (scm_crm_mode) then
        call add_default('FUS     ', 1, ' ')
@@ -684,15 +684,15 @@ contains
   subroutine radiation_tend( &
        state, ptend, pbuf, cam_out, cam_in, net_flx, rd_out)
 
-    !----------------------------------------------------------------------- 
-    ! 
+    !-----------------------------------------------------------------------
+    !
     ! Driver for radiation computation.
-    ! 
+    !
     ! Revision history:
     ! 2007-11-05  M. Iacono        Install rrtmg_lw and sw as radiation model.
     ! 2007-12-27  M. Iacono        Modify to use CAM cloud optical properties with rrtmg.
     !
-    ! 2019-05-06  A. Kirkevåg: Changes for testing the 
+    ! 2019-05-06  A. Kirkevåg: Changes for testing the
     !   "simple plumes" aerosols, based on NorESM1 code P. Räisänen.
     !-----------------------------------------------------------------------
 
@@ -723,11 +723,11 @@ contains
     use cospsimulator_intr, only: docosp, cospsimulator_intr_run, cosp_nradsteps
 
     use constituents,     only: pcnst
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     use physics_buffer,    only: pbuf_get_index
     use oslo_aero_control, only: oslo_aero_getopts
     use oslo_aero_share
-#endif
+    ! OSLO_AERO end
 
     ! Arguments
     type(physics_state), intent(in), target :: state
@@ -755,8 +755,8 @@ contains
     integer  :: lchnk, ncol
     logical  :: dosw, dolw
     !
-    real(r8), pointer :: rvolcmmr(:,:) ! Read in stratospheric volcanoes aerosol mmr  
-    real(r8), pointer :: volcopt(:,:)  ! Read in stratospheric volcano SW optical parameter (CMIP6) 
+    real(r8), pointer :: rvolcmmr(:,:) ! Read in stratospheric volcanoes aerosol mmr
+    real(r8), pointer :: volcopt(:,:)  ! Read in stratospheric volcano SW optical parameter (CMIP6)
     !
     real(r8) :: calday          ! current calendar day
     real(r8) :: delta           ! Solar declination angle  in radians
@@ -765,7 +765,7 @@ contains
     real(r8) :: clon(pcols)     ! current longitudes(radians)
     real(r8) :: coszrs(pcols)   ! Cosine solar zenith angle
 
-    ! Gathered indices of day and night columns 
+    ! Gathered indices of day and night columns
     !  chunk_column_index = IdxDay(daylight_column_index)
     integer :: Nday           ! Number of daylight columns
     integer :: Nnite          ! Number of night columns
@@ -776,8 +776,8 @@ contains
 
     real(r8), pointer :: cld(:,:)      ! cloud fraction
     real(r8), pointer :: cldfsnow(:,:) ! cloud fraction of just "snow clouds- whatever they are"
-    real(r8), pointer :: qrs(:,:)      ! shortwave radiative heating rate 
-    real(r8), pointer :: qrl(:,:)      ! longwave  radiative heating rate 
+    real(r8), pointer :: qrs(:,:)      ! shortwave radiative heating rate
+    real(r8), pointer :: qrl(:,:)      ! longwave  radiative heating rate
     real(r8), pointer :: fsds(:)  ! Surface solar down flux
     real(r8), pointer :: fsns(:)  ! Surface solar absorbed flux
     real(r8), pointer :: fsnt(:)  ! Net column abs solar flux at model top
@@ -837,23 +837,18 @@ contains
     logical :: active_calls(0:N_DIAG)
 
     ! Aerosol radiative properties
-    real(r8) :: aer_tau    (pcols,0:pver,nswbands) ! aerosol extinction optical depth
-    real(r8) :: aer_tau_w  (pcols,0:pver,nswbands) ! aerosol single scattering albedo * tau
-    real(r8) :: aer_tau_w_g(pcols,0:pver,nswbands) ! aerosol assymetry parameter * w * tau
-    real(r8) :: aer_tau_w_f(pcols,0:pver,nswbands) ! aerosol forward scattered fraction * w * tau
     real(r8) :: aer_lw_abs (pcols,pver,nlwbands)   ! aerosol absorption optics depth (LW)
 
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     ! Local variables used for calculating aerosol optics and direct and indirect forcings.
     ! aodvis and absvis are AOD and absorptive AOD for visible wavelength close to 0.55 um (0.35-0.64)
-    ! Note that aodvis and absvis output should be devided by dayfoc to give physical (A)AOD values  
+    ! Note that aodvis and absvis output should be devided by dayfoc to give physical (A)AOD values
     real(r8) :: qdirind(pcols,pver,pcnst)  ! Common tracers for indirect and direct calculations
     real(r8) :: aodvis(pcols)              ! AOD vis
     real(r8) :: absvis(pcols)              ! absorptive AOD vis
     real(r8) :: clearodvis(pcols), clearabsvis(pcols), cloudfree(pcols), cloudfreemax(pcols)
     real(r8) :: clearod440(pcols),clearod550(pcols),clearod870(pcols),clearabs550(pcols),clearabs550alt(pcols)
     real(r8) :: ftem_1d(pcols)                        ! work-array to avoid NAN and pcols/ncol confusion
-    real(r8) :: Nnatk(pcols,pver,0:nmodes_oslo)       ! Modal aerosol number concentration
     real(r8) :: per_tau    (pcols,0:pver,nswbands)    ! aerosol extinction optical depth
     real(r8) :: per_tau_w  (pcols,0:pver,nswbands)    ! aerosol single scattering albedo * tau
     real(r8) :: per_tau_w_g(pcols,0:pver,nswbands)    ! aerosol assymetry parameter * w * tau
@@ -865,7 +860,8 @@ contains
     real(r8) :: volc_ext_earth(pcols,pver,nlwbands)   ! volcanic aerosol extinction for terrestrial bands, CMIP6
     real(r8) :: volc_omega_earth(pcols,pver,nlwbands) ! volcanic aerosol SSA for terrestrial bands, CMIP6
     integer  :: ns                                    ! spectral loop index
-#endif
+    ! OSLO_AERO end
+
     real(r8) :: fns(pcols,pverp)     ! net shortwave flux
     real(r8) :: fcns(pcols,pverp)    ! net clear-sky shortwave flux
     real(r8) :: fnl(pcols,pverp)     ! net longwave flux
@@ -894,7 +890,7 @@ contains
     per_tau_w(:,:,:)   =0._r8
     per_tau_w_g(:,:,:) =0._r8
     per_tau_w_f(:,:,:) =0._r8
-    ! 
+    !
     if (present(rd_out)) then
        rd => rd_out
        write_output = .false.
@@ -960,7 +956,7 @@ contains
        end do
     end if
 
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     qdirind(:ncol,:,:) = state%q(:ncol,:,:)
     if (has_prescribed_volcaero) then
        call oslo_aero_getopts(volc_fraction_coarse_out = volc_fraction_coarse)
@@ -968,7 +964,7 @@ contains
        qdirind(:ncol,:,l_so4_pr) = qdirind(:ncol,:,l_so4_pr) + (1.0_r8 - volc_fraction_coarse)*rvolcmmr(:ncol,:)
        qdirind(:ncol,:,l_ss_a3) = qdirind(:ncol,:,l_ss_a3) + volc_fraction_coarse*rvolcmmr(:ncol,:)
     end if
-#endif
+    ! OSLO_AERO end
 
     ! Find tropopause height if needed for diagnostic output
     if (hist_fld_active('FSNR') .or. hist_fld_active('FLNR')) then
@@ -1141,8 +1137,8 @@ contains
 
        if (dosw) then
 
-#ifdef OSLO_AERO
-          ! Volcanic optics for solar (SW) bands        
+          ! OSLO_AERO begin
+          ! Volcanic optics for solar (SW) bands
           do band=1, solar_bands
              volc_ext_sun(1:ncol,1:pver,band)=0.0_r8
              volc_omega_sun(1:ncol,1:pver,band)=0.999_r8
@@ -1151,18 +1147,18 @@ contains
           if (has_prescribed_volcaero_cmip6) then
              do band=1, solar_bands
                 write(c3,'(i3)') band
-                volc_idx = pbuf_get_index('ext_sun'//trim(adjustl(c3))) 
+                volc_idx = pbuf_get_index('ext_sun'//trim(adjustl(c3)))
                 call pbuf_get_field(pbuf, volc_idx,  volcopt,      start=(/1,1,itim_old/), kount=(/pcols,pver,1/) )
                 volc_ext_sun(1:ncol,1:pver,band)=volcopt(1:ncol,1:pver)
-                volc_idx = pbuf_get_index('omega_sun'//trim(adjustl(c3))) 
+                volc_idx = pbuf_get_index('omega_sun'//trim(adjustl(c3)))
                 call pbuf_get_field(pbuf, volc_idx,  volcopt,      start=(/1,1,itim_old/), kount=(/pcols,pver,1/) )
                 volc_omega_sun(1:ncol,1:pver,band)=volcopt(1:ncol,1:pver)
-                volc_idx = pbuf_get_index('g_sun'//trim(adjustl(c3))) 
+                volc_idx = pbuf_get_index('g_sun'//trim(adjustl(c3)))
                 call pbuf_get_field(pbuf, volc_idx,  volcopt,      start=(/1,1,itim_old/), kount=(/pcols,pver,1/) )
                 volc_g_sun(1:ncol,1:pver,band)=volcopt(1:ncol,1:pver)
              enddo
           endif
-          !  Volcanic optics for terrestrial (LW) bands (g is not used here)       
+          !  Volcanic optics for terrestrial (LW) bands (g is not used here)
           do band=1, terrestrial_bands
              volc_ext_earth(1:ncol,1:pver,band)=0.0_r8
              volc_omega_earth(1:ncol,1:pver,band)=0.999_r8
@@ -1170,11 +1166,11 @@ contains
           if (has_prescribed_volcaero_cmip6) then
              do band=1, terrestrial_bands
                 write(c3,'(i3)') band
-                volc_idx = pbuf_get_index('ext_earth'//trim(adjustl(c3))) 
+                volc_idx = pbuf_get_index('ext_earth'//trim(adjustl(c3)))
                 call pbuf_get_field(pbuf, volc_idx,  volcopt,      start=(/1,1,itim_old/), kount=(/pcols,pver,1/) )
                 volc_ext_earth(1:ncol,1:pver,band)=volcopt(1:ncol,1:pver)
 
-                volc_idx = pbuf_get_index('omega_earth'//trim(adjustl(c3))) 
+                volc_idx = pbuf_get_index('omega_earth'//trim(adjustl(c3)))
                 call pbuf_get_field(pbuf, volc_idx,  volcopt,      start=(/1,1,itim_old/), kount=(/pcols,pver,1/) )
                 volc_omega_earth(1:ncol,1:pver,band)=volcopt(1:ncol,1:pver)
              enddo
@@ -1183,11 +1179,12 @@ contains
           ! No aerocom variables passed for now
           ! dod440, dod550, dod870, abs550, abs550alt
           call oslo_aero_optical_params_calc(lchnk, ncol, 10.0_r8*state%pint, state%pmid,  &
-               coszrs, state, state%t, cld, qdirind, Nnatk, &
+               coszrs, state, state%t, cld, qdirind, &
                per_tau, per_tau_w, per_tau_w_g, per_tau_w_f, per_lw_abs, &
-               volc_ext_sun, volc_omega_sun, volc_g_sun, volc_ext_earth, volc_omega_earth, & 
+               volc_ext_sun, volc_omega_sun, volc_g_sun, volc_ext_earth, volc_omega_earth, &
                aodvis, absvis)
-#endif
+          ! OSLO_AERO end
+
           call get_variability(sfac)
 
           ! Get the active climate/diagnostic shortwave calculations
@@ -1201,14 +1198,11 @@ contains
                 ! update the concentrations in the RRTMG state object
                 call rrtmg_state_update(state, pbuf, icall, r_state)
 
-#ifdef OSLO_AERO
-                !call aer_rad_props_sw(icall, state, pbuf, nnite, idxnite, &
-                !                   aer_tau, aer_tau_w, aer_tau_w_g, aer_tau_w_f)
+                ! OSLO_AERO begin
                 ! A first call with Oslo aerosols set to zero for radiative forcing diagnostics
                 ! follwoing the Ghan (2013) method:
-
-                ! for calculation of direct radiative forcing, not necessarily "offline" as such anymore 
-                ! (just nudged), but with an extra call with 0 aerosol extiction.  
+                ! for calculation of direct radiative forcing, not necessarily "offline" as such anymore
+                ! (just nudged), but with an extra call with 0 aerosol extiction.
                 !
                 idrf = .true.
                 call rad_rrtmg_sw( &
@@ -1225,12 +1219,11 @@ contains
                      E_cld_tau_w=c_cld_tau_w, E_cld_tau_w_g=c_cld_tau_w_g,      &
                      E_cld_tau_w_f=c_cld_tau_w_f, old_convert=.false.)
 
-
                 ftem(:ncol,:pver) = qrs(:ncol,:pver)/cpair
                 !
                 ! Dump shortwave radiation information to history tape buffer (diagnostics)
                 !
-                ! Note that DRF fields are now from the per_tau=0 call (clean), no longer with per_tau from pmxsub                 
+                ! Note that DRF fields are now from the per_tau=0 call (clean), no longer with per_tau from pmxsub
                 call outfld('QRS_DRF ',ftem  ,pcols,lchnk)
                 ftem(:ncol,:pver) = rd%qrsc(:ncol,:pver)/cpair
                 call outfld('QRSC_DRF',ftem  ,pcols,lchnk)
@@ -1245,18 +1238,7 @@ contains
                 call outfld('FSUS_DRF',ftem_1d,pcols,lchnk)
                 call outfld('FSDSCDRF',rd%fsdsc(:) ,pcols,lchnk)
 #endif
-                idrf = .false.         
-#else
-               call aer_rad_props_sw(icall, state, pbuf, nnite, idxnite, &
-                                     aer_tau, aer_tau_w, aer_tau_w_g, aer_tau_w_f)
-#endif
-
-                rd%cld_tau_cloudsim(:ncol,:) = cld_tau(rrtmg_sw_cloudsim_band,:ncol,:)
-                rd%aer_tau550(:ncol,:)       = aer_tau(:ncol,:,idx_sw_diag)
-                rd%aer_tau400(:ncol,:)       = aer_tau(:ncol,:,idx_sw_diag+1)
-                rd%aer_tau700(:ncol,:)       = aer_tau(:ncol,:,idx_sw_diag-1)
-
-#ifdef OSLO_AERO
+                idrf = .false.
                 call rad_rrtmg_sw( &
                      lchnk, ncol, num_rrtmg_levs, r_state, state%pmid,          &
                      cldfprime, per_tau, per_tau_w, per_tau_w_g, per_tau_w_f,  &
@@ -1265,24 +1247,11 @@ contains
                      fsnt, rd%fsntc, rd%fsntoa, rd%fsutoa, rd%fsntoac,          &
                      rd%fsnirt, rd%fsnrtc, rd%fsnirtsq, fsns, rd%fsnsc,         &
                      rd%fsdsc, fsds, cam_out%sols, cam_out%soll, cam_out%solsd, &
-                     cam_out%solld, fns, fcns, idrf, Nday, Nnite,               & ! Note the extra idrf 
+                     cam_out%solld, fns, fcns, idrf, Nday, Nnite,               & ! Note the extra idrf
                      IdxDay, IdxNite, su, sd, E_cld_tau=c_cld_tau,              &
                      E_cld_tau_w=c_cld_tau_w, E_cld_tau_w_g=c_cld_tau_w_g,      &
                      E_cld_tau_w_f=c_cld_tau_w_f, old_convert=.false.)
-#else
-                call rad_rrtmg_sw( &
-                     lchnk, ncol, num_rrtmg_levs, r_state, state%pmid,          &
-                     cldfprime, aer_tau, aer_tau_w, aer_tau_w_g,  aer_tau_w_f,  &
-                     eccf, coszrs, rd%solin, sfac, cam_in%asdir,                &
-                     cam_in%asdif, cam_in%aldir, cam_in%aldif, qrs, rd%qrsc,    &
-                     fsnt, rd%fsntc, rd%fsntoa, rd%fsutoa, rd%fsntoac,          &
-                     rd%fsnirt, rd%fsnrtc, rd%fsnirtsq, fsns, rd%fsnsc,         &
-                     rd%fsdsc, fsds, cam_out%sols, cam_out%soll, cam_out%solsd, &
-                     cam_out%solld, fns, fcns, Nday, Nnite,                     &
-                     IdxDay, IdxNite, su, sd, E_cld_tau=c_cld_tau,              &
-                     E_cld_tau_w=c_cld_tau_w, E_cld_tau_w_g=c_cld_tau_w_g,      &
-                     E_cld_tau_w_f=c_cld_tau_w_f, old_convert=.false.)
-#endif
+                ! OSLO_AERO end
 
                 ! Output net fluxes at 200 mb
 
@@ -1301,8 +1270,8 @@ contains
 
        end if
 
-#ifdef OSLO_AERO
-       !Calculate cloud-free fraction assuming random overlap 
+       ! SLO_AERO begin
+       !Calculate cloud-free fraction assuming random overlap
        !(kind of duplicated from cloud_cover_diags::cldsav)
        cloudfree(1:ncol)    = 1.0_r8
        cloudfreemax(1:ncol) = 1.0_r8
@@ -1315,14 +1284,14 @@ contains
           end do
        end do
 
-       !Calculate AOD (visible) for cloud free 
+       !Calculate AOD (visible) for cloud free
        do i = 1, ncol
           clearodvis(i)=cloudfree(i)*aodvis(i)
           clearabsvis(i)=cloudfree(i)*absvis(i)
        end do
 
        !  clear-sky AOD and absorptive AOD for visible wavelength close to 0.55 um (0.35-0.64)
-       !  Note that caodvis and cabsvis output should be devided by dayfoc*cloudfree to give physical (A)AOD values  
+       !  Note that caodvis and cabsvis output should be devided by dayfoc*cloudfree to give physical (A)AOD values
        call outfld('CAODVIS ',clearodvis,pcols,lchnk)
        call outfld('CABSVIS ',clearabsvis,pcols,lchnk)
        call outfld('CLDFREE ',cloudfree,pcols,lchnk)
@@ -1341,7 +1310,7 @@ contains
        call outfld('CABS550 ',clearabs550  ,pcols,lchnk)
        call outfld('CABS550A',clearabs550alt,pcols,lchnk)
 #endif
-#endif
+       ! OSLO_AERO end
 
        ! Output aerosol mmr
        call rad_cnst_out(0, state, pbuf)
@@ -1362,9 +1331,9 @@ contains
 
                 call aer_rad_props_lw(icall, state, pbuf,  aer_lw_abs)
 
-                ! for calculation of direct and direct radiative forcing 
+                ! for calculation of direct and direct radiative forcing
 
-#ifdef OSLO_AERO
+                ! OSLO_AERO begin
                 call rad_rrtmg_lw( &
                      lchnk, ncol, num_rrtmg_levs, r_state, state%pmid,  &
                      per_lw_abs*0.0_r8, cldfprime, c_cld_lw_abs, qrl, rd%qrlc, &
@@ -1385,14 +1354,7 @@ contains
                 ! FLNT_ORG is just for temporary testing vs. FLNT
                 ftem_1d(1:ncol) = cam_out%flwds(1:ncol) - flns(1:ncol)
                 call outfld('FLUS    ',ftem_1d ,pcols,lchnk)
-#else
-                call rad_rrtmg_lw( &
-                     lchnk, ncol, num_rrtmg_levs, r_state, state%pmid,  &
-                     aer_lw_abs, cldfprime, c_cld_lw_abs, qrl, rd%qrlc, &
-                     flns, flnt, rd%flnsc, rd%flntc, cam_out%flwds,     &
-                     rd%flut, rd%flutc, fnl, fcnl, rd%fldsc,            &
-                     lu, ld)
-#endif
+                ! OSLO_AERO end
 
                 !  Output fluxes at 200 mb
                 call vertinterp(ncol, pcols, pverp, state%pint, 20000._r8, fnl,  rd%fln200)
@@ -1648,7 +1610,7 @@ contains
 
   subroutine calc_col_mean(state, mmr_pointer, mean_value)
 
-    ! Compute the column mean mass mixing ratio.  
+    ! Compute the column mean mass mixing ratio.
 
     type(physics_state),        intent(in)  :: state
     real(r8), dimension(:,:),   pointer     :: mmr_pointer  ! mass mixing ratio (lev)
@@ -1677,4 +1639,3 @@ contains
   !===============================================================================
 
 end module radiation
-

--- a/src_cam/radlw.F90
+++ b/src_cam/radlw.F90
@@ -1,7 +1,7 @@
 
 module radlw
-!----------------------------------------------------------------------- 
-! 
+!-----------------------------------------------------------------------
+!
 ! Purpose: Longwave radiation calculations.
 !
 !-----------------------------------------------------------------------
@@ -28,14 +28,14 @@ save
 public ::&
    radlw_init,   &! initialize constants
    rad_rrtmg_lw   ! driver for longwave radiation code
-   
+
 ! Private data
 integer :: ntoplw    ! top level to solve for longwave cooling
 
 ! Flag for cloud overlap method
 ! 0=clear, 1=random, 2=maximum/random, 3=maximum
 integer, parameter :: icld = 2
-                              
+
 
 !===============================================================================
 CONTAINS
@@ -92,7 +92,7 @@ subroutine rad_rrtmg_lw(lchnk   ,ncol      ,rrtmg_levs,r_state,       &
 
    real(r8), pointer, dimension(:,:,:) :: lu ! longwave spectral flux up
    real(r8), pointer, dimension(:,:,:) :: ld ! longwave spectral flux down
-   
+
 !
 !---------------------------Local variables-----------------------------
 !
@@ -110,7 +110,7 @@ subroutine rad_rrtmg_lw(lchnk   ,ncol      ,rrtmg_levs,r_state,       &
 
    real(r8), parameter :: dps = 1._r8/86400._r8 ! Inverse of seconds per day
 
-   ! Cloud arrays for McICA 
+   ! Cloud arrays for McICA
    integer, parameter :: nsubclw = ngptlw       ! rrtmg_lw g-point (quadrature point) dimension
    integer :: permuteseed                       ! permute seed for sub-column generator
 
@@ -140,10 +140,10 @@ subroutine rad_rrtmg_lw(lchnk   ,ncol      ,rrtmg_levs,r_state,       &
    ! mji/rrtmg
 
    ! Calculate cloud optical properties here if using CAM method, or if using one of the
-   ! methods in RRTMG_LW, then pass in cloud physical properties and zero out cloud optical 
+   ! methods in RRTMG_LW, then pass in cloud physical properties and zero out cloud optical
    ! properties here
-   
-   ! Zero optional cloud optical depth input array tauc_lw, 
+
+   ! Zero optional cloud optical depth input array tauc_lw,
    ! if inputting cloud physical properties into RRTMG_LW
    !          tauc_lw(:,:,:) = 0.
    ! Or, pass in CAM cloud longwave optical depth to RRTMG_LW
@@ -156,7 +156,7 @@ subroutine rad_rrtmg_lw(lchnk   ,ncol      ,rrtmg_levs,r_state,       &
    ! Call sub-column generator for McICA in radiation
    call t_startf('mcica_subcol_lw')
 
-   ! Set permute seed (must be offset between LW and SW by at least 140 to insure 
+   ! Set permute seed (must be offset between LW and SW by at least 140 to insure
    ! effective randomization)
    permuteseed = 150
 
@@ -172,7 +172,7 @@ subroutine rad_rrtmg_lw(lchnk   ,ncol      ,rrtmg_levs,r_state,       &
 
    call t_stopf('mcica_subcol_lw')
 
-   
+
    call t_startf('rrtmg_lw')
 
    ! Convert incoming water amounts from specific humidity to vmr as needed;
@@ -206,7 +206,7 @@ subroutine rad_rrtmg_lw(lchnk   ,ncol      ,rrtmg_levs,r_state,       &
    ! extra layer above model top with vertical indexing from bottom to top.
    ! Heating units are in K/d on output from RRTMG and contain output for
    ! extra layer above model top with vertical indexing from bottom to top.
-   ! Heating units are converted to J/kg/s below for use in CAM. 
+   ! Heating units are converted to J/kg/s below for use in CAM.
 
    flwds(:ncol) = dflx (:ncol,1)
    fldsc(:ncol) = dflxc(:ncol,1)
@@ -229,17 +229,11 @@ subroutine rad_rrtmg_lw(lchnk   ,ncol      ,rrtmg_levs,r_state,       &
    fsul(:ncol,pverp-rrtmg_levs+1:pverp)=uflxc(:ncol,rrtmg_levs:1:-1)
    fsdl(:ncol,pverp-rrtmg_levs+1:pverp)=dflxc(:ncol,rrtmg_levs:1:-1)
 
-#ifndef OSLO_AERO
-   if (single_column.and.scm_crm_mode) then
-#endif
       call outfld('FUL     ',ful,pcols,lchnk)
       call outfld('FDL     ',fdl,pcols,lchnk)
       call outfld('FULC    ',fsul,pcols,lchnk)
       call outfld('FDLC    ',fsdl,pcols,lchnk)
-#ifndef OSLO_AERO
-   endif
-#endif
-   
+
    fnl(:ncol,:) = ful(:ncol,:) - fdl(:ncol,:)
    ! mji/ cam excluded this?
    fcnl(:ncol,:) = fsul(:ncol,:) - fsdl(:ncol,:)
@@ -262,12 +256,12 @@ subroutine rad_rrtmg_lw(lchnk   ,ncol      ,rrtmg_levs,r_state,       &
       lu(:ncol,pverp-rrtmg_levs+1:pverp,:) = reshape(lwuflxs(:,:ncol,rrtmg_levs:1:-1), &
            (/ncol,rrtmg_levs,nbndlw/), order=(/3,1,2/))
    end if
-   
+
    if (associated(ld)) then
       ld(:ncol,pverp-rrtmg_levs+1:pverp,:) = reshape(lwdflxs(:,:ncol,rrtmg_levs:1:-1), &
            (/ncol,rrtmg_levs,nbndlw/), order=(/3,1,2/))
    end if
-   
+
    call t_stopf('rrtmg_lw')
 
 end subroutine rad_rrtmg_lw
@@ -275,9 +269,9 @@ end subroutine rad_rrtmg_lw
 !-------------------------------------------------------------------------------
 
 subroutine radlw_init()
-!----------------------------------------------------------------------- 
-! 
-! Purpose: 
+!-----------------------------------------------------------------------
+!
+! Purpose:
 ! Initialize various constants for radiation scheme.
 !
 !-----------------------------------------------------------------------

--- a/src_cam/radsw.F90
+++ b/src_cam/radsw.F90
@@ -1,7 +1,7 @@
 
 module radsw
-!----------------------------------------------------------------------- 
-! 
+!-----------------------------------------------------------------------
+!
 ! Purpose: Solar radiation calculations.
 !
 !-----------------------------------------------------------------------
@@ -49,11 +49,9 @@ subroutine rad_rrtmg_sw(lchnk,ncol       ,rrtmg_levs   ,r_state      , &
                     qrs      ,qrsc       ,fsnt         ,fsntc        ,fsntoa,fsutoa, &
                     fsntoac  ,fsnirtoa   ,fsnrtoac     ,fsnrtoaq     ,fsns    , &
                     fsnsc    ,fsdsc      ,fsds         ,sols         ,soll    , &
-#ifdef OSLO_AERO
+                    ! OSLO_AERO begin
                     solsd    ,solld      ,fns          ,fcns         ,idrf    , &
-#else
-                    solsd    ,solld      ,fns          ,fcns         , &
-#endif
+                    ! OSLO_AERO end
                     Nday     ,Nnite      ,IdxDay       ,IdxNite      , &
                     su       ,sd         ,                             &
                     E_cld_tau, E_cld_tau_w, E_cld_tau_w_g, E_cld_tau_w_f,  &
@@ -61,33 +59,33 @@ subroutine rad_rrtmg_sw(lchnk,ncol       ,rrtmg_levs   ,r_state      , &
 
 
 !-----------------------------------------------------------------------
-! 
-! Purpose: 
+!
+! Purpose:
 ! Solar radiation code
-! 
-! Method: 
+!
+! Method:
 ! mji/rrtmg
 ! RRTMG, two-stream, with McICA
-! 
+!
 ! Divides solar spectrum into 14 intervals from 0.2-12.2 micro-meters.
 ! solar flux fractions specified for each interval. allows for
 ! seasonally and diurnally varying solar input.  Includes molecular,
-! cloud, aerosol, and surface scattering, along with h2o,o3,co2,o2,cloud, 
+! cloud, aerosol, and surface scattering, along with h2o,o3,co2,o2,cloud,
 ! and surface absorption. Computes delta-eddington reflections and
-! transmissions assuming homogeneously mixed layers. Adds the layers 
-! assuming scattering between layers to be isotropic, and distinguishes 
+! transmissions assuming homogeneously mixed layers. Adds the layers
+! assuming scattering between layers to be isotropic, and distinguishes
 ! direct solar beam from scattered radiation.
-! 
+!
 ! Longitude loops are broken into 1 or 2 sections, so that only daylight
 ! (i.e. coszrs > 0) computations are done.
-! 
+!
 ! Note that an extra layer above the model top layer is added.
-! 
+!
 ! mks units are used.
-! 
+!
 ! Special diagnostic calculation of the clear sky surface and total column
 ! absorbed flux is also done for cloud forcing diagnostics.
-! 
+!
 !-----------------------------------------------------------------------
 
    use cmparray_mod,        only: CmpDayNite, ExpDayNite
@@ -95,8 +93,8 @@ subroutine rad_rrtmg_sw(lchnk,ncol       ,rrtmg_levs   ,r_state      , &
    use mcica_subcol_gen_sw, only: mcica_subcol_sw
    use physconst,           only: cpair
    use rrtmg_state,         only: rrtmg_state_t
-   
-   ! Minimum cloud amount (as a fraction of the grid-box area) to 
+
+   ! Minimum cloud amount (as a fraction of the grid-box area) to
    ! distinguish from clear sky
    real(r8), parameter :: cldmin = 1.0e-80_r8
 
@@ -130,12 +128,12 @@ subroutine rad_rrtmg_sw(lchnk,ncol       ,rrtmg_levs   ,r_state      , &
    real(r8), intent(in) :: E_aldir(pcols)     ! 0.7-5.0 micro-meter srfc alb: direct rad
    real(r8), intent(in) :: E_asdif(pcols)     ! 0.2-0.7 micro-meter srfc alb: diffuse rad
    real(r8), intent(in) :: E_aldif(pcols)     ! 0.7-5.0 micro-meter srfc alb: diffuse rad
-   real(r8), intent(in) :: sfac(nbndsw)            ! factor to account for solar variability in each band 
+   real(r8), intent(in) :: sfac(nbndsw)            ! factor to account for solar variability in each band
 
    real(r8), optional, intent(in) :: E_cld_tau    (nbndsw, pcols, pver)      ! cloud optical depth
-   real(r8), optional, intent(in) :: E_cld_tau_w  (nbndsw, pcols, pver)      ! cloud optical 
-   real(r8), optional, intent(in) :: E_cld_tau_w_g(nbndsw, pcols, pver)      ! cloud optical 
-   real(r8), optional, intent(in) :: E_cld_tau_w_f(nbndsw, pcols, pver)      ! cloud optical 
+   real(r8), optional, intent(in) :: E_cld_tau_w  (nbndsw, pcols, pver)      ! cloud optical
+   real(r8), optional, intent(in) :: E_cld_tau_w_g(nbndsw, pcols, pver)      ! cloud optical
+   real(r8), optional, intent(in) :: E_cld_tau_w_f(nbndsw, pcols, pver)      ! cloud optical
    logical, optional, intent(in) :: old_convert
 
    ! Output arguments
@@ -164,9 +162,9 @@ subroutine rad_rrtmg_sw(lchnk,ncol       ,rrtmg_levs   ,r_state      , &
    real(r8), intent(out) :: fns(pcols,pverp)   ! net flux at interfaces
    real(r8), intent(out) :: fcns(pcols,pverp)  ! net clear-sky flux at interfaces
 
-#ifdef OSLO_AERO
+   ! OSLO_AERO begin
    logical, intent(in) :: idrf
-#endif
+   ! OSLO_AERO end
 
    real(r8), pointer, dimension(:,:,:) :: su ! shortwave spectral flux up
    real(r8), pointer, dimension(:,:,:) :: sd ! shortwave spectral flux down
@@ -191,10 +189,10 @@ subroutine rad_rrtmg_sw(lchnk,ncol       ,rrtmg_levs   ,r_state      , &
 
    real(r8) :: h2ovmr(pcols,rrtmg_levs)   ! h2o volume mixing ratio
    real(r8) :: o3vmr(pcols,rrtmg_levs)    ! o3 volume mixing ratio
-   real(r8) :: co2vmr(pcols,rrtmg_levs)   ! co2 volume mixing ratio 
-   real(r8) :: ch4vmr(pcols,rrtmg_levs)   ! ch4 volume mixing ratio 
-   real(r8) :: o2vmr(pcols,rrtmg_levs)    ! o2  volume mixing ratio 
-   real(r8) :: n2ovmr(pcols,rrtmg_levs)   ! n2o volume mixing ratio 
+   real(r8) :: co2vmr(pcols,rrtmg_levs)   ! co2 volume mixing ratio
+   real(r8) :: ch4vmr(pcols,rrtmg_levs)   ! ch4 volume mixing ratio
+   real(r8) :: o2vmr(pcols,rrtmg_levs)    ! o2  volume mixing ratio
+   real(r8) :: n2ovmr(pcols,rrtmg_levs)   ! n2o volume mixing ratio
 
    real(r8) :: tsfc(pcols)          ! surface temperature
 
@@ -217,7 +215,7 @@ subroutine rad_rrtmg_sw(lchnk,ncol       ,rrtmg_levs   ,r_state      , &
    real(r8) :: asm_aer_sw(pcols, rrtmg_levs-1, nbndsw)      ! aer asymmetry parameter
 
    real(r8) :: cld_stosw(nsubcsw, pcols, rrtmg_levs-1)      ! stochastic cloud fraction
-   real(r8) :: rei_stosw(pcols, rrtmg_levs-1)               ! stochastic ice particle size 
+   real(r8) :: rei_stosw(pcols, rrtmg_levs-1)               ! stochastic ice particle size
    real(r8) :: rel_stosw(pcols, rrtmg_levs-1)               ! stochastic liquid particle size
    real(r8) :: cicewp_stosw(nsubcsw, pcols, rrtmg_levs-1)   ! stochastic cloud ice water path
    real(r8) :: cliqwp_stosw(nsubcsw, pcols, rrtmg_levs-1)   ! stochastic cloud liquid wter path
@@ -227,7 +225,7 @@ subroutine rad_rrtmg_sw(lchnk,ncol       ,rrtmg_levs   ,r_state      , &
    real(r8) :: fsfc_stosw(nsubcsw, pcols, rrtmg_levs-1)     ! stochastic cloud forward scattering fraction (optional)
 
    real(r8), parameter :: dps = 1._r8/86400._r8 ! Inverse of seconds per day
- 
+
    real(r8) :: swuflx(pcols,rrtmg_levs+1)       ! Total sky shortwave upward flux (W/m2)
    real(r8) :: swdflx(pcols,rrtmg_levs+1)       ! Total sky shortwave downward flux (W/m2)
    real(r8) :: swhr(pcols,rrtmg_levs)           ! Total sky shortwave radiative heating rate (K/d)
@@ -313,16 +311,10 @@ subroutine rad_rrtmg_sw(lchnk,ncol       ,rrtmg_levs   ,r_state      , &
    fns(1:ncol,1:pverp) = 0.0_r8
    fcns(1:ncol,1:pverp) = 0.0_r8
 
-#ifndef OSLO_AERO
-   if (single_column.and.scm_crm_mode) then 
-#endif
       fus(1:ncol,1:pverp) = 0.0_r8
       fds(1:ncol,1:pverp) = 0.0_r8
       fusc(:ncol,:pverp) = 0.0_r8
       fdsc(:ncol,:pverp) = 0.0_r8
-#ifndef OSLO_AERO
-   endif
-#endif
 
    if (associated(su)) su(1:ncol,:,:) = 0.0_r8
    if (associated(sd)) sd(1:ncol,:,:) = 0.0_r8
@@ -402,10 +394,10 @@ subroutine rad_rrtmg_sw(lchnk,ncol       ,rrtmg_levs   ,r_state      , &
    end do
 
    ! Calculate cloud optical properties here if using CAM method, or if using one of the
-   ! methods in RRTMG_SW, then pass in cloud physical properties and zero out cloud optical 
+   ! methods in RRTMG_SW, then pass in cloud physical properties and zero out cloud optical
    ! properties here
 
-   ! Zero optional cloud optical property input arrays tauc_sw, ssac_sw, asmc_sw, 
+   ! Zero optional cloud optical property input arrays tauc_sw, ssac_sw, asmc_sw,
    ! if inputting cloud physical properties to RRTMG_SW
    !tauc_sw(:,:,:) = 0.0_r8
    !ssac_sw(:,:,:) = 1.0_r8
@@ -428,7 +420,7 @@ subroutine rad_rrtmg_sw(lchnk,ncol       ,rrtmg_levs   ,r_state      , &
               fsfc_sw(ns,i,k) = 0._r8
               asmc_sw(ns,i,k) = 0._r8
            endif
-   
+
            tauc_sw(ns,i,k)=E_cld_tau(ns,IdxDay(i),kk)
            if (tauc_sw(ns,i,k) > 0._r8) then
               ssac_sw(ns,i,k)=E_cld_tau_w(ns,IdxDay(i),kk)/tauc_sw(ns,i,k)
@@ -454,7 +446,7 @@ subroutine rad_rrtmg_sw(lchnk,ncol       ,rrtmg_levs   ,r_state      , &
               fsfc_sw(ns,i,k) = 0._r8
               asmc_sw(ns,i,k) = 0._r8
            endif
-   
+
            tauc_sw(ns,i,k)=E_cld_tau(ns,IdxDay(i),kk)
            if (tauc_sw(ns,i,k) > 0._r8) then
               ssac_sw(ns,i,k)=max(E_cld_tau_w(ns,IdxDay(i),kk),1.e-80_r8)/max(tauc_sw(ns,i,k),1.e-80_r8)
@@ -500,7 +492,7 @@ subroutine rad_rrtmg_sw(lchnk,ncol       ,rrtmg_levs   ,r_state      , &
    ! Call sub-column generator for McICA in radiation
    call t_startf('mcica_subcol_sw')
 
-   ! Set permute seed (must be offset between LW and SW by at least 140 to insure 
+   ! Set permute seed (must be offset between LW and SW by at least 140 to insure
    ! effective randomization)
    permuteseed = 1
 
@@ -539,8 +531,8 @@ subroutine rad_rrtmg_sw(lchnk,ncol       ,rrtmg_levs   ,r_state      , &
    ! Flux units are in W/m2 on output from rrtmg_sw and contain output for
    ! extra layer above model top with vertical indexing from bottom to top.
    !
-   ! Heating units are in J/kg/s on output from rrtmg_sw and contain output 
-   ! for extra layer above model top with vertical indexing from bottom to top.  
+   ! Heating units are in J/kg/s on output from rrtmg_sw and contain output
+   ! for extra layer above model top with vertical indexing from bottom to top.
    !
    ! Reverse vertical indexing to go from top to bottom for CAM output.
 
@@ -558,7 +550,7 @@ subroutine rad_rrtmg_sw(lchnk,ncol       ,rrtmg_levs   ,r_state      , &
    fsnt(1:Nday) = swdflx(1:Nday,rrtmg_levs) - swuflx(1:Nday,rrtmg_levs)
    fsntc(1:Nday) = swdflxc(1:Nday,rrtmg_levs) - swuflxc(1:Nday,rrtmg_levs)
 
-   ! Set the downwelling flux at the surface 
+   ! Set the downwelling flux at the surface
    fsds(1:Nday) = swdflx(1:Nday,1)
    fsdsc(1:Nday) = swdflxc(1:Nday,1)
 
@@ -636,36 +628,30 @@ subroutine rad_rrtmg_sw(lchnk,ncol       ,rrtmg_levs   ,r_state      , &
 
    !  these outfld calls don't work for spmd only outfield in scm mode (nonspmd)
    ! Following outputs added for CRM
-#ifndef OSLO_AERO
-   if (single_column .and. scm_crm_mode) then 
-#endif
-      call ExpDayNite(fus,Nday, IdxDay, Nnite, IdxNite, 1, pcols, 1, pverp)
-      call ExpDayNite(fusc,Nday, IdxDay, Nnite, IdxNite, 1, pcols, 1, pverp)
-      call ExpDayNite(fds,Nday, IdxDay, Nnite, IdxNite, 1, pcols, 1, pverp)
-      call ExpDayNite(fdsc,Nday, IdxDay, Nnite, IdxNite, 1, pcols, 1, pverp)
-      call outfld('FUS     ', fus,  pcols, lchnk)
-      call outfld('FUSC    ', fusc, pcols, lchnk)
-      call outfld('FDS     ', fds,  pcols, lchnk)
-      call outfld('FDSC    ', fdsc, pcols, lchnk)
-#ifndef OSLO_AERO
-   end if
-#endif
+   call ExpDayNite(fus,Nday, IdxDay, Nnite, IdxNite, 1, pcols, 1, pverp)
+   call ExpDayNite(fusc,Nday, IdxDay, Nnite, IdxNite, 1, pcols, 1, pverp)
+   call ExpDayNite(fds,Nday, IdxDay, Nnite, IdxNite, 1, pcols, 1, pverp)
+   call ExpDayNite(fdsc,Nday, IdxDay, Nnite, IdxNite, 1, pcols, 1, pverp)
+   call outfld('FUS     ', fus,  pcols, lchnk)
+   call outfld('FUSC    ', fusc, pcols, lchnk)
+   call outfld('FDS     ', fds,  pcols, lchnk)
+   call outfld('FDSC    ', fdsc, pcols, lchnk)
 
-#ifdef OSLO_AERO
+   ! OSLO_AERO begin
    if (idrf) then
       call outfld('FUSCDRF ', fusc, pcols, lchnk)
       call outfld('FDSCDRF ', fdsc, pcols, lchnk)
    endif
-#endif
+   ! OSLO_Aero end
 
 end subroutine rad_rrtmg_sw
 
 !-------------------------------------------------------------------------------
 
 subroutine radsw_init()
-!----------------------------------------------------------------------- 
-! 
-! Purpose: 
+!-----------------------------------------------------------------------
+!
+! Purpose:
 ! Initialize various constants for radiation scheme.
 !
 !-----------------------------------------------------------------------
@@ -678,7 +664,7 @@ subroutine radsw_init()
 
    ! Initialize rrtmg_sw
    call rrtmg_sw_ini
- 
+
 end subroutine radsw_init
 
 

--- a/src_cam/runtime_opts.F90
+++ b/src_cam/runtime_opts.F90
@@ -1,0 +1,208 @@
+module runtime_opts
+
+!-----------------------------------------------------------------------
+!
+! Provide driver level routine for making calls to the namelist readers
+! for the infrastructure and the dycore and physics parameterizations.
+!
+!-----------------------------------------------------------------------
+
+use shr_kind_mod,    only: r8=>shr_kind_r8
+
+implicit none
+private
+save
+
+public :: read_namelist
+
+!=======================================================================
+contains
+!=======================================================================
+
+subroutine read_namelist(nlfilename, single_column, scmlat, scmlon)
+
+   use cam_initfiles,       only: cam_initfiles_readnl
+   use constituents,        only: cnst_readnl
+
+   use phys_grid,           only: phys_grid_readnl
+
+   use chem_surfvals,       only: chem_surfvals_readnl
+   use check_energy,        only: check_energy_readnl
+   use radiation,           only: radiation_readnl
+   use carma_flags_mod,     only: carma_readnl
+   use co2_cycle,           only: co2_cycle_readnl
+   use scamMod,             only: scam_readnl
+
+   use spmd_utils,          only: spmd_utils_readnl
+   use cam_history,         only: history_readnl
+   use physconst,           only: physconst_readnl
+   use physics_buffer,      only: pbuf_readnl
+   use phys_control,        only: phys_ctl_readnl
+   ! OSLO_AERO begin
+   use oslo_aero_control,   only: oslo_aero_ctl_readnl
+   ! OSLO_AERO end
+   use wv_saturation,       only: wv_sat_readnl
+   use ref_pres,            only: ref_pres_readnl
+   use cam3_aero_data,      only: cam3_aero_data_readnl
+   use cam3_ozone_data,     only: cam3_ozone_data_readnl
+   use dadadj_cam,          only: dadadj_readnl
+   use macrop_driver,       only: macrop_driver_readnl
+   use microp_driver,       only: microp_driver_readnl
+   ! OSLO_AERO begin
+   use oslo_aero_microp,    only: oslo_aero_microp_readnl
+   ! OSLO_AERO end
+   use subcol,              only: subcol_readnl
+   use cloud_fraction,      only: cldfrc_readnl
+   use cldfrc2m,            only: cldfrc2m_readnl
+   use rk_stratiform,       only: rk_stratiform_readnl
+   use unicon_cam,          only: unicon_cam_readnl
+   use zm_conv_intr,        only: zm_conv_readnl
+   use hk_conv,             only: hkconv_readnl
+   use uwshcu,              only: uwshcu_readnl
+   use pkg_cld_sediment,    only: cld_sediment_readnl
+   use gw_drag,             only: gw_drag_readnl
+   use qbo,                 only: qbo_readnl
+   use iondrag,             only: iondrag_readnl
+   use waccmx_phys_intr,    only: waccmx_phys_ion_elec_temp_readnl
+   use phys_debug_util,     only: phys_debug_readnl
+   use conv_water,          only: conv_water_readnl
+   use rad_constituents,    only: rad_cnst_readnl
+   use radiation_data,      only: rad_data_readnl
+   use modal_aer_opt,       only: modal_aer_opt_readnl
+   use clubb_intr,          only: clubb_readnl
+   use chemistry,           only: chem_readnl
+   use prescribed_volcaero, only: prescribed_volcaero_readnl
+   use prescribed_strataero,only: prescribed_strataero_readnl
+   use aerodep_flx,         only: aerodep_flx_readnl
+   use solar_data,          only: solar_data_readnl
+   use tropopause,          only: tropopause_readnl
+   use aoa_tracers,         only: aoa_tracers_readnl
+   use prescribed_ozone,    only: prescribed_ozone_readnl
+   use prescribed_aero,     only: prescribed_aero_readnl
+   use prescribed_ghg,      only: prescribed_ghg_readnl
+   use aircraft_emit,       only: aircraft_emit_readnl
+   use cospsimulator_intr,  only: cospsimulator_intr_readnl
+   use vertical_diffusion,  only: vd_readnl
+   use rayleigh_friction,   only: rayleigh_friction_readnl
+
+   use cam_diagnostics,     only: diag_readnl
+   use radheat,             only: radheat_readnl
+#if ( defined OFFLINE_DYN )
+   use metdata,             only: metdata_readnl
+#endif
+   use offline_driver,      only: offline_driver_readnl
+   use inic_analytic_utils, only: analytic_ic_readnl
+   use rate_diags,          only: rate_diags_readnl
+   use tracers,             only: tracers_readnl
+   use nudging,             only: nudging_readnl
+
+   use dyn_comp,            only: dyn_readnl
+   use ionosphere_interface,only: ionosphere_readnl
+   use qneg_module,         only: qneg_readnl
+
+   !---------------------------Arguments-----------------------------------
+
+   character(len=*), intent(in) :: nlfilename
+   logical,          intent(in) :: single_column
+   real(r8),         intent(in) :: scmlat
+   real(r8),         intent(in) :: scmlon
+
+   !---------------------------Local variables-----------------------------
+   character(len=*), parameter ::  subname = "read_namelist"
+
+   !-----------------------------------------------------------------------
+
+   ! Call subroutines for modules to read their own namelist.
+   ! In some cases namelist default values may depend on settings from
+   ! other modules, so there may be an order dependence in the following
+   ! calls.
+   ! ***N.B.*** In particular, physconst_readnl should be called before
+   !            the other readnl methods in case that method is used to set
+   !            physical constants, some of which are set at runtime
+   !            by the physconst_readnl method.
+   ! Modules that read their own namelist are responsible for making sure
+   ! all processes receive the values.
+
+   call spmd_utils_readnl(nlfilename)
+   call phys_grid_readnl(nlfilename)
+   call physconst_readnl(nlfilename)
+!++bee 13 Oct 2015, need to fix the pbuf_global_allocate functionality, then
+!                   can uncomment the pbuf_readnl line
+!   call pbuf_readnl(nlfilename)
+   call cam_initfiles_readnl(nlfilename)
+   call cnst_readnl(nlfilename)
+   call history_readnl(nlfilename)
+   call chem_surfvals_readnl(nlfilename)
+   call phys_ctl_readnl(nlfilename)
+   call wv_sat_readnl(nlfilename)
+   call ref_pres_readnl(nlfilename)
+   call cam3_aero_data_readnl(nlfilename)
+   call cam3_ozone_data_readnl(nlfilename)
+   call dadadj_readnl(nlfilename)
+   call macrop_driver_readnl(nlfilename)
+   call microp_driver_readnl(nlfilename)
+   ! OSLO_AERO begin
+   call oslo_aero_microp_readnl(nlfilename)
+   ! OSLO_AERO end
+   call clubb_readnl(nlfilename)
+   call subcol_readnl(nlfilename)
+   call cldfrc_readnl(nlfilename)
+   call cldfrc2m_readnl(nlfilename)
+   call unicon_cam_readnl(nlfilename)
+   call zm_conv_readnl(nlfilename)
+   call rk_stratiform_readnl(nlfilename)
+   call hkconv_readnl(nlfilename)
+   call uwshcu_readnl(nlfilename)
+   call cld_sediment_readnl(nlfilename)
+   call gw_drag_readnl(nlfilename)
+   call qbo_readnl(nlfilename)
+   call iondrag_readnl(nlfilename)
+   call waccmx_phys_ion_elec_temp_readnl(nlfilename)
+   call phys_debug_readnl(nlfilename)
+   call conv_water_readnl(nlfilename)
+   call radiation_readnl(nlfilename)
+   call rad_cnst_readnl(nlfilename)
+   call rad_data_readnl(nlfilename)
+   call modal_aer_opt_readnl(nlfilename)
+   call chem_readnl(nlfilename)
+   call prescribed_volcaero_readnl(nlfilename)
+   call prescribed_strataero_readnl(nlfilename)
+   call solar_data_readnl(nlfilename)
+   call carma_readnl(nlfilename)
+   call tropopause_readnl(nlfilename)
+   call aoa_tracers_readnl(nlfilename)
+   call tracers_readnl(nlfilename)
+   call aerodep_flx_readnl(nlfilename)
+   call prescribed_ozone_readnl(nlfilename)
+   call prescribed_aero_readnl(nlfilename)
+   call prescribed_ghg_readnl(nlfilename)
+   call co2_cycle_readnl(nlfilename)
+   call aircraft_emit_readnl(nlfilename)
+   call cospsimulator_intr_readnl(nlfilename)
+   call diag_readnl(nlfilename)
+   call check_energy_readnl(nlfilename)
+   call radheat_readnl(nlfilename)
+   call vd_readnl(nlfilename)
+   call rayleigh_friction_readnl(nlfilename)
+#if ( defined OFFLINE_DYN )
+   call metdata_readnl(nlfilename)
+#endif
+   ! OSLO_AERO begin
+   call oslo_aero_ctl_readnl(nlfilename)
+   ! OSLO_AERO end
+   call offline_driver_readnl(nlfilename)
+   call analytic_ic_readnl(nlfilename)
+   call rate_diags_readnl(nlfilename)
+   call scam_readnl(nlfilename, single_column, scmlat, scmlon)
+   call nudging_readnl(nlfilename)
+
+   call dyn_readnl(nlfilename)
+   call ionosphere_readnl(nlfilename)
+   call qneg_readnl(nlfilename)
+
+end subroutine read_namelist
+
+
+!=======================================================================
+
+end module runtime_opts

--- a/src_cam/zm_microphysics.F90
+++ b/src_cam/zm_microphysics.F90
@@ -3,12 +3,12 @@ module  zm_microphysics
 !---------------------------------------------------------------------------------
 ! Purpose:
 !   CAM Interface for cumulus microphysics
-! 
-! Author: Xialiang Song and Guang Jun Zhang, June 2010  
+!
+! Author: Xialiang Song and Guang Jun Zhang, June 2010
 !---------------------------------------------------------------------------------
 
 use shr_kind_mod,      only: r8=>shr_kind_r8
-use spmd_utils,        only: masterproc    
+use spmd_utils,        only: masterproc
 use ppgrid,            only: pcols, pver, pverp
 use physconst,         only: gravit, rair, tmelt, cpair, rh2o, r_universal, mwh2o, rhoh2o
 use physconst,         only: latvap, latice
@@ -16,7 +16,7 @@ use physconst,         only: latvap, latice
 use ndrop,             only: activate_modal
 use ndrop_bam,         only: ndrop_bam_run
 use nucleate_ice,      only: nucleati
-use shr_spfn_mod,     only: erf => shr_spfn_erf 
+use shr_spfn_mod,     only: erf => shr_spfn_erf
 use shr_spfn_mod,     only: gamma => shr_spfn_gamma
 use wv_saturation,  only: svp_water, svp_ice
 use cam_logfile,       only: iulog
@@ -51,7 +51,7 @@ real(r8) :: xlf    ! latent heat of freezing
 real(r8) :: rhosn  ! bulk density snow
 real(r8) :: rhoi   ! bulk density ice
 
-real(r8) :: ac,bc,as,bs,ai,bi,ar,br  !fall speed parameters 
+real(r8) :: ac,bc,as,bs,ai,bi,ar,br  !fall speed parameters
 real(r8) :: ci,di    !ice mass-diameter relation parameters
 real(r8) :: cs,ds    !snow mass-diameter relation parameters
 real(r8) :: cr,dr    !drop mass-diameter relation parameters
@@ -193,18 +193,18 @@ contains
 
 subroutine zm_mphyi
 
-!----------------------------------------------------------------------- 
-! 
+!-----------------------------------------------------------------------
+!
 ! Purpose:
 ! initialize constants for the cumulus microphysics
 ! called from zm_conv_init() in zm_conv_intr.F90
 !
 ! Author: Xialiang Song, June 2010
-! 
+!
 !-----------------------------------------------------------------------
 
 !NOTE:
-! latent heats should probably be fixed with temperature 
+! latent heats should probably be fixed with temperature
 ! for energy conservation with the rest of the model
 ! (this looks like a +/- 3 or 4% effect, but will mess up energy balance)
 
@@ -242,7 +242,7 @@ subroutine zm_mphyi
 ! currently we assume spherical particles for cloud ice/snow
 ! m = cD^d
 
-        pi= 3.14159265358979323846_r8     
+        pi= 3.14159265358979323846_r8
 
 ! cloud ice mass-diameter relationship
 
@@ -298,7 +298,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                    fhmlm,  hmpim,  accslm, dlfm,   autoln, accrln, bergnn, fhtimn, fhtctn,    &
                    fhmln,  accsln, activn, dlfn,   autoim, accsim, difm,   nuclin, autoin,    &
                    accsin, hmpin,  difn,   trspcm, trspcn, trspim, trspin, lamc,   pgam  )
-   
+
 
 ! Purpose:
 ! microphysic parameterization for Zhang-McFarlane convection scheme
@@ -355,7 +355,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
   real(r8), intent(out) :: nr(pcols,pver)       ! rain number conc
   real(r8), intent(out) :: rprd(pcols,pver)     ! rate of production of precip at that layer
   real(r8), intent(out) :: sprd(pcols,pver)     ! rate of production of snow at that layer
-  real(r8), intent(out) :: frz(pcols,pver)      ! rate of freezing 
+  real(r8), intent(out) :: frz(pcols,pver)      ! rate of freezing
 
 
   real(r8), intent(inout) :: lamc(pcols,pver)     ! slope of cloud liquid size distr
@@ -402,7 +402,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
   real(r8) :: deltat                ! time step (s)
   real(r8) :: omsm                  ! number near unity for round-off issues
   real(r8) :: dum                   ! temporary dummy variable
-  real(r8) :: dum1                  ! temporary dummy variable 
+  real(r8) :: dum1                  ! temporary dummy variable
   real(r8) :: dum2                  ! temporary dummy variable
 
   real(r8) :: q(pcols,pver)         ! water vapor mixing ratio (kg/kg)
@@ -484,7 +484,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
   real(r8) :: qre                   ! dummy qr for conservation check
   real(r8) :: nre                   ! dummy nr for conservation check
   real(r8) :: qnie                  ! dummy qni for conservation check
-  real(r8) :: nse                   ! dummy ns for conservation check      
+  real(r8) :: nse                   ! dummy ns for conservation check
   real(r8) :: ratio                 ! parameter for conservation check
 
 ! sum of source/sink terms for cloud hydrometeor
@@ -516,7 +516,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
 
 ! bulk aerosol variables
   real(r8), allocatable :: naer2(:,:,:)    ! new aerosol number concentration (/m3)
-  real(r8), allocatable :: naer2h(:,:,:)   ! new aerosol number concentration (/m3) 
+  real(r8), allocatable :: naer2h(:,:,:)   ! new aerosol number concentration (/m3)
   real(r8), allocatable :: maerosol(:)     ! aerosol mass conc (kg/m3)
   real(r8) :: so4_num
   real(r8) :: soot_num
@@ -551,7 +551,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
   real(r8) :: nidep(pcols,pver)     !number conc of ice nuclei due to deoposion nucleation (hetero nuc) (1/m3)
   real(r8) :: niimm(pcols,pver)     !number conc of ice nuclei due to immersion freezing (hetero nuc) (1/m3)
 
-  real(r8) :: wpice, weff, fhom      ! unused dummies  
+  real(r8) :: wpice, weff, fhom      ! unused dummies
 
 ! loop array variables
   integer i,k, n, l
@@ -582,8 +582,8 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
 ! used in vertical velocity calculation
   real(r8) th(pcols,pver)
   real(r8) qh(pcols,pver)
-  real(r8) zkine(pcols,pver) 
-  real(r8) zbuo(pcols,pver)    
+  real(r8) zkine(pcols,pver)
+  real(r8) zbuo(pcols,pver)
   real(r8) zfacbuo, cwdrag, cwifrac, retv,  zbuoc
   real(r8) zbc, zbe,  zdkbuo, zdken
   real(r8) arcf(pcols,pver)
@@ -601,7 +601,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
   real(r8) :: niadj(pcols,pver)     !ice crystal num tendency due to adjustment
   real(r8) :: ncorg, niorg, total
 
-  real(r8) :: rhoh(pcols,pver)    ! air density (kg m-3) at interface 
+  real(r8) :: rhoh(pcols,pver)    ! air density (kg m-3) at interface
   real(r8) :: rhom(pcols,pver)    ! air density (kg m-3) at mid-level
   real(r8) :: tu(pcols,pver)      ! temperature in updraft (K)
 
@@ -611,7 +611,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
   real(r8) :: nai_bcphi, nai_dst1, nai_dst2, nai_dst3, nai_dst4
 
   real(r8) flxrm, mvtrm, flxrn, mvtrn, flxsm, mvtsm, flxsn, mvtsn
-  integer  nlr, nls 
+  integer  nlr, nls
 
   real(r8)  rmean, beta6, beta66, r6, r6c
   real(r8)  temp1, temp2, temp3, temp4   ! variable to store output which is not required by this routine
@@ -633,9 +633,9 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
         maerosol(aero%nbulk))
 
   end if
-	
+
   deltat= get_step_size()      !for FV dynamical core
-        
+
   ! parameters for scheme
   omsm=0.99999_r8
   zfacbuo = 0.5_r8/(1._r8+0.5_r8)
@@ -643,11 +643,11 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
   cwifrac = 0.5_r8
   retv    = 0.608_r8
   bergtsf = 1800._r8
- 
+
   ! initialize multi-level fields
   do i=1,il2g
      do k=1,pver
-        q(i,k) = qu(i,k)         
+        q(i,k) = qu(i,k)
         tu(i,k)= su(i,k) - grav/cp*zf(i,k)
         t(i,k) = su(i,k) - grav/cp*zf(i,k)
         p(i,k) = 100._r8*pm(i,k)
@@ -669,7 +669,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
         qcic(i,k) = 0._r8
         qiic(i,k) = 0._r8
         ncic(i,k) = 0._r8
-        niic(i,k) = 0._r8 
+        niic(i,k) = 0._r8
         qr(i,k)   = 0._r8
         qni(i,k)  = 0._r8
         nr(i,k)   = 0._r8
@@ -681,7 +681,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
         nimey(i,k) = 0._r8
         nihf(i,k)  = 0._r8
         nidep(i,k) = 0._r8
-        niimm(i,k) = 0._r8  
+        niimm(i,k) = 0._r8
         fhmrm(i,k) = 0._r8
 
         autolm(i,k) = 0._r8
@@ -736,10 +736,10 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
            qh (i,k) = qe(i,k)
            dz (i,k)  = zf(i,k) - zf(i,k+1)
            ph(i,k)   = p(i,k)
-        else 
+        else
            rhoh(i,k) = 0.5_r8*(p(i,k)+p(i,k-1))/(t(i,k)*rd)
            if (k .eq. pver) then
-              rhom(i,k) = p(i,k)/(rd*t(i,k))   
+              rhom(i,k) = p(i,k)/(rd*t(i,k))
            else
               rhom(i,k) = 2.0_r8*p(i,k)/(rd*(t(i,k)+t(i,k+1)))
            end if
@@ -752,10 +752,10 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
         mua(i,k) = 1.496E-6_r8*t(i,k)**1.5_r8/ &
            (t(i,k)+120._r8)
 
-        rho(i,k) = rhoh(i,k)    
+        rho(i,k) = rhoh(i,k)
 
         ! air density adjustment for fallspeed parameters
-        ! add air density correction factor to the power of 
+        ! add air density correction factor to the power of
         ! 0.54 following Heymsfield and Bansemer 2006
 
         arn(i,k)=ar*(rhosu/rho(i,k))**0.54_r8
@@ -791,7 +791,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
      do k=1,pver
         do i=1,il2g
            naer2(i,k,:)=0._r8
-           naer2h(i,k,:)=0._r8      
+           naer2h(i,k,:)=0._r8
            dum2l(i,k)=0._r8
            dum2i(i,k)=0._r8
         end do
@@ -815,7 +815,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
               else
                  naer2(i,k,m)=maerosol(m)*aero%num_to_mass_aer(m)
               end if
-              ntaer(i,k) = ntaer(i,k) + naer2(i,k,m) 
+              ntaer(i,k) = ntaer(i,k) + naer2(i,k,m)
            end do
         end do
      end do
@@ -858,7 +858,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
            ncde(i,k) = 0._r8
            nide(i,k) = 0._r8
            rprd(i,k) = 0._r8
-           sprd(i,k) = 0._r8  
+           sprd(i,k) = 0._r8
            frz(i,k)  = 0._r8
         end do
         goto 300
@@ -867,7 +867,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
      kqc(i) = 1
      kqi(i) = 1
      lcbase(i) = .true.
-     libase(i) = .true. 
+     libase(i) = .true.
 
      ! assign number of steps for iteration
      ! use 2 steps following Song and Zhang, 2011, J. Clim.
@@ -899,7 +899,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
            qiic(i,k)=0._r8
            qcic(i,k)=0._r8
            niic(i,k)=0._r8
-           ncic(i,k)=0._r8           
+           ncic(i,k)=0._r8
            qcimp(k) = .false.
            ncimp(k) = .false.
            qiimp(k) = .false.
@@ -949,15 +949,15 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
         end do
 
         do k = pver,msg+2,-1
-  
+
            if (k > jt(i) .and. k <= jb(i) .and. eps0(i) > 0._r8      &
               .and.mu(i,k).gt.0._r8 .and. mu(i,k-1).gt.0._r8) then
 
               ! initialize precip fallspeeds to zero
               if (it.eq.1) then
-                ums(k)=0._r8 
-                uns(k)=0._r8 
-                umr(k)=0._r8 
+                ums(k)=0._r8
+                uns(k)=0._r8
+                umr(k)=0._r8
                 unr(k)=0._r8
                 prf(k)=0._r8
                 pnrf(k)=0._r8
@@ -984,8 +984,8 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                  qric(i,k) = qr(i,k)
                  nsic(i,k) = ns(i,k)
                  nric(i,k) = nr(i,k)
-              else 
-                 if (k.le.kqc(i)) then   
+              else
+                 if (k.le.kqc(i)) then
                     qcic(i,k) = qc(i,k)
                     ncic(i,k) = nc(i,k)
 
@@ -995,7 +995,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                     flxrn = 0._r8
                     mvtrn = 0._r8
                     nlr = 0
-                    
+
                     do kk= k,jt(i)+3,-1
                        if (qr(i,kk-1) .gt. 0._r8) then
                            nlr = nlr + 1
@@ -1030,7 +1030,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                    flxsn = 0._r8
                    mvtsn = 0._r8
                    nls = 0
-  
+
                    do kk= k,jt(i)+3,-1
                      if (qni(i,kk-1) .gt. 0._r8) then
                        nls = nls + 1
@@ -1079,11 +1079,11 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                  kqi(i)=k
                  libase(i) = .false.
                  qiic(i,k) = dz(i,k)*cmei(i,k-1)/(mu(i,k-1)+dz(i,k)*du(i,k-1))
-                 niic(i,k) = qiic(i,k)/(4._r8/3._r8*pi*25.e-6_r8**3*rhoi)               
+                 niic(i,k) = qiic(i,k)/(4._r8/3._r8*pi*25.e-6_r8**3*rhoi)
               end if
 
               !***************************************************************************
-              ! get size distribution parameters based on in-cloud cloud water/ice 
+              ! get size distribution parameters based on in-cloud cloud water/ice
               ! these calculations also ensure consistency between number and mixing ratio
               !***************************************************************************
               ! cloud ice
@@ -1133,7 +1133,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
 
                  ! lammin, 50 micron diameter max mean size
                  lammin = (pgam(i,k)+1._r8)/40.e-6_r8
-                 lammax = (pgam(i,k)+1._r8)/1.e-6_r8 
+                 lammax = (pgam(i,k)+1._r8)/1.e-6_r8
 
                  if (lamc(i,k).lt.lammin) then
                     lamc(i,k) = lammin
@@ -1149,7 +1149,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
 
                  ! parameter to calculate droplet freezing
 
-                 cdist1(k) = ncic(i,k)/gamma(pgam(i,k)+1._r8) 
+                 cdist1(k) = ncic(i,k)/gamma(pgam(i,k)+1._r8)
               else
                  lamc(i,k) = 0._r8
                  cdist1(k) = 0._r8
@@ -1166,9 +1166,9 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                  qi(i,k) = 0._r8
                  ni(i,k) = 0._r8
               end if
-              
+
               !**************************************************************************
-              ! begin micropysical process calculations 
+              ! begin micropysical process calculations
               !**************************************************************************
 
               !.................................................................
@@ -1180,15 +1180,15 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
 
                  ! nprc is increase in rain number conc due to autoconversion
                  ! nprc1 is decrease in cloud droplet conc due to autoconversion
-                 ! Khrouditnov and Kogan (2000) 
+                 ! Khrouditnov and Kogan (2000)
 !                 prc(k) = 1350._r8*qcic(i,k)**2.47_r8*    &
 !                    (ncic(i,k)/1.e6_r8*rho(i,k))**(-1.79_r8)
 
                 ! Liu and Daum(2004)(modified), Wood(2005)
                 rmean = 1.e6_r8*((qcic(i,k)/ncic(i,k))/(4._r8/3._r8*pi*rhow))**(1._r8/3._r8)
 
-                if (rmean .ge. 15._r8) then 
- 
+                if (rmean .ge. 15._r8) then
+
                   beta6  = (1._r8+3._r8/rmean)**(1._r8/3._r8)
                   beta66 = (1._r8+3._r8/rmean)**2._r8
                   r6     = beta6*rmean
@@ -1208,13 +1208,13 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                  nprc(k)=0._r8
                  nprc1(k)=0._r8
               end if
- 
+
               ! provisional rain mixing ratio and number concentration (qric and nric)
               ! at boundary are estimated via autoconversion
 
               if (k.eq.kqc(i) .and. it.eq.1) then
                  qric(i,k) = prc(k)*dz(i,k)/0.55_r8
-                 nric(i,k) = nprc(k)*dz(i,k)/0.55_r8 
+                 nric(i,k) = nprc(k)*dz(i,k)/0.55_r8
                  qr(i,k) = 0.0_r8
                  nr(i,k) = 0.0_r8
               end if
@@ -1223,9 +1223,9 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
               ! Autoconversion of cloud ice to snow
               ! similar to Ferrier (1994)
 
-              call ice_autoconversion(t(i,k), qiic(i,k), lami(k), n0i(k), dcs, prci(k), nprci(k), 1)  
+              call ice_autoconversion(t(i,k), qiic(i,k), lami(k), n0i(k), dcs, prci(k), nprci(k), 1)
 
-              ! provisional snow mixing ratio and number concentration (qniic and nsic) 
+              ! provisional snow mixing ratio and number concentration (qniic and nsic)
               ! at boundary are estimated via autoconversion
 
               if (k.eq.kqi(i) .and. it.eq.1) then
@@ -1245,7 +1245,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                  nric(i,k)=0._r8
               end if
 
-              ! make sure number concentration is a positive number to avoid 
+              ! make sure number concentration is a positive number to avoid
               ! taking root of negative later
               nric(i,k)=max(nric(i,k),0._r8)
               nsic(i,k)=max(nsic(i,k),0._r8)
@@ -1309,7 +1309,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
 
                  ! provisional snow number and mass weighted mean fallspeed (m/s)
                  ums(k) = min(asn(i,k)*gamma(4._r8+bs)/(6._r8*lams(k)**bs),3.6_r8)
-                 uns(k) = min(asn(i,k)*gamma(1._r8+bs)/lams(k)**bs,3.6_r8) 
+                 uns(k) = min(asn(i,k)*gamma(1._r8+bs)/lams(k)**bs,3.6_r8)
               else
                  lams(k) = 0._r8
                  n0s(k) = 0._r8
@@ -1334,9 +1334,9 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
 
               call accrete_cloud_water_snow(t(i,k), rho(i,k), asn(i,k), uns(k), mua(i,k),  &
                      qcic(i,k), ncic(i,k), qniic(i,k), pgam(i,k), lamc(i,k), lams(k), n0s(k), &
-                     psacws(k), npsacws(k), 1) 
+                     psacws(k), npsacws(k), 1)
 
-              ! secondary ice production due to accretion of droplets by snow 
+              ! secondary ice production due to accretion of droplets by snow
               ! (Hallet-Mossop process) (from Cotton et al., 1986)
 
               call secondary_ice_production(t(i,k), psacws(k), msacwi(k), nsacwi(k), 1)
@@ -1359,7 +1359,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
               ! formula from Khrouditnov and Kogan (2000)
               ! gravitational collection kernel, droplet fall speed neglected
 
-              call accrete_cloud_water_rain(.true., qric(i,k), qcic(i,k), ncic(i,k), [1._r8], [0._r8], pra(k), npra(k), 1) 
+              call accrete_cloud_water_rain(.true., qric(i,k), qcic(i,k), ncic(i,k), [1._r8], [0._r8], pra(k), npra(k), 1)
 
               !.......................................................................
               ! Self-collection of rain drops
@@ -1384,7 +1384,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
 
               !........................................................................
               ! calculate vertical velocity in cumulus updraft
-              
+
               if (k.eq.jb(i)) then
                  zkine(i,jb(i)) = 0.5_r8
                  wu   (i,jb(i)) = 1._r8
@@ -1465,13 +1465,6 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
 
                     end if
 
-#ifndef OSLO_AERO
-                    call activate_modal(  &
-                       wu(i,k), wmix, wdiab, wmin, wmax,                 &
-                       t(i,k), rho(i,k), naermod, aero%nmodes, vaerosol, &
-                       hygro, fn, fm,                  &
-                       fluxn, fluxm, flux_fullact, in_cloud_in=in_cloud, smax_f=smax_f)
-#endif
                     do m = 1, aero%nmodes
                        nlsrc = nlsrc + fn(m)*naermod(m)  !  number nucleated
                     end do
@@ -1482,7 +1475,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                       write(iulog,*) "vaerosol(m)=",vaerosol,"aero%voltonumbhi(m)=",aero%voltonumbhi
                       write(iulog,*) "aero%voltonumblo(m)=",aero%voltonumblo,"k=",k,"i=",i
                       write(iulog,*) "aero%numg_a(i,k,m)=",aero%numg_a(i,k,:),"rho(i,k)=",rho(i,k)
-                      write(iulog,*) "aero%mmrg_a(i,k,l,m)=",aero%mmrg_a(i,k,:,:)                                    
+                      write(iulog,*) "aero%mmrg_a(i,k,l,m)=",aero%mmrg_a(i,k,:,:)
                     end if
 
                     dum2l(i,k) = nlsrc
@@ -1507,7 +1500,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                  ! assume aerosols already activated are equal number of existing droplets for simplicity
                  if (k.eq.kqc(i))  then
                     npccn(k) = dum2l(i,k)/deltat
-                 else  
+                 else
                     npccn(k) = (dum2l(i,k)-ncic(i,k))/deltat
                  end if
 
@@ -1539,7 +1532,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                  dst3_num = 0._r8
                  dst4_num = 0._r8
 
-                 if (aero%scheme == 'modal') then          
+                 if (aero%scheme == 'modal') then
 
                     !For modal aerosols, assume for the upper troposphere:
                     ! soot = accumulation mode
@@ -1551,44 +1544,44 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                     dmc  = 0.5_r8*(aero%mmrg_a(i,k-1,aero%coarse_dust_idx,aero%mode_coarse_idx)      &
                                   +aero%mmrg_a(i,k,aero%coarse_dust_idx,aero%mode_coarse_idx))
                     ssmc = 0.5_r8*(aero%mmrg_a(i,k-1,aero%coarse_nacl_idx,aero%mode_coarse_idx)      &
-                                  +aero%mmrg_a(i,k,aero%coarse_nacl_idx,aero%mode_coarse_idx))  
+                                  +aero%mmrg_a(i,k,aero%coarse_nacl_idx,aero%mode_coarse_idx))
                     if (dmc > 0._r8) then
-                        dst_num = dmc/(ssmc + dmc) *(aero%numg_a(i,k-1,aero%mode_coarse_idx)         & 
+                        dst_num = dmc/(ssmc + dmc) *(aero%numg_a(i,k-1,aero%mode_coarse_idx)         &
                                   + aero%numg_a(i,k,aero%mode_coarse_idx))*0.5_r8*rho(i,k)*1.0e-6_r8
-                    else 
+                    else
                        dst_num = 0.0_r8
                     end if
                     dgnum_aitken = 0.5_r8*(aero%dgnumg(i,k,aero%mode_aitken_idx)+   &
-                                           aero%dgnumg(i,k-1,aero%mode_aitken_idx))     
+                                           aero%dgnumg(i,k-1,aero%mode_aitken_idx))
                     if (dgnum_aitken > 0._r8) then
                        ! only allow so4 with D>0.1 um in ice nucleation
                        so4_num  = 0.5_r8*(aero%numg_a(i,k-1,aero%mode_aitken_idx)+          &
                           aero%numg_a(i,k,aero%mode_aitken_idx))*rho(i,k)*1.0e-6_r8         &
                           * (0.5_r8 - 0.5_r8*erf(log(0.1e-6_r8/dgnum_aitken)/  &
                           (2._r8**0.5_r8*log(aero%sigmag_aitken))))
-                    else 
-                       so4_num = 0.0_r8 
+                    else
+                       so4_num = 0.0_r8
                     end if
                     so4_num = max(0.0_r8, so4_num)
 
-                 else if (aero%scheme == 'bulk') then          
+                 else if (aero%scheme == 'bulk') then
 
-                    if (aero%idxsul > 0) then 
+                    if (aero%idxsul > 0) then
                        so4_num = naer2h(i,k,aero%idxsul)/25._r8 *1.0e-6_r8
                     end if
-                    if (aero%idxbcphi > 0) then 
+                    if (aero%idxbcphi > 0) then
                        soot_num = naer2h(i,k,aero%idxbcphi)/25._r8 *1.0e-6_r8
                     end if
-                    if (aero%idxdst1 > 0) then 
+                    if (aero%idxdst1 > 0) then
                        dst1_num = naer2h(i,k,aero%idxdst1)/25._r8 *1.0e-6_r8
                     end if
-                    if (aero%idxdst2 > 0) then 
+                    if (aero%idxdst2 > 0) then
                        dst2_num = naer2h(i,k,aero%idxdst2)/25._r8 *1.0e-6_r8
                     end if
-                    if (aero%idxdst3 > 0) then 
+                    if (aero%idxdst3 > 0) then
                        dst3_num = naer2h(i,k,aero%idxdst3)/25._r8 *1.0e-6_r8
                     end if
-                    if (aero%idxdst4 > 0) then 
+                    if (aero%idxdst4 > 0) then
                        dst4_num = naer2h(i,k,aero%idxdst4)/25._r8 *1.0e-6_r8
                     end if
                     dst_num = dst1_num + dst2_num + dst3_num + dst4_num
@@ -1605,7 +1598,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                        1.0e-20_r8, 0.0_r8, rho(i,k), so4_num, dst_num, soot_num, 1.0_r8, &
                        dum2i(i,k), nihf(i,k), niimm(i,k), nidep(i,k), nimey(i,k),   &
                        wpice, weff, fhom, temp1, temp2, temp3, temp4, .true.   )
-                 end if   
+                 end if
                  nihf(i,k)=nihf(i,k)*rho(i,k)           !  convert from #/kg -> #/m3)
                  niimm(i,k)=niimm(i,k)*rho(i,k)
                  nidep(i,k)=nidep(i,k)*rho(i,k)
@@ -1624,7 +1617,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                  dum2i(i,k)=0._r8
               end if
 
-              ! ice nucleation if activated nuclei exist at t<0C 
+              ! ice nucleation if activated nuclei exist at t<0C
 
               if (dum2i(i,k).gt.0._r8.and.t(i,k).lt.tmelt.and. &
                  relhum(i,k)*es(i,k)/esi(i,k).gt. 1.05_r8  .and. k.gt.jt(i)+1) then
@@ -1648,11 +1641,11 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
               !................................................................................
               ! Bergeron process
               ! If 0C< T <-40C and both ice and liquid exist
-         
+
               if (t(i,k).le.273.15_r8 .and. t(i,k).gt.233.15_r8 .and.  &
                  qiic(i,k).gt.0.5e-6_r8 .and. qcic(i,k).gt. qsmall)  then
                  plevap = qcic(i,k)/bergtsf
-                 prb(k) = max(0._r8,plevap) 
+                 prb(k) = max(0._r8,plevap)
                  nprb(k) = prb(k)/(qcic(i,k)/ncic(i,k))
               else
                  prb(k)=0._r8
@@ -1684,10 +1677,10 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                     naimm = (0.00291_r8*nai_bcphi + 32.3_r8*(nai_dst1 + nai_dst2 + &
                        nai_dst3 + nai_dst4))/ntaerh(i,k)             !m-3
                     if (ttend(k) .lt. 0._r8) then
-                       nnuccc(k) = -naimm*exp(273.15_r8-t(i,k))*ttend(k)*qcic(i,k)/rhow   ! kg-1s-1                        
+                       nnuccc(k) = -naimm*exp(273.15_r8-t(i,k))*ttend(k)*qcic(i,k)/rhow   ! kg-1s-1
                        mnuccc(k) = nnuccc(k)*qcic(i,k)/ncic(i,k)
                     end if
-                 else   
+                 else
                     if (.false.) then
                        ! immersion freezing (Diehl and Wurzler, 2004)
                        ttend(k) = -grav*wu(i,k)/cp/(1.0_r8+gamhat(i,k))
@@ -1711,7 +1704,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                  ! contact freezing (Young, 1974) with hooks into simulated dust
 
                  tcnt=(270.16_r8-t(i,k))**1.3_r8
-                 viscosity=1.8e-5_r8*(t(i,k)/298.0_r8)**0.85_r8    ! Viscosity (kg/m/s)          
+                 viscosity=1.8e-5_r8*(t(i,k)/298.0_r8)**0.85_r8    ! Viscosity (kg/m/s)
                  mfp=2.0_r8*viscosity/(ph(i,k)  &                  ! Mean free path (m)
                     *sqrt(8.0_r8*28.96e-3_r8/(pi*8.314409_r8*t(i,k))))
 
@@ -1719,7 +1712,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                  slip2=1.0_r8+(mfp/rn_dst2)*(1.257_r8+(0.4_r8*Exp(-(1.1_r8*rn_dst2/mfp))))
                  slip3=1.0_r8+(mfp/rn_dst3)*(1.257_r8+(0.4_r8*Exp(-(1.1_r8*rn_dst3/mfp))))
                  slip4=1.0_r8+(mfp/rn_dst4)*(1.257_r8+(0.4_r8*Exp(-(1.1_r8*rn_dst4/mfp))))
-                 
+
                  dfaer1=1.381e-23_r8*t(i,k)*slip1/(6._r8*pi*viscosity*rn_dst1)  ! aerosol diffusivity (m2/s)
                  dfaer2=1.381e-23_r8*t(i,k)*slip2/(6._r8*pi*viscosity*rn_dst2)
                  dfaer3=1.381e-23_r8*t(i,k)*slip3/(6._r8*pi*viscosity*rn_dst3)
@@ -1739,7 +1732,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                     dmc  = 0.5_r8*(aero%mmrg_a(i,k,aero%coarse_dust_idx,aero%mode_coarse_idx)     &
                                   +aero%mmrg_a(i,k-1,aero%coarse_dust_idx,aero%mode_coarse_idx))
                     ssmc = 0.5_r8*(aero%mmrg_a(i,k,aero%coarse_nacl_idx,aero%mode_coarse_idx)     &
-                                  +aero%mmrg_a(i,k-1,aero%coarse_nacl_idx,aero%mode_coarse_idx)) 
+                                  +aero%mmrg_a(i,k-1,aero%coarse_nacl_idx,aero%mode_coarse_idx))
                     if (dmc > 0.0_r8) then
                         nacon3 = dmc/(ssmc + dmc) * (aero%numg_a(i,k,aero%mode_coarse_idx)     &
                                  + aero%numg_a(i,k-1,aero%mode_coarse_idx))*0.5_r8*rho(i,k)
@@ -1773,7 +1766,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                  !                 mnuccc(k)=mnuccc(k)*dum
                  !                 nnuccc(k)=nnuccd(k)
                  !              end if
- 
+
               else
                  mnuccc(k) = 0._r8
                  nnuccc(k) = 0._r8
@@ -1815,14 +1808,14 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
               mtimec=deltat/900._r8
 
               ! conservation of qc
-              ! ice mass production from ice nucleation(deposition/cond.-freezing), mnuccd, 
+              ! ice mass production from ice nucleation(deposition/cond.-freezing), mnuccd,
               ! is considered as a part of cmei.
-                            
+
               qce = mu(i,k)*qc(i,k)-fholm(i,k) +dz(i,k)*cmel(i,k-1)
               dum = arcf(i,k)*(pra(k)+prc(k)+prb(k)+mnuccc(k)+mnucct(k)+msacwi(k)+   &
                                psacws(k))*dz(i,k)
               if( qce.lt.0._r8)  then
-                 qcimp(k) = .true.              
+                 qcimp(k) = .true.
                  prc(k) = 0._r8
                  pra(k) = 0._r8
                  prb(k) = 0._r8
@@ -1836,15 +1829,15 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                  pra(k) = pra(k)*ratio
                  prb(k) = prb(k)*ratio
                  mnuccc(k) = mnuccc(k)*ratio
-                 mnucct(k) = mnucct(k)*ratio  
-                 msacwi(k) = msacwi(k)*ratio  
-                 psacws(k) = psacws(k)*ratio 
+                 mnucct(k) = mnucct(k)*ratio
+                 msacwi(k) = msacwi(k)*ratio
+                 psacws(k) = psacws(k)*ratio
               end if
 
               ! conservation of nc
               nce = mu(i,k)*nc(i,k)-fholn(i,k) + (arcf(i,k)*npccn(k)*mtimec)*dz(i,k)
               dum = arcf(i,k)*dz(i,k)*(nprc1(k)+npra(k)+nnuccc(k)+nnucct(k)+ &
-                 npsacws(k)+ nprb(k) )              
+                 npsacws(k)+ nprb(k) )
               if (nce.lt.0._r8) then
                  ncimp(k) = .true.
                  nprc1(k) = 0._r8
@@ -1852,21 +1845,21 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                  nnuccc(k) = 0._r8
                  nnucct(k) = 0._r8
                  npsacws(k) = 0._r8
-                 nprb(k) = 0._r8                                  
+                 nprb(k) = 0._r8
               else if (dum.gt.nce) then
-                 ratio = nce/dum*omsm 
+                 ratio = nce/dum*omsm
                  nprc1(k) = nprc1(k)*ratio
                  npra(k) = npra(k)*ratio
                  nnuccc(k) = nnuccc(k)*ratio
-                 nnucct(k) = nnucct(k)*ratio  
+                 nnucct(k) = nnucct(k)*ratio
                  npsacws(k) = npsacws(k)*ratio
-                 nprb(k) = nprb(k)*ratio                           
+                 nprb(k) = nprb(k)*ratio
               end if
- 
+
               ! conservation of qi
               qie = mu(i,k)*qi(i,k)+fholm(i,k) +dz(i,k)*(cmei(i,k-1) +  &
                     ( mnuccc(k)+mnucct(k)+msacwi(k)+prb(k))*arcf(i,k) )
-              dum = arcf(i,k)*(prci(k)+ prai(k))*dz(i,k) 
+              dum = arcf(i,k)*(prci(k)+ prai(k))*dz(i,k)
               if (qie.lt.0._r8) then
                  qiimp(k) = .true.
                  prci(k) = 0._r8
@@ -1955,7 +1948,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
               !*****************************************************************************
 
               if (k.le.kqc(i))   then
-                 qctend(i,k) = (-pra(k)-prc(k)-prb(k)-mnuccc(k)-mnucct(k)-msacwi(k)- &   
+                 qctend(i,k) = (-pra(k)-prc(k)-prb(k)-mnuccc(k)-mnucct(k)-msacwi(k)- &
                                 psacws(k))
 
                  qitend(i,k) = (prb(k)+mnuccc(k)+mnucct(k)+msacwi(k)-prci(k)- prai(k))
@@ -1966,8 +1959,8 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
 
                  ! multiply activation/nucleation by mtime to account for fast timescale
 
-                 nctend(i,k) = npccn(k)*mtimec+(-nnuccc(k)-nnucct(k)-npsacws(k) &    
-                               -npra(k)-nprc1(k)-nprb(k))                           
+                 nctend(i,k) = npccn(k)*mtimec+(-nnuccc(k)-nnucct(k)-npsacws(k) &
+                               -npra(k)-nprc1(k)-nprb(k))
 
                  nitend(i,k) = nnuccd(k)*mtime+(nnuccc(k)+ nnucct(k)+nsacwi(k)-nprci(k)- &
                                nprai(k))
@@ -1996,7 +1989,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                  accsln(i,k-1) = -npsacws(k)*arcf(i,k)
                  activn(i,k-1) = npccn(k)*mtimec*arcf(i,k)
                  fhmln(i,k-1)  = -fholn(i,k)/dz(i,k)
-                 
+
                  !cloud ice------------------------
 
                  autoim(i,k-1) = -prci(k)*arcf(i,k)
@@ -2025,7 +2018,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
               if ( k.le.kqi(i) ) then
                  qni(i,k-1) = 1._r8/mu(i,k-1)*                                    &
                     (mu(i,k)*qni(i,k)+dz(i,k)*(qnitend(i,k)+psf(k))*arcf(i,k) )
-                 
+
                  ns(i,k-1) = 1._r8/mu(i,k-1)*                                    &
                     (mu(i,k)*ns(i,k)+dz(i,k)*(nstend(i,k)+pnsf(k))*arcf(i,k) )
 
@@ -2062,7 +2055,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
               if (t(i,k-1) < 233.15_r8 .and. qr(i,k-1) > 0._r8) then
 
                  ! make sure freezing rain doesn't increase temperature above threshold
-                 dum = xlf/cp*qr(i,k-1) 
+                 dum = xlf/cp*qr(i,k-1)
                  if (t(i,k-1)+dum.gt.233.15_r8) then
                     dum = -(t(i,k-1)-233.15_r8)*cp/xlf
                     dum = dum/qr(i,k-1)
@@ -2086,8 +2079,8 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
 
                   qcde(i,k) = qc(i,k-1)
 
-                  nc(i,k-1) = (mu(i,k)*nc(i,k) -fholn(i,k) +dz(i,k)*nctend(i,k)*arcf(i,k) )   & 
-                              /(mu(i,k-1)+dz(i,k)*du(i,k-1)) 
+                  nc(i,k-1) = (mu(i,k)*nc(i,k) -fholn(i,k) +dz(i,k)*nctend(i,k)*arcf(i,k) )   &
+                              /(mu(i,k-1)+dz(i,k)*du(i,k-1))
 
                   ncde(i,k) = nc(i,k-1)
               else
@@ -2109,15 +2102,15 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                  write(iulog,*) "mu(i,k-1)=",mu(i,k-1),"mu(i,k)=",mu(i,k),"nc(i,k)=",ni(i,k)
                  write(iulog,*) "dz(i,k)=",dz(i,k),"du(i,k-1)=",du(i,k-1),"nctend(i,k)=",nctend(i,k)
                  write(iulog,*) "eu(i,k-1)=",eu(i,k-1)
-              end if              
-  
+              end if
+
               ! cloud ice
-              if( k.le.kqi(i)) then  
+              if( k.le.kqi(i)) then
                   qi(i,k-1) = (mu(i,k)*qi(i,k)+fholm(i,k) +dz(i,k)*qitend(i,k)*arcf(i,k)      &
                                +dz(i,k)*cmei(i,k-1) )/(mu(i,k-1)+dz(i,k)*du(i,k-1))
 
                   qide(i,k) = qi(i,k-1)
-                
+
                   ni(i,k-1) = (mu(i,k)*ni(i,k)+fholn(i,k)+dz(i,k)*nitend(i,k)*arcf(i,k) )   &
                               /(mu(i,k-1)+dz(i,k)*du(i,k-1))
 
@@ -2129,7 +2122,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
 
               if (qi(i,k-1).lt.0._r8) write(iulog,*) "negative qi(i,k-1)=",qi(i,k-1)
               difm(i,k-1) = -du(i,k-1)*qide(i,k)
-              difn(i,k-1) = -du(i,k-1)*nide(i,k)         
+              difn(i,k-1) = -du(i,k-1)*nide(i,k)
 
               if (qi(i,k-1).le. 0._r8) then
                  qi(i,k-1)=0._r8
@@ -2137,12 +2130,12 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
               end if
 
 
-              if (ni(i,k-1).lt. 0._r8) then  
+              if (ni(i,k-1).lt. 0._r8) then
                  write(iulog,*) "ni(i,k-1)=",ni(i,k-1),"k-1=",k-1,"arcf(i,k)=",arcf(i,k)
                  write(iulog,*) "mu(i,k-1)=",mu(i,k-1),"mu(i,k)=",mu(i,k),"ni(i,k)=",ni(i,k)
                  write(iulog,*) "dz(i,k)=",dz(i,k),"du(i,k-1)=",du(i,k-1),"nitend(i,k)=",nitend(i,k)
                  write(iulog,*) "eu(i,k-1)=",eu(i,k-1)
-              end if            
+              end if
 
 
               frz(i,k-1) = cmei(i,k-1) + arcf(i,k)*(prb(k)+mnuccc(k)+mnucct(k)+msacwi(k)+   &
@@ -2154,10 +2147,10 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
               ! these calculations also ensure consistency between number and mixing ratio
 
               ! following equation(2,3,4) of Morrison and Gettelman, 2008, J. Climate.
-              ! Gamma(n)= (n-1)! 
+              ! Gamma(n)= (n-1)!
               ! lamc <-> lambda for cloud liquid water
               ! pgam <-> meu    for cloud liquid water
-              ! meu=0 for ice,rain and snow         
+              ! meu=0 for ice,rain and snow
               !*******************************************************************************
 
               ! cloud ice
@@ -2203,7 +2196,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                  if (total .ne. 0._r8) then
                     nuclin(i,k-1) = nuclin(i,k-1) + nuclin(i,k-1)*niadj(i,k-1)/total
                     fhtimn(i,k-1) = fhtimn(i,k-1) + fhtimn(i,k-1)*niadj(i,k-1)/total
-                    fhtctn(i,k-1) = fhtctn(i,k-1) + fhtctn(i,k-1)*niadj(i,k-1)/total 
+                    fhtctn(i,k-1) = fhtctn(i,k-1) + fhtctn(i,k-1)*niadj(i,k-1)/total
                     fhmln (i,k-1) = fhmln (i,k-1) + fhmln (i,k-1)*niadj(i,k-1)/total
                     hmpin (i,k-1) = hmpin (i,k-1) + hmpin (i,k-1)*niadj(i,k-1)/total
                  else
@@ -2218,12 +2211,12 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                  total = autoin(i,k-1)+accsin(i,k-1)
                  if (total .ne. 0._r8) then
                     autoin(i,k-1) = autoin(i,k-1) + autoin(i,k-1)*niadj(i,k-1)/total
-                    accsin(i,k-1) = accsin(i,k-1) + accsin(i,k-1)*niadj(i,k-1)/total 
+                    accsin(i,k-1) = accsin(i,k-1) + accsin(i,k-1)*niadj(i,k-1)/total
                  else
                     total = 2._r8
                     autoin(i,k-1) = autoin(i,k-1) + niadj(i,k-1)/total
-                    accsin(i,k-1) = accsin(i,k-1) + niadj(i,k-1)/total  
-                 end if  
+                    accsin(i,k-1) = accsin(i,k-1) + niadj(i,k-1)/total
+                 end if
               end if
 
               !................................................................................
@@ -2235,7 +2228,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                  nc(i,k-1)=min(nc(i,k-1),qc(i,k-1)*1.e20_r8)
                  ! and make sure it's non-negative
                  ! nc(i,k-1) = max(nc(i,k-1), 0._r8)
-                 if (nc(i,k-1).lt. 0._r8) write(iulog,*) "nc(i,k-1)=",nc(i,k-1) 
+                 if (nc(i,k-1).lt. 0._r8) write(iulog,*) "nc(i,k-1)=",nc(i,k-1)
 
                  ! get pgam from fit to observations of martin et al. 1994
 
@@ -2274,9 +2267,9 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
 
               ncde(i,k)   = nc(i,k-1)
               dlfn(i,k-1) = -du(i,k-1)*ncde(i,k)
-              
+
               ncadj(i,k-1) = (nc(i,k-1)- ncorg)*mu(i,k-1)/dz(i,k)
-              if (ncadj(i,k-1) .lt. 0._r8) then 
+              if (ncadj(i,k-1) .lt. 0._r8) then
                  activn(i,k-1) = activn(i,k-1) + ncadj(i,k-1)
               else if (ncadj(i,k-1) .gt. 0._r8) then
                 total = autoln(i,k-1)+accrln(i,k-1)+bergnn(i,k-1)+accsln(i,k-1)
@@ -2339,7 +2332,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                  end if
 
                  unr(k-1) = min(arn(i,k-1)*gamma(1._r8+br)/lamr(k-1)**br,10._r8)
-                 umr(k-1) = min(arn(i,k-1)*gamma(4._r8+br)/(6._r8*lamr(k-1)**br),10._r8)                   
+                 umr(k-1) = min(arn(i,k-1)*gamma(4._r8+br)/(6._r8*lamr(k-1)**br),10._r8)
               else
                  lamr(k-1) = 0._r8
                  n0r(k-1) = 0._r8
@@ -2378,7 +2371,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
               end if
 
               rprd(i,k-1)= (qnitend(i,k) + qrtend(i,k))*arcf(i,k)
-              sprd(i,k-1)=  qnitend(i,k) *arcf(i,k) -fhmrm(i,k-1)       
+              sprd(i,k-1)=  qnitend(i,k) *arcf(i,k) -fhmrm(i,k-1)
 
            end if  ! k<jlcl
 
@@ -2404,7 +2397,7 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
               nc(i,k-1)=0._r8
            end if
 
-           ! make sure number concentration is a positive number to avoid 
+           ! make sure number concentration is a positive number to avoid
            ! taking root of negative
 
            nr(i,k-1)=max(nr(i,k-1),0._r8)


### PR DESCRIPTION
Changes to have the shadow files be noresm specific and have a minimal set of #CPP-ifdefs.
This will need to be accompanied by a CAM PR as well to point to this external.
Testing summary to follow:

- Verified that SMS_Ln9.f19_f19_mtn14.NF1850norbc_aer2014.betzy_intel.cam-aerocom is bfb with noresm2_1_develop EXCEPT for 29 fields which are aerocom specific and out of which many are round-off level different. The others seem to be different only after 7 decimal places.
- Verified that PEM_Ln9.f09_f09_mtn14.NF1850norbc.betzy_intel.cam-outfrq9s passed

Recommendations for other tests to be carried out would be helpful. Should the entire CAM test suite be run for this PR?