### PR TITLE
Fix rhoh2o override to make gnu-complier happy

### DIFF
--- a/src/oslo_aero_depos.F90
+++ b/src/oslo_aero_depos.F90
@@ -56,7 +56,6 @@ module oslo_aero_depos
   real(r8), public :: sol_facti_cloud_borne
 
   real(r8), parameter :: cmftau = 3600._r8
-  real(r8), parameter :: rhoh2o = 1000._r8 ! density of water
   real(r8), parameter :: molwta = 28.97_r8 ! molecular weight dry air gm/mole
 
   type wetdep_inputs_t


### PR DESCRIPTION
`rhoh2o` is a parameter "USEd" from physconst which imports it from shr_const_mod. Attempting to redefine it (with the same value) as a parameter is conflict which just happened to not generate an error with the Intel compilers we have been using. Removing the module parameter definition allows the clean import from shr_const_mod.