### PR TITLE
noresm2_3_develop : Introduction of possibility to run with full atmospheric chemistry

### DIFF
--- a/src/aero_model.F90
+++ b/src/aero_model.F90
@@ -370,8 +370,6 @@ contains
     reff_strat = 0._r8
     strato_sad = 0._r8
 
-!   write(iulog,*) 'modal_strat_sulfate : ', modal_strat_sulfate
-
     if (.not. modal_strat_sulfate) return
 
     beglev(:ncol)=top_lev
@@ -607,11 +605,6 @@ contains
   subroutine surf_area_dens( ncol, mmr, pmid, temp, beglev, endlev, sad, reff, sfc )
     ! djlo : diam kept out as argument
     use mo_constants     , only : pi
-!    use commondefinitions, only: nmodes_oslo => nmodes
-!    use const            , only: numberToSurface
-!    use aerosoldef       , only: lifeCycleNumberMedianRadius
-!    use aerosoldef       , only: lifeCycleSigma  ! djlo
-!    use oslo_utils       , only: calculateNumberConcentration
 
     ! dummy args
     integer,  intent(in)  :: ncol
@@ -641,7 +634,7 @@ contains
     !Get air density in all layers
     do k=1,pver
        do i=1,ncol
-          rho_air(i,k) = pmid(i,k)/(temp(i,k)*287.04_r8)
+          rho_air(i,k) = pmid(i,k)/(temp(i,k)*rair)
        end do
     end do
     !    
@@ -655,17 +648,15 @@ contains
     vol      = 0._r8
     reff     = 0._r8
 
-    do i=1,ncol ! djlo : added explicit loop over i (because of ltrop(i) dependence
+    do i=1,ncol ! djlo : added explicit loop over i (because of ltrop(i) dependence)
        do k=beglev(i),endlev(i)
           do m=1,nmodes_oslo
              if ( m .eq. 1 &
              .or. m .eq. 2 &
              .or. m .eq. 4 &
              .or. m .eq. 5 ) then
-! skipped mode 12 and 14
-!             .or. m .eq. 12 & 
-!             .or. m .eq. 14 ) then  
-
+!               currently only over modes 1,2,4 and 5   
+!               might be extended in the future with modes 12 and 14
                 sad_mode(i,k,m) = numberConcentration(i,k,m)*numberToSurface(m)*1.e-2_r8 !m2/m3 ==> cm2/cm3
 
                 vol_mode(i,k,m) = numberConcentration(i,k,m) &

--- a/src/aero_model.F90
+++ b/src/aero_model.F90
@@ -603,7 +603,7 @@ contains
   !=============================================================================
 
   subroutine surf_area_dens( ncol, mmr, pmid, temp, beglev, endlev, sad, reff, sfc )
-    ! djlo : diam kept out as argument
+    ! The input, diam, used by MAM, is not used in OSLO_AERO
     use mo_constants     , only : pi
 
     ! dummy args
@@ -611,7 +611,7 @@ contains
     real(r8), intent(in)  :: mmr(:,:,:)
     real(r8), intent(in)  :: pmid(:,:)
     real(r8), intent(in)  :: temp(:,:)
-    ! real(r8), intent(in)  :: diam(:,:,:) ! djlo : kept out as argument
+    ! real(r8), intent(in)  :: diam(:,:,:) ! diam, used by MAM, is not used in OSLO_AERO
     integer,  intent(in)  :: beglev(:)
     integer,  intent(in)  :: endlev(:)
     real(r8), intent(out) :: sad(:,:)
@@ -622,8 +622,8 @@ contains
     !HAVE TO GET RID OF THIS MODE 0!! MESSES UP EVERYTHING!!
     real(r8)         :: numberConcentration(pcols,pver,0:nmodes_oslo)
     real(r8), target :: sad_mode(pcols,pver, nmodes_oslo)
-    real(r8)         :: vol_mode(pcols,pver, nmodes_oslo) ! djlo
-    real(r8)         :: vol(pcols,pver)                   ! djlo
+    real(r8)         :: vol_mode(pcols,pver, nmodes_oslo)
+    real(r8)         :: vol(pcols,pver)                  
     real(r8) :: rho_air(pcols,pver)
     integer :: m
     integer :: i,k

--- a/src/aero_model.F90
+++ b/src/aero_model.F90
@@ -61,6 +61,8 @@ module aero_model
   use oslo_aero_aerocom_tables, only: initaeropt
   use oslo_aero_logn_tables,    only: initlogn
 
+  use modal_aero_wateruptake, only: modal_strat_sulfate
+
   implicit none
   private
 
@@ -100,7 +102,7 @@ contains
     integer :: unitn, ierr
     character(len=*), parameter :: subname = 'aero_model_readnl'
 
-    namelist /aerosol_nl/ sol_facti_cloud_borne, sol_factb_interstitial, sol_factic_interstitial
+    namelist /aerosol_nl/ sol_facti_cloud_borne, sol_factb_interstitial, sol_factic_interstitial, modal_strat_sulfate
     !-----------------------------------------------------------------------------
 
     ! Read namelist
@@ -121,6 +123,8 @@ contains
     if (ierr /= mpi_success) call endrun(subname//" mpi_bcast: sol_factb_interstitial")
     call mpi_bcast(sol_factic_interstitial, 1, mpi_real8, mstrid, mpicom, ierr)
     if (ierr /= mpi_success) call endrun(subname//" mpi_bcast: sol_factic_interstitial")
+    call mpi_bcast(modal_strat_sulfate, 1, mpi_real8, mstrid, mpicom, ierr)
+    if (ierr /= mpi_success) call endrun(subname//" mpi_bcast: modal_strat_sulfate")
 
     call oslo_aero_ctl_readnl(nlfilename)
     call oslo_aero_microp_readnl(nlfilename)
@@ -321,41 +325,23 @@ contains
     real(r8), intent(out)   :: reff_trop(:,:)
 
     ! local vars
-    ! HAVE TO GET RID OF THIS MODE 0!! MESSES UP EVERYTHING!!
-    real(r8)         :: numberConcentration(pcols,pver,0:nmodes_oslo)
-    real(r8), target :: sad_mode(pcols,pver,nmodes_oslo)
-    real(r8)         :: rho_air(pcols,pver)
-    integer          :: l,m,i,k
+    integer :: beglev(ncol)
+    integer :: endlev(ncol)
+  
+    integer :: i,k
 
-    ! Get air density
-    do k=1,pver
-       do i=1,ncol
-          rho_air(i,k) = pmid(i,k)/(temp(i,k)*287.04_r8)
-       end do
-    end do
+    beglev(:ncol)=ltrop(:ncol)+1
+    endlev(:ncol)=pver
 
-    ! Get number concentrations
-    call calculateNumberConcentration(ncol, mmr, rho_air, numberConcentration)
+    ! diameter left out as an argument                                                       
+      call surf_area_dens(ncol, mmr, pmid, temp, beglev, endlev, sad_trop, reff_trop, sfc=sfc) 
 
-    ! Convert to area using lifecycle-radius
-    sad_mode = 0._r8
-    sad_trop = 0._r8
-    do m=1,nmodes_oslo
-       do k=1,pver
-          sad_mode(:ncol,k,m) = numberConcentration(:ncol,k,m)*numberToSurface(m)*1.e-2_r8 !m2/m3 ==> cm2/cm3
-          sad_trop(:ncol,k) = sad_trop(:ncol,k) + sad_mode(:ncol,k,m)
-       end do
-    end do
-
-    do m=1,nmodes_oslo
-       do k=1,pver
-          sfc(:ncol,k,m) = sad_mode(:ncol,k,m)     ! aitken_idx:aitken_idx)
-          dm_aer(:ncol,k,m) = 2.0_r8*lifeCycleNumberMedianRadius(m)
-       end do
-    end do
-
-    ! Need to implement reff_trop here
-    reff_trop(:,:) = 1.0e-6_r8
+      do i = 1,ncol                                                                            
+         do k = ltrop(i)+1, pver                                                               
+            ! djlo : do not use the 0-th mode                                                  
+            dm_aer(i,k,:) = 2._r8 * lifeCycleNumberMedianRadius(1:nmodes_oslo) * 1.e-2_r8 ! radius ==> diameter, m ==> cm
+         enddo                                                                                 
+      enddo
 
   end subroutine aero_model_surfarea
 
@@ -377,8 +363,22 @@ contains
     real(r8), intent(out)   :: strato_sad(:,:)
     real(r8), intent(out)   :: reff_strat(:,:)
 
-    reff_strat = 0.1e-6_r8
+   ! local vars
+    integer :: beglev(ncol)
+    integer :: endlev(ncol)   
+
+    reff_strat = 0._r8
     strato_sad = 0._r8
+
+!   write(iulog,*) 'modal_strat_sulfate : ', modal_strat_sulfate
+
+    if (.not. modal_strat_sulfate) return
+
+    beglev(:ncol)=top_lev
+    endlev(:ncol)=ltrop(:ncol)
+    call surf_area_dens(ncol, mmr, pmid, temp, beglev, endlev, strato_sad, reff_strat)
+
+    return
 
   end subroutine aero_model_strat_surfarea
 
@@ -603,6 +603,88 @@ contains
   !=============================================================================
   ! private methods
   !=============================================================================
+
+  subroutine surf_area_dens( ncol, mmr, pmid, temp, beglev, endlev, sad, reff, sfc )
+    ! djlo : diam kept out as argument
+    use mo_constants     , only : pi
+!    use commondefinitions, only: nmodes_oslo => nmodes
+!    use const            , only: numberToSurface
+!    use aerosoldef       , only: lifeCycleNumberMedianRadius
+!    use aerosoldef       , only: lifeCycleSigma  ! djlo
+!    use oslo_utils       , only: calculateNumberConcentration
+
+    ! dummy args
+    integer,  intent(in)  :: ncol
+    real(r8), intent(in)  :: mmr(:,:,:)
+    real(r8), intent(in)  :: pmid(:,:)
+    real(r8), intent(in)  :: temp(:,:)
+    ! real(r8), intent(in)  :: diam(:,:,:) ! djlo : kept out as argument
+    integer,  intent(in)  :: beglev(:)
+    integer,  intent(in)  :: endlev(:)
+    real(r8), intent(out) :: sad(:,:)
+    real(r8), intent(out) :: reff(:,:)
+    real(r8),optional, intent(out) :: sfc(:,:,:)
+
+    ! local vars
+    !HAVE TO GET RID OF THIS MODE 0!! MESSES UP EVERYTHING!!
+    real(r8)         :: numberConcentration(pcols,pver,0:nmodes_oslo)
+    real(r8), target :: sad_mode(pcols,pver, nmodes_oslo)
+    real(r8)         :: vol_mode(pcols,pver, nmodes_oslo) ! djlo
+    real(r8)         :: vol(pcols,pver)                   ! djlo
+    real(r8) :: rho_air(pcols,pver)
+    integer :: m
+    integer :: i,k
+
+    ! Compute surface aero for each mode.
+    ! Total over all modes as the surface area for chemical reactions.
+
+    !Get air density in all layers
+    do k=1,pver
+       do i=1,ncol
+          rho_air(i,k) = pmid(i,k)/(temp(i,k)*287.04_r8)
+       end do
+    end do
+    !    
+    !Get number concentrations in all layers
+    call calculateNumberConcentration(ncol, mmr, rho_air, numberConcentration, isChemistry=.true.)
+
+    !Convert to area using lifecycle-radius
+    sad_mode = 0._r8
+    sad      = 0._r8
+    vol_mode = 0._r8
+    vol      = 0._r8
+    reff     = 0._r8
+
+    do i=1,ncol ! djlo : added explicit loop over i (because of ltrop(i) dependence
+       do k=beglev(i),endlev(i)
+          do m=1,nmodes_oslo
+             if ( m .eq. 1 &
+             .or. m .eq. 2 &
+             .or. m .eq. 4 &
+             .or. m .eq. 5 ) then
+! skipped mode 12 and 14
+!             .or. m .eq. 12 & 
+!             .or. m .eq. 14 ) then  
+
+                sad_mode(i,k,m) = numberConcentration(i,k,m)*numberToSurface(m)*1.e-2_r8 !m2/m3 ==> cm2/cm3
+
+                vol_mode(i,k,m) = numberConcentration(i,k,m) &
+                                * 4._r8 / 3._r8 * pi * lifeCycleNumberMedianRadius(m)**3._r8 &
+                                * dexp(4.5_r8 * log(lifeCycleSigma(m)) *log(lifeCyclesigma(m))) ! m3/m3 = cm3/cm3  
+             endif
+          end do
+
+          sad(i,k) = sum(sad_mode(i,k,:))
+          vol(i,k) = sum(vol_mode(i,k,:))
+          reff(i,k) = 3._r8 * vol(i,k) / sad(i,k) ! djlo : maybe if-test needed when sad=0?
+       end do
+    end do
+
+    if ( present(sfc) ) then
+       sfc(:,:,:) = sad_mode(:,:,:)
+    endif
+
+  end subroutine surf_area_dens
 
   subroutine qqcw2vmr(lchnk, vmr, mbar, ncol, im, pbuf)
 

--- a/src/oslo_aero_ocean.F90
+++ b/src/oslo_aero_ocean.F90
@@ -261,14 +261,14 @@ contains
           flux (:ncol) = 62.13*kwdms(:ncol)*1e-9*odms(:ncol)
        endif
 
-       cflx(:ncol,pndx_fdms) = flux(:ncol)
+       cflx(:ncol,pndx_fdms) = cflx(:ncol,pndx_fdms) + flux(:ncol)
 
        call outfld('odms', odms(:ncol), ncol, lchnk)
 
     elseif (dms_source=='ocean_flux') then
 
        ! if ocean flux
-       cflx(:ncol,pndx_fdms) = fdms(:ncol)
+       cflx(:ncol,pndx_fdms) = cflx(:ncol,pndx_fdms) + fdms(:ncol)
 
     endif
 

--- a/src/oslo_aero_share.F90
+++ b/src/oslo_aero_share.F90
@@ -849,21 +849,30 @@ contains
   end function qqcw_get_field
 
   !===============================================================================
-  subroutine calculateNumberConcentration(ncol, q, rho_air, numberConcentration)
+  subroutine calculateNumberConcentration(ncol, q, rho_air, numberConcentration, isChemistry)
 
     ! arguments
     integer  , intent(in)  :: ncol                                     !number of columns used
     real(r8) , intent(in)  :: q(pcols,pver,pcnst)                      ![kg/kg] mass mixing ratios
     real(r8) , intent(in)  :: rho_air(pcols,pver)                      ![kg/m3] air density
     real(r8) , intent(out) :: numberConcentration(pcols,pver,0:nmodes) ![#/m3] number concentration
+    logical, optional, intent(in) :: isChemistry
 
     ! local variables
     integer :: m, l, mm, k
+    logical :: isChemistry_local
 
     numberConcentration(:,:,:) = 0.0_r8
+
+    if ( present(isChemistry) ) then
+       isChemistry_local = isChemistry
+    else
+       isChemistry_local = .false.     ! standard setup
+    endif
+
     do m = 0, nmodes
        do l=1,getNumberOfBackgroundTracersInMode(m)
-          mm = getTracerIndex(m,l,.false.)
+          mm = getTracerIndex(m,l,isChemistry_local)
           do k=1,pver
              numberConcentration(:ncol,k,m) = numberConcentration(:ncol,k,m) &
                   + ( q(:ncol,k,mm) / getDryDensity(m,l))  !Volume of this tracer

--- a/src_cam/mo_gas_phase_chemdr.F90
+++ b/src_cam/mo_gas_phase_chemdr.F90
@@ -61,6 +61,7 @@ contains
 
      ! OSLO_AERO begin
     use mo_chem_utls,      only : get_spc_ndx, get_extfrc_ndx, get_rxt_ndx, get_inv_ndx
+    use modal_aero_wateruptake, only: modal_strat_sulfate
     ! OSLO_AERO end
     use cam_history,       only : addfld,add_default,horiz_only
     use mo_chm_diags,      only : chm_diags_inti
@@ -229,19 +230,21 @@ contains
 
     ! OSLO_AERO begin
     ! Adding extra fields for oxi-output (before and after diurnal variations.)
-    call addfld ('OH_bef    ',  (/ 'lev' /), 'A','unit', 'OH invariants before adding diurnal variations'           )
-    call addfld ('HO2_bef   ',  (/ 'lev' /), 'A','unit', 'HO2 invariants before adding diurnal variations'          )
-    call addfld ('NO3_bef   ',  (/ 'lev' /), 'A','unit', 'NO3 invariants before adding diurnal variations'          )
-    call addfld ('OH_aft    ',  (/ 'lev' /), 'A','unit', 'OH invariants after adding diurnal variations'            )
-    call addfld ('HO2_aft   ',  (/ 'lev' /), 'A','unit', 'HO2 invariants after adding diurnal variations'           )
-    call addfld ('NO3_aft   ',  (/ 'lev' /), 'A','unit', 'NO3 invariants after adding diurnal variations'           )
+    if (.not.modal_strat_sulfate) then
+       call addfld ('OH_bef    ',  (/ 'lev' /), 'A','unit', 'OH invariants before adding diurnal variations'           )
+       call addfld ('HO2_bef   ',  (/ 'lev' /), 'A','unit', 'HO2 invariants before adding diurnal variations'          )
+       call addfld ('NO3_bef   ',  (/ 'lev' /), 'A','unit', 'NO3 invariants before adding diurnal variations'          )
+       call addfld ('OH_aft    ',  (/ 'lev' /), 'A','unit', 'OH invariants after adding diurnal variations'            )
+       call addfld ('HO2_aft   ',  (/ 'lev' /), 'A','unit', 'HO2 invariants after adding diurnal variations'           )
+       call addfld ('NO3_aft   ',  (/ 'lev' /), 'A','unit', 'NO3 invariants after adding diurnal variations'           )
 
-    call add_default ('OH_bef       ', 1, ' ')
-    call add_default ('HO2_bef      ', 1, ' ')
-    call add_default ('NO3_bef      ', 1, ' ')
-    call add_default ('OH_aft       ', 1, ' ')
-    call add_default ('HO2_aft      ', 1, ' ')
-    call add_default ('NO3_aft      ', 1, ' ')
+       call add_default ('OH_bef       ', 1, ' ')
+       call add_default ('HO2_bef      ', 1, ' ')
+       call add_default ('NO3_bef      ', 1, ' ')
+       call add_default ('OH_aft       ', 1, ' ')
+       call add_default ('HO2_aft      ', 1, ' ')
+       call add_default ('NO3_aft      ', 1, ' ')
+    endif
     ! OSLO_AERO end
 
     if (het1_ndx>0) then
@@ -341,6 +344,7 @@ contains
     use gas_wetdep_opts,   only : gas_wetdep_method
     ! OSLO_AERO begin
     use oslo_aero_diurnal_var, only : set_diurnal_invariants
+    use modal_aero_wateruptake, only: modal_strat_sulfate
     ! OSLO_AERO end
     use physics_buffer,    only : physics_buffer_desc, pbuf_get_field, pbuf_old_tim_idx
     use infnan,            only : nan, assignment(=)
@@ -672,16 +676,20 @@ contains
     !-----------------------------------------------------------------------
     !        ... Set the "day/night cycle for prescribed oxidants"
     !-----------------------------------------------------------------------
-    call outfld('OH_bef',    invariants(:,:,id_oh),  ncol, lchnk)
-    call outfld('HO2_bef',   invariants(:,:,id_ho2), ncol, lchnk)
-    call outfld('NO3_bef',   invariants(:,:,id_no3), ncol, lchnk)
+    if (.not.modal_strat_sulfate) then 
+       call outfld('OH_bef',    invariants(:,:,id_oh),  ncol, lchnk)
+       call outfld('HO2_bef',   invariants(:,:,id_ho2), ncol, lchnk)
+       call outfld('NO3_bef',   invariants(:,:,id_no3), ncol, lchnk)
+    endif
 
     if (inv_oh.or.inv_ho2.or.inv_no3)  & !++IH: added inv_no3
       call set_diurnal_invariants(invariants,delt,ncol,lchnk,inv_oh,inv_ho2,id_oh,id_ho2,inv_no3,id_no3) !++IH: added inv_no3 and id_no3
 
-    call outfld('OH_aft',    invariants(:,:,id_oh),  ncol, lchnk)
-    call outfld('HO2_aft',   invariants(:,:,id_ho2), ncol, lchnk)
-    call outfld('NO3_aft',   invariants(:,:,id_no3), ncol, lchnk)
+    if (.not.modal_strat_sulfate) then
+       call outfld('OH_aft',    invariants(:,:,id_oh),  ncol, lchnk)
+       call outfld('HO2_aft',   invariants(:,:,id_ho2), ncol, lchnk)
+       call outfld('NO3_aft',   invariants(:,:,id_no3), ncol, lchnk)
+    endif
     ! OSLO_AERO end
     !-----------------------------------------------------------------------
     !        ... stratosphere aerosol surface area

--- a/src_cam/mo_gas_phase_chemdr.F90
+++ b/src_cam/mo_gas_phase_chemdr.F90
@@ -231,12 +231,12 @@ contains
     ! OSLO_AERO begin
     ! Adding extra fields for oxi-output (before and after diurnal variations.)
     if (.not.modal_strat_sulfate) then
-       call addfld ('OH_bef    ',  (/ 'lev' /), 'A','unit', 'OH invariants before adding diurnal variations'           )
-       call addfld ('HO2_bef   ',  (/ 'lev' /), 'A','unit', 'HO2 invariants before adding diurnal variations'          )
-       call addfld ('NO3_bef   ',  (/ 'lev' /), 'A','unit', 'NO3 invariants before adding diurnal variations'          )
-       call addfld ('OH_aft    ',  (/ 'lev' /), 'A','unit', 'OH invariants after adding diurnal variations'            )
-       call addfld ('HO2_aft   ',  (/ 'lev' /), 'A','unit', 'HO2 invariants after adding diurnal variations'           )
-       call addfld ('NO3_aft   ',  (/ 'lev' /), 'A','unit', 'NO3 invariants after adding diurnal variations'           )
+       call addfld ('OH_bef    ',  (/ 'lev' /), 'A','molecules cm-3', 'OH invariants before adding diurnal variations'           )
+       call addfld ('HO2_bef   ',  (/ 'lev' /), 'A','molecules cm-3', 'HO2 invariants before adding diurnal variations'          )
+       call addfld ('NO3_bef   ',  (/ 'lev' /), 'A','molecules cm-3', 'NO3 invariants before adding diurnal variations'          )
+       call addfld ('OH_aft    ',  (/ 'lev' /), 'A','molecules cm-3', 'OH invariants after adding diurnal variations'            )
+       call addfld ('HO2_aft   ',  (/ 'lev' /), 'A','molecules cm-3', 'HO2 invariants after adding diurnal variations'           )
+       call addfld ('NO3_aft   ',  (/ 'lev' /), 'A','molecules cm-3', 'NO3 invariants after adding diurnal variations'           )
 
        call add_default ('OH_bef       ', 1, ' ')
        call add_default ('HO2_bef      ', 1, ' ')

--- a/src_cam/mo_srf_emissions.F90
+++ b/src_cam/mo_srf_emissions.F90
@@ -386,11 +386,11 @@ contains
     ! OSLO_AERO begin
     ! Remove DMS emissions if option is not "from file"
     ! Online emissions are treated in seasalt module
-    if (.not. oslo_aero_dms_inq())  then ! Returns "True" if "emissions from file"
-       if (dms_ndx .gt. 0)then
-          sflx(:,dms_ndx) = 0.0_r8
-       end if
-    end if
+!    if (.not. oslo_aero_dms_inq())  then ! Returns "True" if "emissions from file"
+!       if (dms_ndx .gt. 0)then
+!          sflx(:,dms_ndx) = 0.0_r8
+!       end if
+!    end if
     ! OSLO_AERO end
 
     do i = 1,ncol

--- a/src_cam/mo_srf_emissions.F90
+++ b/src_cam/mo_srf_emissions.F90
@@ -12,9 +12,6 @@ module mo_srf_emissions
   use ppgrid,        only : pcols, begchunk, endchunk
   use cam_logfile,   only : iulog
   use tracer_data,   only : trfld,trfile
-  ! OSLO_AERO begin
-  use oslo_aero_ocean, only: oslo_aero_dms_inq
-  ! OSLO_AERO end
 
   implicit none
 
@@ -382,16 +379,6 @@ contains
     doy_loc     = aint( calday )
     declination = dec_max * cos((doy_loc - 172._r8)*twopi/dayspy)
     tod = (calday - doy_loc) + .5_r8
-
-    ! OSLO_AERO begin
-    ! Remove DMS emissions if option is not "from file"
-    ! Online emissions are treated in seasalt module
-!    if (.not. oslo_aero_dms_inq())  then ! Returns "True" if "emissions from file"
-!       if (dms_ndx .gt. 0)then
-!          sflx(:,dms_ndx) = 0.0_r8
-!       end if
-!    end if
-    ! OSLO_AERO end
 
     do i = 1,ncol
        !


### PR DESCRIPTION
General :
Introduction of the ability to run with more complex atmospheric gas-phase chemistry.   This PR goes together with a separate PR for CAM and one for NorESM.

The main changes are related to :
- calculation of aerosol surface density used in heterogeneous chemistry (aero_model.F90)
- calculation of aerosol number concentration which can be called for chemical q instead of physical q (oslo_aero_share.F90)
- not writing anymore oxidant climatologies which are not used (mo_gas_phase_chemdr.F90).  The namelist variable modal_strat_sulfate is used to distinguish.  
- allowing DMS emissions from file (e.g., biomass burning), in addition to interactive emissions from ocean (mo_srf_emissions.F90 and oslo_aero_ocean.F90)
