### PR TITLE
change outname name from AOD_VIS to AODVIS

### DIFF
--- a/src/oslo_aero_optical_params.F90
+++ b/src/oslo_aero_optical_params.F90
@@ -533,11 +533,11 @@ contains
     end do   ! icol
 
     ! Extinction and absorption for 0.55 um for the total aerosol, and AODs
-    call outfld('AOD_VIS ',aodvis ,pcols,lchnk)
+    call outfld('AODVIS  ',aodvis ,pcols,lchnk)
     call outfld('ABSVIS  ',absvis ,pcols,lchnk)
     call outfld('AODVVOLC',aodvisvolc ,pcols,lchnk)
     call outfld('ABSVVOLC',absvisvolc ,pcols,lchnk)
-    call outfld('BVISVOLC',bevisvolc ,pcols,lchnk)
+    call outfld('BVISVOLC',bevisvolc  ,pcols,lchnk)
 
 #ifdef AEROCOM
     ! Extinction and absorption for 0.55 um for the total aerosol, and AODs


### PR DESCRIPTION
This is needed to compare with trop_mam4_output and is also more consistent.