### PR TITLE
Implement KeyClim cloud2 modifications for Oslo Aero

### DIFF
--- a/src_cam/vertical_diffusion.F90
+++ b/src_cam/vertical_diffusion.F90
@@ -74,7 +74,7 @@ use phys_control,     only : phys_getopts
 use time_manager,     only : is_first_step
 ! OSLO_AERO begin
 use oslo_aero_share, only: getNumberOfAerosolTracers, fillAerosolTracerList
-! OSLO_AERO enda
+! OSLO_AERO end
 
 
 implicit none


### PR DESCRIPTION
- oslo_aero_hetfrz.F90
  - Scale bc, dst1, and dst3 by a new namelist variable, hetfrz_aer_scalfac.
  - hetfrz_aer_scalfac replaces hetfrz_bc_scalfac and hetfrz_dust_scalfac from the KeyClim cloud2 code.
  - Add diagnostics for new scaled fields
  - Scale total_aer_num, total_aer_num, uncoated_aer_num, and total_interstitial_aer_num by the same factor for the hetfrz_classnuc_calc computation.

addresses NorESMhub/NorESM#465