### PR TITLE
update DMS exchange

### DIFF
--- a/src/aero_model.F90
+++ b/src/aero_model.F90
@@ -60,7 +60,6 @@ module aero_model
   use oslo_aero_aerodry_tables, only: initdry
   use oslo_aero_aerocom_tables, only: initaeropt
   use oslo_aero_logn_tables,    only: initlogn
-  use atm_import_export,        only: dms_from_ocn
 
   implicit none
   private
@@ -79,8 +78,10 @@ module aero_model
 
   ! Misc private data
   integer :: pblh_idx= 0
-  integer :: ndx_h2so4, ndx_soa_lv, ndx_soa_sv ! for surf_area_dens
-  logical :: convproc_do_aer
+  integer :: ndx_h2so4 = -1  ! for surf_area_dens
+  integer :: ndx_soa_lv = -1 ! for surf_area_dens
+  integer :: ndx_soa_sv = -1 ! for surf_area_dens
+  logical :: convproc_do_aer = .false.
 
   ! Namelist variables
   real(r8) :: sol_facti_cloud_borne   = 1._r8
@@ -580,6 +581,7 @@ contains
 
   !=============================================================================
   subroutine aero_model_emissions( state, cam_in )
+     use phys_control, only: dms_from_ocn
 
     ! Arguments:
     type(physics_state), intent(in)    :: state   ! Physics state variables
@@ -593,7 +595,7 @@ contains
        call oslo_aero_seasalt_emis(state%ncol, state%lchnk, &
             state%u(:,pver), state%v(:,pver), state%zm(:,pver), &
             cam_in%ocnfrac, cam_in%icefrac, cam_in%sst, cam_in%cflx)
-    endif
+    end if
 
     ! Pick up correct DMS emissions (replace values from file if requested)
     ! If DMS is sent from the ocean then cflx is updated in the nuopc cap

--- a/src/aero_model.F90
+++ b/src/aero_model.F90
@@ -60,6 +60,7 @@ module aero_model
   use oslo_aero_aerodry_tables, only: initdry
   use oslo_aero_aerocom_tables, only: initaeropt
   use oslo_aero_logn_tables,    only: initlogn
+  use atm_import_export,        only: dms_from_ocn
 
   implicit none
   private
@@ -595,9 +596,12 @@ contains
     endif
 
     ! Pick up correct DMS emissions (replace values from file if requested)
-    call oslo_aero_dms_emis(state%ncol, state%lchnk, &
-         state%u(:,pver), state%v(:,pver), state%zm(:,pver), &
-         cam_in%ocnfrac, cam_in%icefrac, cam_in%sst, cam_in%fdms, cam_in%cflx)
+    ! If DMS is sent from the ocean then cflx is updated in the nuopc cap
+    if (.not. dms_from_ocn) then
+       call oslo_aero_dms_emis(state%ncol, state%lchnk, &
+            state%u(:,pver), state%v(:,pver), state%zm(:,pver), &
+            cam_in%ocnfrac, cam_in%icefrac, cam_in%sst, cam_in%cflx)
+    end if
 
   end subroutine aero_model_emissions
 

--- a/src/aero_model.F90
+++ b/src/aero_model.F90
@@ -581,7 +581,7 @@ contains
 
   !=============================================================================
   subroutine aero_model_emissions( state, cam_in )
-     use phys_control, only: dms_from_ocn
+     use oslo_aero_control, only: dms_from_ocn
 
     ! Arguments:
     type(physics_state), intent(in)    :: state   ! Physics state variables

--- a/src/oslo_aero_control.F90
+++ b/src/oslo_aero_control.F90
@@ -10,13 +10,17 @@ module oslo_aero_control
   use namelist_utils,    only: find_group_name
   use cam_logfile,       only: iulog
   use cam_abortutils,    only: endrun
-  use atm_import_export, only: dms_from_ocn
+  use atm_import_export, only: drv_dms_from_ocn => dms_from_ocn
 
   implicit none
   private
 
   public :: oslo_aero_ctl_readnl ! read namelist from file
   public :: oslo_aero_getopts    ! generic query method
+
+  ! Public module data
+  ! Take DMS from ocean?
+  logical, public, protected :: dms_from_ocn = .false.
 
   ! Private module data
   character(len=16), parameter :: unset_str = 'UNSET'
@@ -102,6 +106,9 @@ contains
     if (ierr /= mpi_success) call endrun(subname//" mpi_bcast: ocean_filename")
     call mpi_bcast(ocean_filepath, len(ocean_filepath), mpi_character, mstrid, mpicom, ierr)
     if (ierr /= mpi_success) call endrun(subname//" mpi_bcast: ocean_filepath")
+
+    ! Set this from the driver namelist (always read first)
+    dms_from_ocn = drv_dms_from_ocn
 
     ! Reset dms_source if ocean is sending dms to atm
     if (dms_from_ocn) then

--- a/src/oslo_aero_ocean.F90
+++ b/src/oslo_aero_ocean.F90
@@ -24,6 +24,7 @@ module oslo_aero_ocean
   use physics_types,  only : physics_state
   use physics_buffer, only : physics_buffer_desc
   use tracer_data,    only : trfld, trfile, trcdata_init, advance_trcdata
+  use atm_import_export, only : brf_from_ocn
   !
   use oslo_aero_control, only: oslo_aero_getopts
 
@@ -48,7 +49,6 @@ module oslo_aero_ocean
 
   ! Private interfaces
   private:: oslo_aero_ocean_getnl
-
 
   !  These variables are settable via the namelist (with longer names)
   !  For reading concentration file
@@ -207,7 +207,10 @@ contains
   endsubroutine oslo_aero_ocean_adv
 
   !===============================================================================
-  subroutine oslo_aero_dms_emis(ncol, lchnk, u, v, zm, ocnfrc, icefrc, sst, fdms, cflx)
+  subroutine oslo_aero_dms_emis(ncol, lchnk, u, v, zm, ocnfrc, icefrc, sst, cflx)
+
+    ! Compute dms emissions from ocean
+    ! Called from aero_model_emissions
 
     ! arguments
     integer  , intent(in)    :: ncol  ![nbr] number of columns in use
@@ -218,12 +221,10 @@ contains
     real(r8) , intent(in)    :: ocnfrc(pcols)
     real(r8) , intent(in)    :: icefrc(pcols)
     real(r8) , intent(in)    :: sst(pcols)
-    real(r8) , intent(in)    :: fdms(pcols)
     real(r8) , intent(inout) :: cflx(pcols,pcnst)
 
     ! local variables
     real(r8) :: u10m(pcols)     ! [m/s]
-    real(r8) :: rk600(pcols)    ! ocean/atmos. DMS exchange factor [cm/hr]
     real(r8) :: flux(pcols)     ! Local flux array: DMS emission rate [kg m-2 s-1]
     real(r8) :: odms(pcols)     ! Ocean dms concentration [nmol/L] from file
     real(r8) :: open_ocn(pcols) ! Open Ocean
@@ -232,11 +233,9 @@ contains
     real(r8) :: kwdms(pcols)
     real(r8), parameter :: z0= 0.0001_r8     ! [m] roughness length over ocean
     real(r8), parameter :: Xconvxa= 6.97e-07 ! Wanninkhof's a=0.251 converted to ms-1/(ms-1)^2
-    logical , parameter :: method_oslo   = .false.
-    logical , parameter :: method_hamocc = .true.
 
+    ! use interpolated data if appropriate
     if (dms_source=='lana' .or. dms_source=='kettle') then
-
        ! if concentration file - obtain dms data from file
        flux(:) = 0._r8
        odms(:) = 0._r8
@@ -246,31 +245,18 @@ contains
        open_ocn(:ncol) = ocnfrc(:ncol) * (1._r8-icefrc(:ncol))
 
        !start with midpoint wind speed
-       u10m(:ncol)=sqrt(u(:ncol)**2 + v(:ncol)**2)
+       u10m(:ncol) = sqrt(u(:ncol)**2 + v(:ncol)**2)
 
-       if (method_oslo) then
-          ! move the winds to 10m high from the midpoint of the gridbox:
-          u10m (:ncol) = u10m(:ncol)*log(10._r8/z0)/log(zm(:ncol)/z0)
-          rk600(:ncol) = (0.222_r8*(u10m(:ncol)*u10m(:ncol))) + (0.333_r8*u10m(:ncol))        ! [cm/hr]
-          flux (:ncol) = 2.778e-15*cnst_mw(pndx_fdms)*rk600(:ncol)*open_ocn(:ncol)*odms(:ncol) ! [kg m-2 s-1]
-       else if (method_hamocc) then
-          t(:ncol)     = sst(:ncol)-273.15_r8
-          u10m (:ncol) = u10m(:ncol)*log(10._r8/z0)/log(zm(:ncol)/z0)
-          scdms(:ncol) = 2855.7+  (-177.63 + (6.0438 + (-0.11645 + 0.00094743*t(:ncol))*t(:ncol))*t(:ncol))*t(:ncol)
-          kwdms(:ncol) = open_ocn(:ncol) * Xconvxa *u10m(:ncol)**2*(660./scdms(:ncol))**0.5
-          flux (:ncol) = 62.13*kwdms(:ncol)*1e-9*odms(:ncol)
-       endif
-
-       cflx(:ncol,pndx_fdms) = flux(:ncol)
-
+       ! method_hamocc is the only one supported
+       t(:ncol)     = sst(:ncol)-273.15_r8
+       u10m (:ncol) = u10m(:ncol)*log(10._r8/z0)/log(zm(:ncol)/z0)
+       scdms(:ncol) = 2855.7+  (-177.63 + (6.0438 + (-0.11645 + 0.00094743*t(:ncol))*t(:ncol))*t(:ncol))*t(:ncol)
+       kwdms(:ncol) = open_ocn(:ncol) * Xconvxa *u10m(:ncol)**2*(660./scdms(:ncol))**0.5
+       flux (:ncol) = 62.13*kwdms(:ncol)*1e-9*odms(:ncol)
        call outfld('odms', odms(:ncol), ncol, lchnk)
 
-    elseif (dms_source=='ocean_flux') then
-
-       ! if ocean flux
-       cflx(:ncol,pndx_fdms) = fdms(:ncol)
-
-    endif
+       cflx(:ncol,pndx_fdms) = flux(:ncol)
+    end if
 
     ! IF EMISSION FILE
     ! return without changing cflx

--- a/src/oslo_aero_ocean.F90
+++ b/src/oslo_aero_ocean.F90
@@ -24,7 +24,6 @@ module oslo_aero_ocean
   use physics_types,  only : physics_state
   use physics_buffer, only : physics_buffer_desc
   use tracer_data,    only : trfld, trfile, trcdata_init, advance_trcdata
-  use atm_import_export, only : brf_from_ocn
   !
   use oslo_aero_control, only: oslo_aero_getopts
 


### PR DESCRIPTION
- DMS flux is not computed if `dms_from_ocn` (module variable in atm_import_export) is .false.
    -  `cflx(:ncol,pndx_fdms)` is only updated in oslo_aero_ocean 
- if DMS is received from ocn based on the config variable `dms_from_ocn` then `Fall_fdms_ocn` is advertised in the nuopc cap and `cflx(:ncol,pndx_fdms)` is updated in atm_import_export as follows:
```F90
    call state_getfldptr(importState,  'Faoo_fdms_ocn', fldptr=fldptr1d, exists=exists, rc=rc)
    if (exists) then
       call cnst_get_ind('DMS', pndx_fdms, abort=.true.)
       g = 1
       do c = begchunk,endchunk
          do i = 1,get_ncols_p(c)
             cam_in(c)%fdms(i) = -fldptr1d(g) * med2mod_areacor(g)
             cam_in(c)%cflx(i,pndx_fdms) = cam_in(c)%fdms(i)
             g = g + 1
          end do
          ncols = get_ncols_p(c)
          call outfld( sflxnam(pndx_fdms), cam_in(c)%cflx(:ncols,pndx_fdms), ncols, c)
       end do
    end if
```
This PR needs to be accompanied by https://github.com/NorESMhub/CAM/pull/168 - but needs to come in first.