### PR TITLE
add sum diagnostics and bugfix for oslo_aero 

### DIFF
--- a/src/oslo_aero_dust_sediment.F90
+++ b/src/oslo_aero_dust_sediment.F90
@@ -60,7 +60,7 @@ contains
           vfall(i) = vland*landfrac(i) + vocean*(1._r8-landfrac(i))
 
           ! fall velocity (assume positive downward)
-          pvdust(i,k+1) = vfall(i)     
+          pvdust(i,k+1) = vfall(i)
        end do
     end do
   end subroutine oslo_aero_dust_sediment_vel
@@ -70,7 +70,7 @@ contains
        dustmr, pvdust, dusttend, sfdust, dusttend_to_ll_out )
 
     !----------------------------------------------------------------------
-    !  Apply Particle Gravitational Sedimentation 
+    !  Apply Particle Gravitational Sedimentation
     ! -> note that pvel is at the interfaces (loss from cell is based on pvel(k+1))
     !----------------------------------------------------------------------
 
@@ -123,7 +123,7 @@ contains
        end do
     end do
 
-    ! Now calculate the tendencies 
+    ! Now calculate the tendencies
     do k = 1,pver
        do i = 1,ncol
           ! net flux into cloud changes cloud dust/ice (all flux is out of cloud)
@@ -208,7 +208,7 @@ contains
     integer   , intent(in)  :: ncol                      ! number of colums to process
     real (r8) , intent(in)  :: x(pcols, pverp)
     real (r8) , intent(in)  :: f(pcols, pverp)
-    real (r8) , intent(out) :: fdot(pcols, pverp)
+    real (r8) , intent(inout) :: fdot(pcols, pverp)
     real (r8) , intent(in)  :: xin(pcols)
     real (r8) , intent(out) :: fxdot(pcols)
     real (r8) , intent(out) :: fxdd(pcols)
@@ -228,9 +228,9 @@ contains
     real (r8) :: cfint
     real (r8) :: cfnew
     real (r8) :: xins(pcols)
-    real (r8) :: a, b, c ! the minmod function 
-    real (r8) :: minmod ! the minmod function 
-    real (r8) :: medan ! the minmod function 
+    real (r8) :: a, b, c ! the minmod function
+    real (r8) :: minmod ! the minmod function
+    real (r8) :: medan ! the minmod function
 
     minmod(a,b) = 0.5_r8*(sign(1._r8,a) + sign(1._r8,b))*min(abs(a),abs(b))
     medan(a,b,c) = a + minmod(b-a,c-a)
@@ -240,7 +240,7 @@ contains
        intz(i) = 0
     end do
 
-    ! first find the interval 
+    ! first find the interval
     do k =  1,pverp-1
        do i = 1,ncol
           if ((xins(i)-x(i,k))*(x(i,k+1)-xins(i)).ge.0._r8) then
@@ -335,8 +335,8 @@ contains
     real(r8) :: tmin
     real(r8) :: tmax
     real(r8) :: delxh(pcols,pverp)
-    real(r8) :: minmod           ! the minmod function 
-    real(r8) :: medan            ! the minmod function 
+    real(r8) :: minmod           ! the minmod function
+    real(r8) :: medan            ! the minmod function
 
     minmod(a,b) = 0.5_r8*(sign(1._r8,a) + sign(1._r8,b))*min(abs(a),abs(b))
     medan(a,b,c) = a + minmod(b-a,c-a)
@@ -391,14 +391,14 @@ contains
     do k = 3,pver-1
        do i = 1,ncol
           ! p prime at k-0.5
-          ppl(i,k)=sh(i,k-1) + dh(i,k-1)*delxh(i,k-1)  
+          ppl(i,k)=sh(i,k-1) + dh(i,k-1)*delxh(i,k-1)
 
           ! p prime at k+0.5
           ppr(i,k)=sh(i,k)   - dh(i,k)  *delxh(i,k)
           t = minmod(ppl(i,k),ppr(i,k))
 
           ! derivate from parabola thru f(i,k-1), f(i,k), and f(i,k+1)
-          pp = sh(i,k-1) + d(i,k)*delxh(i,k-1) 
+          pp = sh(i,k-1) + d(i,k)*delxh(i,k-1)
 
           ! quartic estimate of fdot
           fdot(i,k) = pp - delxh(i,k-1)*delxh(i,k)*(eh(i,k-1)*(x(i,k+2)-x(i,k)) &

--- a/src/oslo_aero_dust_sediment.F90
+++ b/src/oslo_aero_dust_sediment.F90
@@ -67,7 +67,7 @@ contains
 
   !===============================================================================
   subroutine oslo_aero_dust_sediment_tend ( ncol,   dtime,  pint, pmid, pdel, t, &
-       dustmr, pvdust, dusttend, sfdust, dusttend_to_ll_out )
+       dustmr, pvdust, dusttend, sfdust)
 
     !----------------------------------------------------------------------
     !  Apply Particle Gravitational Sedimentation
@@ -85,7 +85,6 @@ contains
     real(r8), intent(in)  :: pvdust (pcols,pverp)      ! vertical velocity of dust drops  (Pa/s)
     real(r8), intent(out) :: dusttend(pcols,pver)      ! dust tend
     real(r8), intent(out) :: sfdust(pcols)             ! surface flux of dust (rain, kg/m/s)
-    real(r8),intent(out),optional  :: dusttend_to_ll_out(pcols) ! fluxes at the interfaces, dust (positive = down
 
     ! Local variables
     integer  :: i,k
@@ -133,11 +132,6 @@ contains
 
     ! convert flux out the bottom to mass units Pa -> kg/m2/s
     sfdust(:ncol) = fxdust(:ncol,pverp) / (dtime*gravit)
-
-    ! fluxes at the interface
-    if(present(dusttend_to_ll_out))then
-       dusttend_to_ll_out(1:ncol) = fxdust(:ncol,pver)/(dtime*pdel(:ncol,pver))
-    end if
 
   end subroutine oslo_aero_dust_sediment_tend
 

--- a/src_cam/chemistry.F90
+++ b/src_cam/chemistry.F90
@@ -334,11 +334,9 @@ end function chem_is
     use tracer_cnst,      only: tracer_cnst_defaultopts, tracer_cnst_setopts
     use tracer_srcs,      only: tracer_srcs_defaultopts, tracer_srcs_setopts
     use aero_model,       only: aero_model_readnl
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     use oslo_aero_dust,   only: oslo_aero_dust_readnl
-#else
-    use dust_model,       only: dust_readnl
-#endif
+    ! OSLO_AERO end
     use gas_wetdep_opts,  only: gas_wetdep_readnl
     use mo_drydep,        only: drydep_srf_file
     use mo_sulf,          only: sulf_readnl
@@ -545,11 +543,9 @@ end function chem_is
         tracer_srcs_fixed_tod_in = tracer_srcs_fixed_tod )
 
    call aero_model_readnl(nlfile)
-#ifdef OSLO_AERO
+   ! OSLO_AERO begin
    call oslo_aero_dust_readnl(nlfile)
-#else
-   call dust_readnl(nlfile)
-#endif
+   ! OSLO_AERO end
 !
    call gas_wetdep_readnl(nlfile)
    call gcr_ionization_readnl(nlfile)
@@ -836,13 +832,10 @@ end function chem_is_active
   contains
 
     pure logical function aero_has_emis(spcname)
-#ifdef OSLO_AERO
+      ! OSLO_AERO begin
       use oslo_aero_seasalt, only: seasalt_names
       use oslo_aero_dust,    only: dust_names
-#else
-      use seasalt_model, only : seasalt_names
-      use dust_model, only: dust_names
-#endif
+      ! OSLO_AERO end
 
       character(len=*),intent(in) :: spcname
 
@@ -936,13 +929,6 @@ end function chem_is_active
 
     ! fire surface emissions if not elevated forcing
     call fire_emissions_srf( lchnk, ncol, cam_in%fireflx, cam_in%cflx )
-
-#ifndef OSLO_AERO
-    ! TODO oslo_aero: should this be added to OSLO_AERO - there was
-    ! not a pre-existing ocean salinity file capability air-sea
-    ! exchange of trace gases
-    call ocean_emis_getflux(lchnk, ncol, state, cam_in%u10, cam_in%sst, cam_in%ocnfrac, cam_in%icefrac, cam_in%cflx)
-#endif
 
   end subroutine chem_emissions
 

--- a/src_cam/mo_chm_diags.F90
+++ b/src_cam/mo_chm_diags.F90
@@ -558,13 +558,14 @@ contains
             'mmr_'//trim(aerosol_type_name(n))//' mmr of aerosol type')
        call add_default('mmr_'//trim(aerosol_type_name(n)), 1, ' ')
     end do
+    ! OSLO_AERO end
+
     call addfld('sum_SO4'  , (/ 'lev' /), 'A', 'kg/kg ', 'sum of SO4 concentrations')
     call addfld('sum_BC'   , (/ 'lev' /), 'A', 'kg/kg ', 'sum of BC concentrations')
     call addfld('sum_OM'   , (/ 'lev' /), 'A', 'kg/kg ', 'sum of OM concentrations')
     call addfld('sum_DST'  , (/ 'lev' /), 'A', 'kg/kg ', 'sum of DST concentrations')
     call addfld('sum_SS'   , (/ 'lev' /), 'A', 'kg/kg ', 'sum of SS concentrations')
     call addfld('sum_SOA'  , (/ 'lev' /), 'A', 'kg/kg ', 'sum of SOA concentrations')
-    call addfld('sum_GASES', (/ 'lev' /), 'A', 'kg/kg ', 'sum of GASES concentrations')
 
     call add_default('sum_SO4'  , 1, ' ')
     call add_default('sum_BC'   , 1, ' ')
@@ -572,8 +573,6 @@ contains
     call add_default('sum_DST'  , 1, ' ')
     call add_default('sum_SS'   , 1, ' ')
     call add_default('sum_SOA'  , 1, ' ')
-    call add_default('sum_GASES', 1, ' ')
-    ! OSLO_AERO end
 
     call addfld( 'dry_deposition_NOy_as_N', horiz_only, 'I', 'kg/m2/s', 'NOy dry deposition flux ' )
     call addfld( 'DF_SOX', horiz_only, 'I', 'kg/m2/s', 'SOx dry deposition flux ' )
@@ -668,7 +667,6 @@ contains
     real(r8) :: sum_dst(ncol,pver)
     real(r8) :: sum_ss(ncol,pver)
     real(r8) :: sum_soa(ncol,pver)
-    real(r8) :: sum_gases(ncol,pver)
 
     real(r8) :: area(ncol), mass(ncol,pver)
     real(r8) :: wgt
@@ -923,7 +921,9 @@ contains
     sum_dst(:,:) = 0._r8
     sum_ss(:,:) = 0._r8
     sum_soa(:,:) = 0._r8
-    sum_gases(:,:) = 0._r8
+
+    ! add all the nums in one variable for mam
+
 
     do m = 1,gas_pcnst
        spc_name = trim(solsym(m))
@@ -939,16 +939,6 @@ contains
           sum_ss(:ncol,:) = sum_ss(:ncol,:) + mmr(:ncol,:,m)
        else if (spc_name(1:4) == 'SOA_') then
           sum_soa(:ncol,:) = sum_soa(:ncol,:) + mmr(:ncol,:,m)
-       else if (trim(spc_name) == 'H2SO4') then
-          sum_gases(:ncol,:) = sum_gases(:ncol,:) + mmr(:ncol,:,m)
-       else if (trim(spc_name) == 'SOA_LV') then
-          sum_gases(:ncol,:) = sum_gases(:ncol,:) + mmr(:ncol,:,m)
-       else if (trim(spc_name) == 'SOA_SV') then
-          sum_gases(:ncol,:) = sum_gases(:ncol,:) + mmr(:ncol,:,m)
-       else if (trim(spc_name) == 'monoterp') then
-          sum_gases(:ncol,:) = sum_gases(:ncol,:) + mmr(:ncol,:,m)
-       else if (trim(spc_name) == 'isoprene') then
-          sum_gases(:ncol,:) = sum_gases(:ncol,:) + mmr(:ncol,:,m)
        end if
     end do
     call outfld( 'sum_SO4'   , sum_so4(:ncol,:)   , ncol ,lchnk )
@@ -957,7 +947,6 @@ contains
     call outfld( 'sum_DST'   , sum_dst(:ncol,:)   , ncol ,lchnk )
     call outfld( 'sum_SS'    , sum_ss(:ncol,:)    , ncol ,lchnk )
     call outfld( 'sum_SOA'   , sum_soa(:ncol,:)   , ncol ,lchnk )
-    call outfld( 'sum_GASES' , sum_gases(:ncol,:) , ncol ,lchnk )
 
     ! OSLO_AERO begin
     do n=1,N_AEROSOL_TYPES

--- a/src_cam/mo_chm_diags.F90
+++ b/src_cam/mo_chm_diags.F90
@@ -19,9 +19,6 @@ module mo_chm_diags
   use oslo_aero_share, only : getCloudTracerIndexDirect, getCloudTracerName
   use oslo_aero_share, only : aerosol_type_name, aerosolType, isAerosol, N_AEROSOL_TYPES
   ! OSLO_AERO end
-  !
-  use spmd_utils,   only : masterproc
-  use cam_logfile,  only : iulog
 
   implicit none
   private
@@ -466,9 +463,6 @@ contains
           call addfld( spc_name, (/ 'lev' /), 'A', 'mol/mol', trim(attr)//' concentration')
           call addfld( trim(spc_name)//'_SRF', horiz_only, 'A', 'mol/mol', trim(attr)//" in bottom layer")
        endif
-       if (masterproc) then
-          write(iulog,*)'DEBUG: adding '//trim(spc_name)//' to history'
-       end if
        ! OSLO_AERO end
 
        if ((m /= id_cly) .and. (m /= id_bry)) then
@@ -809,9 +803,6 @@ contains
           if ( any( aer_species == m ) .or. isAerosol(n) ) then
              call outfld( solsym(m), mmr(:ncol,:,m), ncol ,lchnk )
              call outfld( trim(solsym(m))//'_SRF', mmr(:ncol,pver,m), ncol ,lchnk )
-             if (masterproc) then
-                write(iulog,*)'DEBUG: calling outfld for cnst_name = '//trim(solsym(m))
-             end if
           else
              call outfld( solsym(m), vmr(:ncol,:,m), ncol ,lchnk )
              call outfld( trim(solsym(m))//'_SRF', vmr(:ncol,pver,m), ncol ,lchnk )

--- a/src_cam/mo_chm_diags.F90
+++ b/src_cam/mo_chm_diags.F90
@@ -15,10 +15,13 @@ module mo_chm_diags
   use ppgrid,          only : pcols                                               ! OSLO_AERO
   use physics_buffer,  only : pbuf_get_field, pbuf_get_index, physics_buffer_desc ! OSLO_AERO
   use constituents,    only : cnst_get_ind                                        ! OSLO_AERO
-#ifdef OSLO_AERO
+  ! OSLO_AERO begin
   use oslo_aero_share, only : getCloudTracerIndexDirect, getCloudTracerName
   use oslo_aero_share, only : aerosol_type_name, aerosolType, isAerosol, N_AEROSOL_TYPES
-#endif
+  ! OSLO_AERO end
+  !
+  use spmd_utils,   only : masterproc
+  use cam_logfile,  only : iulog
 
   implicit none
   private
@@ -432,27 +435,25 @@ contains
           call addfld( wtrate_name(m), (/ 'lev' /), 'A',   '/s', spc_name//' wet deposition rate' )
        endif
 
-#ifdef OSLO_AERO
-       wetdep_name_area(m)='WD_A_'//trim(spc_name)
-       call addfld( wetdep_name_area(m), horiz_only, 'A', 'kg/m2/s ', spc_name//' wet deposition' )
-
-       !Needed for budget term of gases! Aerosols have their own budget terms
-       if(n.gt.0) then
-          if(.NOT. isAerosol(n))then
-             if(history_chemistry)then
-                call add_default( wetdep_name_area(m), 1, ' ')
-             end if
-          endif
-       end if
-#endif
-
        if (spc_name(1:3) == 'num') then
           unit_basename = ' 1'
        else
           unit_basename = 'kg'
        endif
 
-#ifdef OSLO_AERO
+       ! OSLO_AERO begin
+       wetdep_name_area(m)='WD_A_'//trim(spc_name)
+       call addfld( wetdep_name_area(m), horiz_only, 'A', 'kg/m2/s ', spc_name//' wet deposition' )
+
+       if(n.gt.0) then
+          if(.NOT. isAerosol(n))then
+             if(history_chemistry)then
+                ! Needed for budget term of gases! Aerosols have their own budget terms
+                call add_default( wetdep_name_area(m), 1, ' ')
+             end if
+          endif
+       end if
+
        if (n.gt.0) then
           if ( any( aer_species == m ) .or. isAerosol(n) ) then
              call addfld( spc_name,   (/ 'lev' /), 'A', unit_basename//'/kg ', trim(attr)//' concentration')
@@ -465,15 +466,11 @@ contains
           call addfld( spc_name, (/ 'lev' /), 'A', 'mol/mol', trim(attr)//' concentration')
           call addfld( trim(spc_name)//'_SRF', horiz_only, 'A', 'mol/mol', trim(attr)//" in bottom layer")
        endif
-#else
-       if ( any( aer_species == m ) ) then
-          call addfld( spc_name,   (/ 'lev' /), 'A', unit_basename//'/kg ', trim(attr)//' concentration')
-          call addfld( trim(spc_name)//'_SRF', horiz_only, 'A', unit_basename//'/kg', trim(attr)//" in bottom layer")
-       else
-          call addfld( spc_name, (/ 'lev' /), 'A', 'mol/mol', trim(attr)//' concentration')
-          call addfld( trim(spc_name)//'_SRF', horiz_only, 'A', 'mol/mol', trim(attr)//" in bottom layer")
-       endif
-#endif
+       if (masterproc) then
+          write(iulog,*)'DEBUG: adding '//trim(spc_name)//' to history'
+       end if
+       ! OSLO_AERO end
+
        if ((m /= id_cly) .and. (m /= id_bry)) then
           if (history_aerosol.or.history_chemistry) then
              call add_default( spc_name, 1, ' ' )
@@ -514,7 +511,7 @@ contains
           if (m==id_cfc12 ) call add_default( spc_name, 1, ' ')
        endif
 
-#ifdef OSLO_AERO
+       ! OSLO_AERO begin
        call add_default( spc_name, 1, ' ' )
 
        ! output 3d-field of aersol tracer in cloud water
@@ -551,16 +548,13 @@ contains
              endif
           endif
        end if
-#else
-
-       if (history_dust .and. (index(spc_name,'dst_') > 0))  call add_default( spc_name, 1, ' ')
-
-#endif
+       ! OSLO_AERO end
     enddo
 
     call addfld( 'MASS', (/ 'lev' /), 'A', 'kg', 'mass of grid box' )
     call addfld( 'AREA', horiz_only,  'A', 'm2', 'area of grid box' )
-#ifdef OSLO_AERO
+
+    ! OSLO_AERO begin
     do n=1,N_AEROSOL_TYPES
        call addfld('cb_'//trim(aerosol_type_name(n)),horiz_only, 'A', 'kg/m2',&
             'cb_'//trim(aerosol_type_name(n))//' column of aerosol type')
@@ -570,7 +564,23 @@ contains
             'mmr_'//trim(aerosol_type_name(n))//' mmr of aerosol type')
        call add_default('mmr_'//trim(aerosol_type_name(n)), 1, ' ')
     end do
-#endif
+    call addfld('sum_SO4'  , (/ 'lev' /), 'A', 'kg/kg ', 'sum of SO4 concentrations')
+    call addfld('sum_BC'   , (/ 'lev' /), 'A', 'kg/kg ', 'sum of BC concentrations')
+    call addfld('sum_OM'   , (/ 'lev' /), 'A', 'kg/kg ', 'sum of OM concentrations')
+    call addfld('sum_DST'  , (/ 'lev' /), 'A', 'kg/kg ', 'sum of DST concentrations')
+    call addfld('sum_SS'   , (/ 'lev' /), 'A', 'kg/kg ', 'sum of SS concentrations')
+    call addfld('sum_SOA'  , (/ 'lev' /), 'A', 'kg/kg ', 'sum of SOA concentrations')
+    call addfld('sum_GASES', (/ 'lev' /), 'A', 'kg/kg ', 'sum of GASES concentrations')
+
+    call add_default('sum_SO4'  , 1, ' ')
+    call add_default('sum_BC'   , 1, ' ')
+    call add_default('sum_OM'   , 1, ' ')
+    call add_default('sum_DST'  , 1, ' ')
+    call add_default('sum_SS'   , 1, ' ')
+    call add_default('sum_SOA'  , 1, ' ')
+    call add_default('sum_GASES', 1, ' ')
+    ! OSLO_AERO end
+
     call addfld( 'dry_deposition_NOy_as_N', horiz_only, 'I', 'kg/m2/s', 'NOy dry deposition flux ' )
     call addfld( 'DF_SOX', horiz_only, 'I', 'kg/m2/s', 'SOx dry deposition flux ' )
     call addfld( 'dry_deposition_NHx_as_N', horiz_only, 'I', 'kg/m2/s', 'NHx dry deposition flux ' )
@@ -593,13 +603,11 @@ contains
 
   end subroutine chm_diags_inti
 
-#ifdef OSLO_AERO
+  ! OSLO_AERO begin
   subroutine chm_diags( lchnk, ncol, vmr, mmr, rxt_rates, invariants, depvel, depflx, mmr_tend, pdel, pmid, ltrop, &
                         wetdepflx, nhx_nitrogen_flx, noy_nitrogen_flx, pbuf)
-#else
-  subroutine chm_diags( lchnk, ncol, vmr, mmr, rxt_rates, invariants, depvel, depflx, mmr_tend, pdel, pmid, ltrop, &
-                        wetdepflx, nhx_nitrogen_flx, noy_nitrogen_flx )
-#endif
+  ! OSLO_AERO end
+
     !--------------------------------------------------------------------
     !	... utility routine to output chemistry diagnostic variables
     !--------------------------------------------------------------------
@@ -630,14 +638,14 @@ contains
     real(r8), intent(in)  :: wetdepflx(ncol, gas_pcnst)
     real(r8), intent(out) :: nhx_nitrogen_flx(ncol) ! kgN/m2/sec
     real(r8), intent(out) :: noy_nitrogen_flx(ncol) ! kgN/m2/sec
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     type(physics_buffer_desc), pointer :: pbuf(:)
-#endif
+    ! OSLO_AERO end
 
     !--------------------------------------------------------------------
     !	... local variables
     !--------------------------------------------------------------------
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     real(r8), pointer :: cloudTracerField(:,:)
     integer           :: cloudTracerIndex
     character(len=20) :: cloudTracerName
@@ -646,7 +654,7 @@ contains
     real(r8)          :: cb_aerosol_type(pcols,N_AEROSOL_TYPES)         !column burden aerosol types
     real(r8)          :: mmr_aerosol_type(pcols,pver,N_AEROSOL_TYPES)   !concentration aerosol types
     character(len=16) :: spc_name
-#endif
+    ! OSLO_AERO end
     integer     :: i, k, m, n
     real(r8)    :: wrk(ncol,pver)
     !      real(r8)    :: tmp(ncol,pver)
@@ -659,6 +667,14 @@ contains
     real(r8), dimension(ncol)      :: df_noy, df_sox, df_nhx, do3chm_trp, do3chm_lms
     real(r8), dimension(ncol)      :: wd_noy, wd_nhx
     real(r8), dimension(ncol,pver) :: vmr_hox
+
+    real(r8) :: sum_so4(ncol,pver)
+    real(r8) :: sum_bc(ncol,pver)
+    real(r8) :: sum_om(ncol,pver)
+    real(r8) :: sum_dst(ncol,pver)
+    real(r8) :: sum_ss(ncol,pver)
+    real(r8) :: sum_soa(ncol,pver)
+    real(r8) :: sum_gases(ncol,pver)
 
     real(r8) :: area(ncol), mass(ncol,pver)
     real(r8) :: wgt
@@ -698,10 +714,10 @@ contains
     call outfld( 'AREA', area(:ncol),   ncol, lchnk )
     call outfld( 'MASS', mass(:ncol,:), ncol, lchnk )
 
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     cb_aerosol_type(:,:) = 0.0_r8
     mmr_aerosol_type(:,:,:) = 0.0_r8
-#endif
+    ! OSLO_AERO end
 
     do m = 1,gas_pcnst
 
@@ -785,7 +801,7 @@ contains
           vmr_hox(:ncol,:) = vmr_hox(:ncol,:) +  wgt * vmr(:ncol,:,m)
        endif
 
-#ifdef OSLO_AERO
+       ! OSLO_AERO begin
        spc_name = trim(solsym(m))
        call cnst_get_ind(spc_name, n, abort=.false.)
 
@@ -793,6 +809,9 @@ contains
           if ( any( aer_species == m ) .or. isAerosol(n) ) then
              call outfld( solsym(m), mmr(:ncol,:,m), ncol ,lchnk )
              call outfld( trim(solsym(m))//'_SRF', mmr(:ncol,pver,m), ncol ,lchnk )
+             if (masterproc) then
+                write(iulog,*)'DEBUG: calling outfld for cnst_name = '//trim(solsym(m))
+             end if
           else
              call outfld( solsym(m), vmr(:ncol,:,m), ncol ,lchnk )
              call outfld( trim(solsym(m))//'_SRF', vmr(:ncol,pver,m), ncol ,lchnk )
@@ -827,15 +846,7 @@ contains
              mmr_aerosol_type(:ncol,:,aerosolType(n)) = mmr_aerosol_type(:ncol,:,aerosolType(n)) + mmr(:ncol,:,m)
           endif
        end if !Check if this is a chemistry tracer
-#else
-       if ( any( aer_species == m ) ) then
-          call outfld( solsym(m), mmr(:ncol,:,m), ncol ,lchnk )
-          call outfld( trim(solsym(m))//'_SRF', mmr(:ncol,pver,m), ncol ,lchnk )
-       else
-          call outfld( solsym(m), vmr(:ncol,:,m), ncol ,lchnk )
-          call outfld( trim(solsym(m))//'_SRF', vmr(:ncol,pver,m), ncol ,lchnk )
-       endif
-#endif
+       ! OSLO_AERO end
 
        if (has_drydep(solsym(m))) then
           call outfld( depvel_name(m), depvel(:ncol,m), ncol ,lchnk )
@@ -902,13 +913,67 @@ contains
           call outfld('DO3CHM_LMS',do3chm_lms(:ncol), ncol, lchnk )
        end if
 !
-    enddo
-#ifdef OSLO_AERO
+    enddo ! end loop from m=1,gas_pcnst
+
+
+    ! Generate compund sum
+
+    ! SO4_NA, SO4_A1, SO4_A2    SO4_AC, SO4_PR
+    ! BC_N, BC_AX, BC_NI, BC_A, BC_AI ,BC_AC
+    ! OM_NI, OM_AI, OM_AC
+    ! DST_A2, DST_A3
+    ! SS_A1, SS_A2, SS_A3
+    ! SOA_NA, SOA_A1
+    ! H2SO4, SOA_LV,SOA_SV, monoterp, isoprene
+
+    sum_so4(:,:) = 0._r8
+    sum_bc(:,:) = 0._r8
+    sum_om(:,:) = 0._r8
+    sum_dst(:,:) = 0._r8
+    sum_ss(:,:) = 0._r8
+    sum_soa(:,:) = 0._r8
+    sum_gases(:,:) = 0._r8
+
+    do m = 1,gas_pcnst
+       spc_name = trim(solsym(m))
+       if (spc_name(1:4) == 'SO4_') then
+          sum_so4(:ncol,:) = sum_so4(:ncol,:) + mmr(:ncol,:,m)
+       else if (spc_name(1:3) == 'BC_') then
+          sum_bc(:ncol,:) = sum_bc(:ncol,:) + mmr(:ncol,:,m)
+       else if (spc_name(1:3) == 'OM_') then
+          sum_om(:ncol,:) = sum_om(:ncol,:) + mmr(:ncol,:,m)
+       else if (spc_name(1:4) == 'DST_') then
+          sum_dst(:ncol,:) = sum_dst(:ncol,:) + mmr(:ncol,:,m)
+       else if (spc_name(1:3) == 'SS_') then
+          sum_ss(:ncol,:) = sum_ss(:ncol,:) + mmr(:ncol,:,m)
+       else if (spc_name(1:4) == 'SOA_') then
+          sum_soa(:ncol,:) = sum_soa(:ncol,:) + mmr(:ncol,:,m)
+       else if (trim(spc_name) == 'H2SO4') then
+          sum_gases(:ncol,:) = sum_gases(:ncol,:) + mmr(:ncol,:,m)
+       else if (trim(spc_name) == 'SOA_LV') then
+          sum_gases(:ncol,:) = sum_gases(:ncol,:) + mmr(:ncol,:,m)
+       else if (trim(spc_name) == 'SOA_SV') then
+          sum_gases(:ncol,:) = sum_gases(:ncol,:) + mmr(:ncol,:,m)
+       else if (trim(spc_name) == 'monoterp') then
+          sum_gases(:ncol,:) = sum_gases(:ncol,:) + mmr(:ncol,:,m)
+       else if (trim(spc_name) == 'isoprene') then
+          sum_gases(:ncol,:) = sum_gases(:ncol,:) + mmr(:ncol,:,m)
+       end if
+    end do
+    call outfld( 'sum_SO4'   , sum_so4(:ncol,:)   , ncol ,lchnk )
+    call outfld( 'sum_BC'    , sum_bc(:ncol,:)    , ncol ,lchnk )
+    call outfld( 'sum_OM'    , sum_om(:ncol,:)    , ncol ,lchnk )
+    call outfld( 'sum_DST'   , sum_dst(:ncol,:)   , ncol ,lchnk )
+    call outfld( 'sum_SS'    , sum_ss(:ncol,:)    , ncol ,lchnk )
+    call outfld( 'sum_SOA'   , sum_soa(:ncol,:)   , ncol ,lchnk )
+    call outfld( 'sum_GASES' , sum_gases(:ncol,:) , ncol ,lchnk )
+
+    ! OSLO_AERO begin
     do n=1,N_AEROSOL_TYPES
        call outfld("mmr_"//trim(aerosol_type_name(n)), mmr_aerosol_type(:ncol,:,n), ncol,lchnk)
        call outfld("cb_"//trim(aerosol_type_name(n)) , cb_aerosol_type(:ncol,n)   , ncol,lchnk)
     enddo
-#endif
+    ! OSLO_AERO end
     call outfld( 'NOX',  vmr_nox  (:ncol,:), ncol, lchnk )
     call outfld( 'NOY',  vmr_noy  (:ncol,:), ncol, lchnk )
     call outfld( 'HOX',  vmr_hox  (:ncol,:), ncol, lchnk )
@@ -1038,11 +1103,9 @@ contains
   subroutine het_diags( het_rates, mmr, pdel, lchnk, ncol )
 
     use cam_history,  only : outfld
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     use phys_grid,    only : get_wght_all_p, get_area_all_p
-#else
-    use phys_grid,    only : get_wght_all_p
-#endif
+    ! OSLO_AERO end
 
     integer,  intent(in)  :: lchnk
     integer,  intent(in)  :: ncol
@@ -1051,9 +1114,10 @@ contains
     real(r8), intent(in)  :: pdel(ncol,pver)
 
     real(r8), dimension(ncol) :: noy_wk, sox_wk, nhx_wk, wrk_wd
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     real(r8), dimension(ncol) :: area
-#endif
+    ! OSLO_AERO end
+
     integer :: m, k
     real(r8) :: wght(ncol)
     !
@@ -1063,10 +1127,10 @@ contains
     sox_wk(:) = 0._r8
     nhx_wk(:) = 0._r8
 
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     call get_area_all_p(lchnk, ncol, area)
     area = area * rearth**2
-#endif
+    ! OSLO_AERO end
     call get_wght_all_p(lchnk, ncol, wght)
 
     do m = 1,gas_pcnst
@@ -1082,9 +1146,9 @@ contains
        !
        if (gas_wetdep_method=='MOZ') then
           call outfld( wetdep_name(m), wrk_wd(:ncol), ncol, lchnk )
-#ifdef OSLO_AERO
+          ! OSLO_AERO begin
           call outfld( wetdep_name_area(m), wrk_wd(:ncol)/area(:ncol)  ,ncol, lchnk )
-#endif
+          ! OSLO_AERO end
           call outfld( wtrate_name(m), het_rates(:ncol,:,m), ncol, lchnk )
 
           if ( any(noy_species == m ) ) then

--- a/src_cam/mo_drydep.F90
+++ b/src_cam/mo_drydep.F90
@@ -322,11 +322,10 @@ contains
     logical :: prog_modal_aero
 
     ! determine if modal aerosols are active so that fraction_landuse array is initialized for modal aerosal dry dep
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     prog_modal_aero = .true.
-#else
-    call phys_getopts(prog_modal_aero_out=prog_modal_aero)
-#endif
+    ! OSLO_AERO end
+
     call dvel_inti_fromlnd()
 
     if( masterproc ) then

--- a/src_cam/mo_gas_phase_chemdr.F90
+++ b/src_cam/mo_gas_phase_chemdr.F90
@@ -25,10 +25,10 @@ module mo_gas_phase_chemdr
   integer :: het1_ndx
   integer :: ndx_cldfr, ndx_cmfdqr, ndx_nevapr, ndx_cldtop, ndx_prain
   integer :: ndx_h2so4
-#ifdef OSLO_AERO
+  ! OSLO_AERO begin
   logical :: inv_o3, inv_oh, inv_no3, inv_ho2
   integer :: id_o3, id_oh, id_no3, id_ho2
-#endif
+  ! OSLO_AERO end
 !
 ! CCMI
 !
@@ -60,11 +60,9 @@ contains
 
   subroutine gas_phase_chemdr_inti()
 
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     use mo_chem_utls,      only : get_spc_ndx, get_extfrc_ndx, get_rxt_ndx, get_inv_ndx
-#else
-    use mo_chem_utls,      only : get_spc_ndx, get_extfrc_ndx, get_rxt_ndx, get_inv_ndx
-#endif
+    ! OSLO_AERO end
     use cam_history,       only : addfld,add_default,horiz_only
     use mo_chm_diags,      only : chm_diags_inti
     use constituents,      only : cnst_get_ind
@@ -83,7 +81,7 @@ contains
 
     call phys_getopts( convproc_do_aer_out = convproc_do_aer, history_cesm_forcing_out=history_cesm_forcing )
 
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     inv_o3   = get_inv_ndx('O3') > 0
     inv_oh   = get_inv_ndx('OH') > 0
     inv_no3  = get_inv_ndx('NO3') > 0
@@ -92,7 +90,8 @@ contains
     if (inv_oh)  id_oh = get_inv_ndx('OH')
     if (inv_no3) id_no3 = get_inv_ndx('NO3')
     if (inv_ho2) id_ho2 = get_inv_ndx('HO2')
-#endif
+    ! OSLO_AERO end
+
     ndx_h2so4 = get_spc_ndx('H2SO4')
 !
 ! CCMI
@@ -211,7 +210,7 @@ contains
     call addfld( 'HCL_GAS',    (/ 'lev' /), 'I', 'mol/mol', 'gas-phase hcl' )
     call addfld( 'HCL_STS',    (/ 'lev' /), 'I', 'mol/mol', 'STS condensed HCL' )
 
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     ! Adding extra fields for oxi-output (before and after diurnal variations.)
     call addfld ('OH_bef    ',  (/ 'lev' /), 'A','unit', 'OH invariants before adding diurnal variations'           )
     call addfld ('HO2_bef   ',  (/ 'lev' /), 'A','unit', 'HO2 invariants before adding diurnal variations'          )
@@ -226,7 +225,8 @@ contains
     call add_default ('OH_aft       ', 1, ' ')
     call add_default ('HO2_aft      ', 1, ' ')
     call add_default ('NO3_aft      ', 1, ' ')
-#endif
+    ! OSLO_AERO end
+
     if (het1_ndx>0) then
        call addfld( 'het1_total', (/ 'lev' /), 'I', '/s', 'total N2O5 + H2O het rate constant' )
     endif
@@ -347,9 +347,10 @@ contains
     !
     ! for aqueous chemistry and aerosol growth
     !
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     use oslo_aero_diurnal_var, only : set_diurnal_invariants
-#endif
+    ! OSLO_AERO end
+
     !-----------------------------------------------------------------------
     !        ... Dummy arguments
     !-----------------------------------------------------------------------
@@ -653,7 +654,7 @@ contains
     !-----------------------------------------------------------------------
     call setinv( invariants, tfld, h2ovmr, vmr, pmid, ncol, lchnk, pbuf )
 
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     !-----------------------------------------------------------------------
     !        ... Set the "day/night cycle for prescribed oxidants"
     !-----------------------------------------------------------------------
@@ -666,7 +667,7 @@ contains
     call outfld('OH_aft',    invariants(:,:,id_oh),  ncol, lchnk)
     call outfld('HO2_aft',   invariants(:,:,id_ho2), ncol, lchnk)
     call outfld('NO3_aft',   invariants(:,:,id_no3), ncol, lchnk)
-#endif
+    ! OSLO_AERO end
 
     !-----------------------------------------------------------------------
     !        ... stratosphere aerosol surface area
@@ -1145,17 +1146,13 @@ contains
        endif
     endif
 
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     call chm_diags( lchnk, ncol, vmr(:ncol,:,:), mmr_new(:ncol,:,:), &
                     reaction_rates(:ncol,:,:), invariants(:ncol,:,:), depvel(:ncol,:),  sflx(:ncol,:), &
                     mmr_tend(:ncol,:,:), pdel(:ncol,:), pmid(:ncol,:), troplev(:ncol), wetdepflx_diag(:ncol,:), &
                     nhx_nitrogen_flx(:ncol), noy_nitrogen_flx(:ncol), pbuf )
-#else
-    call chm_diags( lchnk, ncol, vmr(:ncol,:,:), mmr_new(:ncol,:,:), &
-                    reaction_rates(:ncol,:,:), invariants(:ncol,:,:), depvel(:ncol,:),  sflx(:ncol,:), &
-                    mmr_tend(:ncol,:,:), pdel(:ncol,:), pmid(:ncol,:), troplev(:ncol), wetdepflx_diag(:ncol,:), &
-                    nhx_nitrogen_flx(:ncol), noy_nitrogen_flx(:ncol) )
-#endif
+    ! OSLO_AERO end
+
 
     call rate_diags_calc( reaction_rates(:,:,:), vmr(:,:,:), invariants(:,:,indexm), ncol, lchnk )
 !

--- a/src_cam/mo_neu_wetdep.F90
+++ b/src_cam/mo_neu_wetdep.F90
@@ -14,8 +14,10 @@ module mo_neu_wetdep
   use cam_abortutils,   only : endrun
   use shr_drydep_mod,   only : n_species_table, species_name_table, dheff
   use gas_wetdep_opts,  only : gas_wetdep_method, gas_wetdep_list, gas_wetdep_cnt
-  use phys_control,     only: phys_getopts ! OSLO_AERO
-  use mo_constants,     only: rgrav        ! OSLO_AERO
+  ! OSLO_AERO begin
+  use phys_control,     only: phys_getopts
+  use mo_constants,     only: rgrav
+  ! OSLO_AERO end
 !
   implicit none
 !
@@ -460,7 +462,7 @@ subroutine neu_wetdep_tend(lchnk,ncol,mmr,pmid,pdel,zint,tfld,delt, &
 !
   end do
 !
-#ifdef OSLO_AERO
+  ! OSLO_AERO begin
   !This is output normally in mo_chm_diags, but if neu wetdep, we have to output it here!
   call phys_getopts( history_aerosol_out = history_aerosol)
   if (history_aerosol) then
@@ -473,7 +475,8 @@ subroutine neu_wetdep_tend(lchnk,ncol,mmr,pmid,pdel,zint,tfld,delt, &
         call outfld('WD_A_'//trim(gas_wetdep_list(m)),wrk_wd(:ncol),ncol,lchnk)
      end do
   end if
-#endif
+  ! OSLO_AERO end
+
 
   if ( do_diag ) then
     call outfld('QT_RAIN_HNO3', qt_rain, ncol, lchnk )

--- a/src_cam/mo_setaer.F90
+++ b/src_cam/mo_setaer.F90
@@ -10,7 +10,7 @@
 
       save
 
-      real(r8), parameter :: qext_so4(8,17) = reshape( (/  &                      ! m^2/gram (NH4)_2(SO4) 
+      real(r8), parameter :: qext_so4(8,17) = reshape( (/  &                      ! m^2/gram (NH4)_2(SO4)
             7.15_r8,  10.29_r8,  12.86_r8,  15.45_r8,  21.52_r8,  30.97_r8,  50.30_r8,  72.31_r8, &
             7.15_r8,  10.30_r8,  12.87_r8,  15.48_r8,  21.58_r8,  31.07_r8,  50.43_r8,  72.49_r8, &
             7.14_r8,  10.29_r8,  12.88_r8,  15.51_r8,  21.68_r8,  31.23_r8,  50.67_r8,  72.78_r8, &
@@ -57,7 +57,7 @@
       real(r8), parameter :: asm_so4(8,17) = reshape( (/ &
         0.67_r8,   0.68_r8,   0.68_r8,   0.68_r8,   0.69_r8,   0.70_r8,   0.71_r8,   0.73_r8, &
         0.67_r8,   0.68_r8,   0.68_r8,   0.68_r8,   0.69_r8,   0.70_r8,   0.72_r8,   0.73_r8, &
-        0.67_r8,   0.68_r8,   0.69_r8,   0.69_r8,   0.70_r8,   0.70_r8,   0.72_r8,   0.73_r8, & 
+        0.67_r8,   0.68_r8,   0.69_r8,   0.69_r8,   0.70_r8,   0.70_r8,   0.72_r8,   0.73_r8, &
         0.67_r8,   0.69_r8,   0.69_r8,   0.70_r8,   0.70_r8,   0.71_r8,   0.72_r8,   0.74_r8, &
         0.67_r8,   0.69_r8,   0.70_r8,   0.70_r8,   0.71_r8,   0.71_r8,   0.73_r8,   0.74_r8, &
         0.67_r8,   0.69_r8,   0.70_r8,   0.71_r8,   0.71_r8,   0.72_r8,   0.73_r8,   0.74_r8, &
@@ -95,7 +95,7 @@
          3.28_r8,   5.11_r8,   6.70_r8,   8.23_r8,  13.80_r8,  24.05_r8,  47.93_r8,  76.67_r8, &
          2.41_r8,   3.79_r8,   5.04_r8,   6.24_r8,  10.83_r8,  19.88_r8,  42.13_r8,  70.46_r8  &
             /),(/8,17/))
- 
+
       real(r8), parameter :: qext_dant(7,17) = qext_ant(2:8,:) - qext_ant(1:7,:)
 
       real(r8), parameter :: ssa_ant(8,17) = reshape( (/ &
@@ -119,7 +119,7 @@
             /),(/8,17/))
 
       real(r8), parameter :: ssa_dant(7,17) = ssa_ant(2:8,:) - ssa_ant(1:7,:)
- 
+
       real(r8), parameter :: asm_ant(8,17) = reshape( (/ &
         0.67_r8,   0.68_r8,   0.68_r8,   0.68_r8,   0.69_r8,   0.70_r8,   0.71_r8,   0.73_r8, &
         0.67_r8,   0.68_r8,   0.68_r8,   0.68_r8,   0.69_r8,   0.70_r8,   0.72_r8,   0.73_r8, &
@@ -206,7 +206,7 @@
 !--------------------------------------------------------------------
 ! black carbon
 !--------------------------------------------------------------------
-      real(r8), parameter :: qext_cbs(8,17) = reshape( (/ & 
+      real(r8), parameter :: qext_cbs(8,17) = reshape( (/ &
       26.47_r8,  26.47_r8,  26.47_r8,  68.55_r8,  54.51_r8,  68.55_r8,  93.69_r8, 128.49_r8, &
       26.35_r8,  26.35_r8,  26.35_r8,  67.19_r8,  53.53_r8,  67.19_r8,  91.62_r8, 125.62_r8, &
       26.15_r8,  26.15_r8,  26.15_r8,  65.24_r8,  52.13_r8,  65.24_r8,  88.62_r8, 121.44_r8, &
@@ -228,7 +228,7 @@
 
       real(r8), parameter :: qext_dcbs(7,17) = qext_cbs(2:8,:) - qext_cbs(1:7,:)
 
-      real(r8), parameter :: ssa_cbs(8,17) = reshape( (/ & 
+      real(r8), parameter :: ssa_cbs(8,17) = reshape( (/ &
       0.30538_r8,0.30538_r8,0.30538_r8,0.58171_r8,0.52858_r8,0.58171_r8,0.66772_r8,0.73300_r8, &
       0.30531_r8,0.30531_r8,0.30531_r8,0.57816_r8,0.52490_r8,0.57816_r8,0.66490_r8,0.73116_r8, &
       0.30524_r8,0.30524_r8,0.30524_r8,0.57281_r8,0.51947_r8,0.57281_r8,0.66041_r8,0.72800_r8, &
@@ -275,7 +275,7 @@
 !--------------------------------------------------------------------
 ! organic carbon
 !--------------------------------------------------------------------
-      real(r8), parameter :: qext_ocs(8,17) = reshape( (/ & 
+      real(r8), parameter :: qext_ocs(8,17) = reshape( (/ &
       5.38_r8,   8.22_r8,  11.03_r8,  13.09_r8,  14.66_r8,  18.31_r8,  25.39_r8,  28.27_r8, &
       5.37_r8,   8.20_r8,  11.00_r8,  13.06_r8,  14.63_r8,  18.29_r8,  25.39_r8,  28.28_r8, &
       5.35_r8,   8.16_r8,  10.95_r8,  13.02_r8,  14.59_r8,  18.26_r8,  25.39_r8,  28.29_r8, &
@@ -297,7 +297,7 @@
 
       real(r8), parameter :: qext_docs(7,17) = qext_ocs(2:8,:) - qext_ocs(1:7,:)
 
-      real(r8), parameter :: ssa_ocs(8,17) = reshape( (/ & 
+      real(r8), parameter :: ssa_ocs(8,17) = reshape( (/ &
       0.67508_r8,0.73829_r8,0.78690_r8,0.80446_r8,0.82190_r8,0.84991_r8,0.87960_r8,0.88715_r8, &
       0.67840_r8,0.74179_r8,0.79056_r8,0.80819_r8,0.82564_r8,0.85366_r8,0.88338_r8,0.89096_r8, &
       0.68373_r8,0.74715_r8,0.79586_r8,0.81346_r8,0.83078_r8,0.85852_r8,0.88777_r8,0.89520_r8, &
@@ -629,18 +629,18 @@
 !-----------------------------------------------------------------------------
 !   	... calculate aerosol optical depth
 !-----------------------------------------------------------------------------
-!   AEROSOL TYPES: 
+!   AEROSOL TYPES:
 !   ocs1, ocs2, cbs1, cbs2, ant, so4, ds1-ds4,soa, sal
 !   where 1=hydrophobic, 2=hydrophilic;
 !
-!   PARAMETERS:                                                              
+!   PARAMETERS:
 !   NZ      - INTEGER, number of specified altitude levels in the working
-!             grid                                                           
+!             grid
 !   Z       - REAL, specified altitude working grid (km)
 !   axxx     aerosoling mix ratio (where xxx is aerosol type)
 !
 !   dtxxx    REAL, optical depth (absorption)
-!   omxxx    REAL, single albedo             
+!   omxxx    REAL, single albedo
 !   gxxx   asysmetry factor
 !
 !-----------------------------------------------------------------------------
@@ -655,13 +655,11 @@
       use chem_mods,        only : adv_mass
       use mo_constants,     only : avogadro
       use mo_chem_utls,     only : get_spc_ndx
-#ifdef OSLO_AERO
+      ! OSLO_AERO begin
       use oslo_aero_dust,   only : dust_names
       use oslo_aero_seasalt,only : sslt_names=>seasalt_names
-#else
-      use dust_model,       only : dust_names
-      use seasalt_model,    only : sslt_names=>seasalt_names
-#endif
+      ! OSLO_AERO end
+
       implicit none
 
 !-----------------------------------------------------------------------------
@@ -764,9 +762,9 @@
 !    729.00- 743.60
 !
 ! For aerosol types so4 and  ant data tabulated for CAM is used in wavelength bins for which it exists
-! This data has been created by  D. Fillmore in the file aerOptics.nc 
+! This data has been created by  D. Fillmore in the file aerOptics.nc
 ! Data is weighted by wavelength bin
-! 
+!
 ! Otherwise, tables have been recreated by P. Hess
 !
 ! Refractive indices and other DATA is mostly from OPAC dataset Hess et al., .....
@@ -777,7 +775,7 @@
 !              sigma = alog10(2.00)           ! standard deviation of distribution
 !              rmin = 0.005                   ! minimum radius microns
 !              rmax = 20.0                    ! maximum radius microns
-!              rho = 1.76                     ! grams / cm^3 
+!              rho = 1.76                     ! grams / cm^3
 !        PARAMETERS NEEDED FOR CALCULATING KOHLER CURVES for calculating growth with relative humidity
 !              nu_s = 3.0
 !              rho_u = rho
@@ -799,9 +797,9 @@
 !     1.48, 1.47, 1.47, 1.47, 1.46, 1.46, 1.45, 1.44, 1.42, $
 !     1.40, 1.33, 1.27, 1.39, 1.49, 1.48, 1.56, 1.61, 1.61, $
 !     1.60, 1.62, 1.63, 1.56, 1.53, 1.49, 1.48, 1.44]
-!  
+!
 !  IMAGINARY
-!    1.0e-7, 1.0e-7, 1.0e-7, 1.0e-7, 1.0e-7, 1.0e-7, 3.5e-7, 2.4e-6, 
+!    1.0e-7, 1.0e-7, 1.0e-7, 1.0e-7, 1.0e-7, 1.0e-7, 3.5e-7, 2.4e-6,
 !    9.5e-7, 3.4e-6, 1.7e-5, 1.1e-5, 3.4e-5, 2.1e-4, 1.9e-4, 9.0e-5, 7.6e-5, $
 !    1.5e-4, 1.0e-3, 1.5e-3, 3.4e-3, 1.7e-3, 7.7e-4, 4.5e-4, 3.5e-4, 9.0e-4, $
 !    5.0e-3, 5.0e-2, 2.3e-1, 3.3e-1, 2.7e-1, 2.4e-1, 2.7e-1, 2.4e-1, 1.7e-1, $
@@ -810,44 +808,44 @@
 !
 ! NH4NO3
 !
-! treated the same as sulphate except 
+! treated the same as sulphate except
 ! rho=1.73 (Lowenthal, 1999, Atmospheric Environment).
-! 
+!
 ! DUST
 !
 ! dust is treated as 4 size distributions
 ! 0.05 - 0.5; 0.5 - 1.25; 1.25 - 2.5; 2.5 - 5.0 microns
 ! each bin is part of a distribution with median number r_m = 2.524 * exp(- 3.0 * log(2.00)^2) / 2 [number median radius]
 ! r_m = 0.298, sigma = 2.00, rho = 2.650
-! 
+!
 ! note this treatment of dust is somewhat different than that made in CAM, where each size bin
 ! has a different number median radius
 !
-! dust is not assumed to take up water. 
+! dust is not assumed to take up water.
 !
 ! refractive indexes are as in CAM (Fillmore...)
 !
 ! ORGANIC CARBON
 !
-! In absence of data for organic aerosol 
-! refractive indexes are taken as for WASO: based on Fillmore (and OPAC). This is similar to 
-! the formulation used in Liao and Seinfeld, 2004, JGR. 
+! In absence of data for organic aerosol
+! refractive indexes are taken as for WASO: based on Fillmore (and OPAC). This is similar to
+! the formulation used in Liao and Seinfeld, 2004, JGR.
 ! The growth of organic carbon with relative humidity is assumed constant at all radii following
 ! hygrscopic growth given in Chen et al. : rel. hum: 0, 50, 70, 80, 90, 95, 98, 99
 ! multiplier for radius: 1,  1.2,  1.4,  1.5, 1.6, 1.8, 2.1 , 2.2
 !
-! SOA 
+! SOA
 !
 ! Treated the same as organic aerosol.
 !
 ! SOOT
 !
-! Refractive index are taken from Fillmore based on OPAC. 
+! Refractive index are taken from Fillmore based on OPAC.
 ! In a different formulation than that followed in CAM we let hydrophillic soot grow.
 !  The growth of organic carbon with relative humidity is assumed constant at all radii following
 ! hygrscopic growth given in Chen et al. : rel. hum: 0, 50, 70, 80, 90, 95, 98, 99
 ! multiplier for radius: (1,  1,  1,  1.2, 1.4,  1.5, 1.7, 1.9]
-! 
+!
 !
 ! SEA SALT
 !
@@ -886,10 +884,10 @@
 !-----------------------------------------------------------------------------
 !      	... so4
 !-----------------------------------------------------------------------------
-      ndx = get_spc_ndx('SO4') 
+      ndx = get_spc_ndx('SO4')
       if( ndx > 0 ) then
          mw = adv_mass( ndx )
-         gpm2(:) = s2as * dz(:) * aso4(:pver) * mw 
+         gpm2(:) = s2as * dz(:) * aso4(:pver) * mw
          do wn = 1,nw
             do k = 1,pver
                rh_l  = rh_ndx(k)
@@ -909,11 +907,11 @@
 
 !-----------------------------------------------------------------------------
 !   	... ant:  nh4no3
-!-----------------------------------------------------------------------------    
+!-----------------------------------------------------------------------------
       ndx = get_spc_ndx('NH4NO3')
       if( ndx > 0 ) then
          mw = adv_mass( ndx )
-         gpm2(:) = dz(:) * aant(:pver) * mw 
+         gpm2(:) = dz(:) * aant(:pver) * mw
          do wn = 1,nw
             do k = 1,pver
                rh_l  = rh_ndx(k)
@@ -937,10 +935,10 @@
        ndx = get_spc_ndx('CB1')
        if( ndx > 0 ) then
           mw = adv_mass( ndx )
-          gpm2(:) = dz(:) * acbs1(:pver) * mw 
+          gpm2(:) = dz(:) * acbs1(:pver) * mw
           do wn = 1,nw
              dtcbs1(:,wn) = gpm2(:)*qext_cbs(1,wn)
-             omcbs1(:,wn) = ssa_cbs(1,wn) 
+             omcbs1(:,wn) = ssa_cbs(1,wn)
              gcbs1(:,wn)  = asm_cbs(1,wn)
           end do
       else
@@ -953,7 +951,7 @@
 
        ndx = get_spc_ndx('CB2')
        if( ndx > 0 ) then
-          gpm2(:) = dz(:) * acbs2(:pver) * mw 
+          gpm2(:) = dz(:) * acbs2(:pver) * mw
           do wn = 1,nw
              do k = 1,pver
                rh_l  = rh_ndx(k)
@@ -977,10 +975,10 @@
        ndx = get_spc_ndx('OC1')
        if( ndx > 0 ) then
           mw = adv_mass( ndx )
-          gpm2(:) = dz(:) * aocs1(:pver) * mw 
+          gpm2(:) = dz(:) * aocs1(:pver) * mw
           do wn = 1,nw
              dtocs1(:,wn) =  gpm2(:)*qext_ocs(1,wn)
-             omocs1(:,wn) =  ssa_ocs(1,wn) 
+             omocs1(:,wn) =  ssa_ocs(1,wn)
              gocs1(:,wn)  =  asm_ocs(1,wn)
           end do
       else
@@ -990,10 +988,10 @@
             gocs1(:,wn)  = 0._r8
          end do
        end if
- 
+
        ndx = get_spc_ndx('OC2')
        if( ndx > 0 ) then
-          gpm2(:) = dz(:) * aocs2(:pver) * mw 
+          gpm2(:) = dz(:) * aocs2(:pver) * mw
           do wn = 1,nw
             do k = 1,pver
                rh_l  = rh_ndx(k)
@@ -1019,7 +1017,7 @@
           ndx = get_spc_ndx('OC2')
           if( ndx > 0 ) then
              mw = adv_mass( ndx )
-             gpm2(:) = dz(:) * asoa(:pver) * mw 
+             gpm2(:) = dz(:) * asoa(:pver) * mw
              do wn = 1,nw
                 do k = 1,pver
                    rh_l  = rh_ndx(k)
@@ -1040,10 +1038,10 @@
        ndx = get_spc_ndx(dust_names(1))
        if (ndx >0) then
           mw = adv_mass( ndx )
-          gpm2(:) = dz(:) * ads(1,:pver) * mw 
+          gpm2(:) = dz(:) * ads(1,:pver) * mw
           do wn = 1,nw
              dtds1(:,wn) = gpm2(:)*qext_ds1(wn)
-             omds1(:,wn) = ssa_ds1(wn) 
+             omds1(:,wn) = ssa_ds1(wn)
              gds1(:,wn)  = asm_ds1(wn)
           end do
        else
@@ -1056,10 +1054,10 @@
        ndx = get_spc_ndx(dust_names(2))
        if (ndx >0) then
           mw = adv_mass( ndx )
-          gpm2(:) = dz(:) * ads(2,:pver) * mw 
+          gpm2(:) = dz(:) * ads(2,:pver) * mw
           do wn = 1,nw
              dtds2(:,wn) = gpm2(:)*qext_ds2(wn)
-             omds2(:,wn) = ssa_ds2(wn) 
+             omds2(:,wn) = ssa_ds2(wn)
              gds2(:,wn)  = asm_ds2(wn)
           end do
        else
@@ -1072,10 +1070,10 @@
        ndx = get_spc_ndx(dust_names(3))
        if (ndx >0) then
           mw = adv_mass( ndx )
-          gpm2(:) = dz(:) * ads(3,:pver) * mw 
+          gpm2(:) = dz(:) * ads(3,:pver) * mw
           do wn = 1,nw
              dtds3(:,wn) = gpm2(:)*qext_ds3(wn)
-             omds3(:,wn) = ssa_ds3(wn) 
+             omds3(:,wn) = ssa_ds3(wn)
              gds3(:,wn)  = asm_ds3(wn)
           end do
        else
@@ -1088,10 +1086,10 @@
        ndx = get_spc_ndx(dust_names(4))
        if (ndx >0) then
           mw = adv_mass( ndx )
-          gpm2(:) = dz(:) * ads(4,:pver) * mw 
+          gpm2(:) = dz(:) * ads(4,:pver) * mw
           do wn = 1,nw
              dtds4(:,wn) = gpm2(:)*qext_ds4(wn)
-             omds4(:,wn) = ssa_ds4(wn) 
+             omds4(:,wn) = ssa_ds4(wn)
              gds4(:,wn)  = asm_ds4(wn)
           end do
        else
@@ -1106,10 +1104,10 @@
 !  	... sea salts
 !-----------------------------------------------------------------------------
        ndx = get_spc_ndx(sslt_names(1))
-   
+
        if( ndx > 0 ) then
           mw = adv_mass( ndx )
-          gpm2(:) = dz(:) * asal(:pver,1) * mw 
+          gpm2(:) = dz(:) * asal(:pver,1) * mw
           do wn = 1,nw
             do k = 1,pver
                rh_l  = rh_ndx(k)
@@ -1126,11 +1124,11 @@
             gsal(:,wn,1)  = 0._r8
          end do
        end if
- 
+
        ndx = get_spc_ndx(sslt_names(2))
        if( ndx > 0 ) then
           mw = adv_mass( ndx )
-          gpm2(:) = dz(:) * asal(:pver,2) * mw 
+          gpm2(:) = dz(:) * asal(:pver,2) * mw
           do wn = 1,nw
             do k = 1,pver
                rh_l  = rh_ndx(k)
@@ -1151,7 +1149,7 @@
        ndx = get_spc_ndx(sslt_names(3))
        if( ndx > 0 ) then
           mw = adv_mass( ndx )
-          gpm2(:) = dz(:) * asal(:pver,3) * mw 
+          gpm2(:) = dz(:) * asal(:pver,3) * mw
           do wn = 1,nw
             do k = 1,pver
                rh_l  = rh_ndx(k)
@@ -1172,7 +1170,7 @@
       ndx = get_spc_ndx(sslt_names(4))
       if( ndx > 0 ) then
           mw = adv_mass( ndx )
-          gpm2(:) = dz(:) * asal(:pver,4) * mw 
+          gpm2(:) = dz(:) * asal(:pver,4) * mw
           do wn = 1,nw
             do k = 1,pver
                rh_l  = rh_ndx(k)

--- a/src_cam/mo_setsox.F90
+++ b/src_cam/mo_setsox.F90
@@ -33,21 +33,15 @@ contains
     use mo_chem_utls, only : get_spc_ndx, get_inv_ndx
     use spmd_utils,   only : masterproc
     use phys_control, only : phys_getopts
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     use oslo_aero_sox_cldaero, only : sox_cldaero_init
-#else
-    use sox_cldaero_mod, only : sox_cldaero_init
-#endif
-
+    ! OSLO_AERO_END
     implicit none
 
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     modal_aerosols = .true.
     cloud_borne = .true.
-#else
-    call phys_getopts(prog_modal_aero_out=modal_aerosols )
-    cloud_borne = modal_aerosols
-#endif
+    ! OSLO_AERO end
 
     !-----------------------------------------------------------------
     !       ... get species indicies
@@ -181,13 +175,10 @@ contains
     use chem_mods,    only : adv_mass
     use physconst,    only : mwdry, gravit
     use mo_constants, only : pi
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     use oslo_aero_sox_cldaero, only : sox_cldaero_update, sox_cldaero_create_obj, sox_cldaero_destroy_obj
     use oslo_aero_sox_cldaero, only : cldaero_conc_t
-#else
-    use sox_cldaero_mod, only : sox_cldaero_update, sox_cldaero_create_obj, sox_cldaero_destroy_obj
-    use cldaero_mod,     only : cldaero_conc_t
-#endif
+    ! OSLO_AERO end
     !
     implicit none
     !

--- a/src_cam/mo_srf_emissions.F90
+++ b/src_cam/mo_srf_emissions.F90
@@ -10,9 +10,9 @@ module mo_srf_emissions
   use ioFileMod,     only : getfil
   use cam_logfile,   only : iulog
   use tracer_data,   only : trfld,trfile
-#ifdef OSLO_AERO
+  ! OSLO_AERO begin
   use oslo_aero_ocean, only: oslo_aero_dms_inq
-#endif
+  ! OSLO_AERO end
 
   implicit none
 
@@ -39,9 +39,9 @@ module mo_srf_emissions
   type(emission), allocatable :: emissions(:)
   integer                     :: n_emis_files
   integer :: c10h16_ndx, isop_ndx
-#ifdef OSLO_AERO
+  ! OSLO_AERO begin
   integer :: dms_ndx
-#endif
+  ! OSLO_AERO end
 
 contains
 
@@ -291,9 +291,10 @@ contains
 
     c10h16_ndx = get_spc_ndx('C10H16')
     isop_ndx = get_spc_ndx('ISOP')
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     dms_ndx = get_spc_ndx('DMS')
-#endif
+    ! OSLO_AERO end
+
   end subroutine srf_emissions_inti
 
   subroutine set_srf_emissions_time( pbuf2d, state )
@@ -410,7 +411,7 @@ contains
     declination = dec_max * cos((doy_loc - 172._r8)*twopi/dayspy)
     tod = (calday - doy_loc) + .5_r8
 
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     ! Zero DMS emissions if option is not "from file"
     ! oslo_aero_dms_inq() Returns "true" if "emissions from file"
     if (.not. oslo_aero_dms_inq()) then
@@ -418,7 +419,7 @@ contains
           sflx(:ncol,dms_ndx) = 0.0_r8
        end if
     end if
-#endif
+  ! OSLO_AERO end
 
     do i = 1,ncol
        !

--- a/src_cam/mo_usrrxt.F90
+++ b/src_cam/mo_usrrxt.F90
@@ -3,9 +3,9 @@ module mo_usrrxt
   use shr_kind_mod,     only : r8 => shr_kind_r8
   use cam_logfile,      only : iulog
   use ppgrid,           only : pver, pcols
-#ifdef OSLO_AERO
+  ! OSLO_AERO begin
   use oslo_aero_share,  only: nmodes_oslo=> nmodes
-#endif
+  ! OSLO_AERO end
 
   implicit none
 
@@ -764,7 +764,7 @@ contains
     integer :: ntot_amode
 
     real(r8), pointer :: sfc_array(:,:,:), dm_array(:,:,:)
- !TS2
+
     real(r8) ::  aterm(ncol)
     real(r8) ::  natom
     real(r8) ::  nyield
@@ -772,12 +772,12 @@ contains
     real(r8) ::  exp_natom
 
     ! get info about the modal aerosols
+
     ! get ntot_amode
-#ifdef OSLO_AERO
+    ! OSLO_AERO begin
     ntot_amode = nmodes_oslo
-#else
-    call rad_cnst_get_info(0, nmodes=ntot_amode)
-#endif
+    ! OSLO_AERO end
+
     if (ntot_amode>0) then
        allocate(sfc_array(pcols,pver,ntot_amode), dm_array(pcols,pver,ntot_amode) )
     else

--- a/src_cam/radiation.F90
+++ b/src_cam/radiation.F90
@@ -1245,14 +1245,7 @@ subroutine radiation_tend( &
 
       ! OSLO_AERO begin
       if (dosw) then
-
          qdirind(:ncol,:,:) = state%q(:ncol,:,:)
-         if (has_prescribed_volcaero) then
-            call oslo_aero_getopts(volc_fraction_coarse_out = volc_fraction_coarse)
-            call pbuf_get_field(pbuf, volc_idx,  rvolcmmr, start=(/1,1,itim_old/), kount=(/pcols,pver,1/) )
-            qdirind(:ncol,:,l_so4_pr) = qdirind(:ncol,:,l_so4_pr) + (1.0_r8 - volc_fraction_coarse)*rvolcmmr(:ncol,:)
-            qdirind(:ncol,:,l_ss_a3) = qdirind(:ncol,:,l_ss_a3) + volc_fraction_coarse*rvolcmmr(:ncol,:)
-         end if
 
          ! Volcanic optics for solar (SW) bands
          do band=1,nswbands

--- a/src_cam/radiation.F90
+++ b/src_cam/radiation.F90
@@ -1247,12 +1247,6 @@ subroutine radiation_tend( &
       if (dosw) then
 
          qdirind(:ncol,:,:) = state%q(:ncol,:,:)
-         if (has_prescribed_volcaero) then
-            call oslo_aero_getopts(volc_fraction_coarse_out = volc_fraction_coarse)
-            call pbuf_get_field(pbuf, volc_idx,  rvolcmmr, start=(/1,1,itim_old/), kount=(/pcols,pver,1/) )
-            qdirind(:ncol,:,l_so4_pr) = qdirind(:ncol,:,l_so4_pr) + (1.0_r8 - volc_fraction_coarse)*rvolcmmr(:ncol,:)
-            qdirind(:ncol,:,l_ss_a3) = qdirind(:ncol,:,l_ss_a3) + volc_fraction_coarse*rvolcmmr(:ncol,:)
-         end if
 
          ! Volcanic optics for solar (SW) bands
          do band=1,nswbands

--- a/src_cam/radiation.F90
+++ b/src_cam/radiation.F90
@@ -152,7 +152,6 @@ integer :: flnt_idx     = 0
 integer :: cldfsnow_idx = 0
 integer :: cld_idx      = 0
 integer :: cldfgrau_idx = 0
-integer :: volc_idx     = 0
 
 character(len=4) :: diag(0:N_DIAG) =(/'    ','_d1 ','_d2 ','_d3 ','_d4 ','_d5 ','_d6 ','_d7 ','_d8 ','_d9 ','_d10'/)
 
@@ -779,8 +778,6 @@ subroutine radiation_tend( &
    type(rad_out_t), target, optional, intent(out) :: rd_out
 
    ! Local variables
-   real(r8)                 :: volc_fraction_coarse ! Fraction of volcanic aerosols going to coarse mode
-   real(r8), pointer        :: rvolcmmr(:,:)        ! stratospheric volcanoes aerosol mmr
    integer                  :: band
    logical                  :: idrf
    type(rad_out_t), pointer :: rd  ! allow rd_out to be optional by allocating a local object
@@ -1245,6 +1242,7 @@ subroutine radiation_tend( &
 
       ! OSLO_AERO begin
       if (dosw) then
+
          qdirind(:ncol,:,:) = state%q(:ncol,:,:)
 
          ! Volcanic optics for solar (SW) bands

--- a/src_cam/zm_microphysics.F90
+++ b/src_cam/zm_microphysics.F90
@@ -627,6 +627,10 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
 ! initialization
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
+  ! OSLO_AERO begin
+  call endrun('zm_microphysics not supported in oslo-aero')
+  ! OSLO_AERO end
+
   if (aero%scheme == 'modal') then
 
      allocate(vaerosol(aero%nmodes), hygro(aero%nmodes), naermod(aero%nmodes), &
@@ -1475,13 +1479,11 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
 
                     end if
 
-#ifndef OSLO_AERO
                     call activate_aerosol(  &
                        wu(i,k), wmix, wdiab, wmin, wmax,                 &
                        t(i,k), rho(i,k), naermod, aero%nmodes, vaerosol, &
                        hygro, aero_props_obj, fn, fm,                  &
                        fluxn, fluxm, flux_fullact, in_cloud_in=in_cloud, smax_f=smax_f)
-#endif
 
                     do m = 1, aero%nmodes
                        nlsrc = nlsrc + fn(m)*naermod(m)  !  number nucleated


### PR DESCRIPTION
This PR adds new sum diagnostics so that code can be compared with tropmam4. In addition, it also includes 2 bugfixes `oslo_aero/src/oslo_aero_dust_sediment.F90 and oslo_aero/src/oslo_aero_depos.F90` that resolve problems found in the first simulations with the updated oslo-aero in noresm2.5.