### PR TITLE
Remove duplicate definition of rhoh2o

### DIFF
--- a/src/oslo_aero_coag.F90
+++ b/src/oslo_aero_coag.F90
@@ -11,7 +11,7 @@ module oslo_aero_coag
   use chem_mods,      only: gas_pcnst
   use mo_tracname,    only: solsym
   use mo_constants,   only: pi
-  use physconst,      only: rair, gravit
+  use physconst,      only: rair, gravit, rhoh2o
   use cam_history,    only: addfld, add_default, fieldname_len, horiz_only, outfld
   use cam_logfile,    only: iulog
   !
@@ -99,7 +99,6 @@ module oslo_aero_coag
   real(r8), parameter :: temperatureLookupTables = 293.15_r8 !Temperature used in look up tables
   real(r8), parameter :: mfpAir = 63.3e-9_r8                 ![m] mean free path air
   real(r8), parameter :: viscosityAir = 1.983e-5_r8          ![Pa s] viscosity of air
-  real(r8), parameter :: rhoh2o = 1000._r8                   !Density of water
 
 !================================================================
 contains

--- a/src/oslo_aero_depos.F90
+++ b/src/oslo_aero_depos.F90
@@ -56,7 +56,6 @@ module oslo_aero_depos
   real(r8), public :: sol_facti_cloud_borne
 
   real(r8), parameter :: cmftau = 3600._r8
-  real(r8), parameter :: rhoh2o = 1000._r8 ! density of water
   real(r8), parameter :: molwta = 28.97_r8 ! molecular weight dry air gm/mole
 
   type wetdep_inputs_t


### PR DESCRIPTION
`rhoh2o` is a parameter "USEd" from physconst which imports it from shr_const_mod. Attempting to redefine it (with the same value) as a parameter is conflict which just happened to not generate an error with the Intel compilers we have been using. Removing the module parameter definition allows the clean import from shr_const_mod.