### PR TITLE
oslo_aero_3_0a001: Updated shadow files

### DIFF
--- a/src/oslo_aero_control.F90
+++ b/src/oslo_aero_control.F90
@@ -10,7 +10,7 @@ module oslo_aero_control
   use namelist_utils,    only: find_group_name
   use cam_logfile,       only: iulog
   use cam_abortutils,    only: endrun
-  use atm_import_export, only: drv_dms_from_ocn => dms_from_ocn
+  use cam_control_mod,   only: dms_from_ocn
 
   implicit none
   private
@@ -20,7 +20,7 @@ module oslo_aero_control
 
   ! Public module data
   ! Take DMS from ocean?
-  logical, public, protected :: dms_from_ocn = .false.
+  public :: dms_from_ocn ! Forward from cam_control_mod
 
   ! Private module data
   character(len=16), parameter :: unset_str = 'UNSET'
@@ -106,9 +106,6 @@ contains
     if (ierr /= mpi_success) call endrun(subname//" mpi_bcast: ocean_filename")
     call mpi_bcast(ocean_filepath, len(ocean_filepath), mpi_character, mstrid, mpicom, ierr)
     if (ierr /= mpi_success) call endrun(subname//" mpi_bcast: ocean_filepath")
-
-    ! Set this from the driver namelist (always read first)
-    dms_from_ocn = drv_dms_from_ocn
 
     ! Reset dms_source if ocean is sending dms to atm
     if (dms_from_ocn) then

--- a/src/oslo_aero_dust.F90
+++ b/src/oslo_aero_dust.F90
@@ -1,244 +1,282 @@
 module oslo_aero_dust
 
-  ! Calculate emission of all dusts.
-  ! Note that the mobilization is calculated in the land model and
-  ! the soil erodibility factor is applied here.
+   ! Calculate emission of all dusts.
+   ! Note that the mobilization is calculated in the land model and
+   ! the soil erodibility factor is applied here.
 
-  use shr_kind_mod,     only: r8 => shr_kind_r8, cl => shr_kind_cl
-  use spmd_utils,       only: mpicom, mstrid=>masterprocid, masterproc
-  use spmd_utils,       only: mpi_logical, mpi_real8, mpi_character, mpi_integer,  mpi_success
-  use namelist_utils,   only: find_group_name
-  use ppgrid,           only: pcols, begchunk, endchunk
-  use phys_grid,        only: get_ncols_p, get_rlat_all_p, get_rlon_all_p
-  use constituents,     only: cnst_name, pcnst
-  use interpolate_data, only: lininterp_init, lininterp, lininterp_finish, interp_type
-  use mo_constants,     only: pi, d2r
-  use cam_logfile,      only: iulog
-  use cam_abortutils,   only: endrun
-  use cam_pio_utils,    only: cam_pio_openfile
-  use ioFileMod,        only: getfil
-  use pio,              only: file_desc_t,pio_inq_dimid,pio_inq_dimlen,pio_get_var,pio_inq_varid, PIO_NOWRITE
-  !
-  use oslo_aero_share,  only: l_dst_a2, l_dst_a3
+   use shr_kind_mod,     only: r8 => shr_kind_r8, cl => shr_kind_cl
+   use shr_const_mod,    only: pi => shr_const_pi
+   use spmd_utils,       only: mpicom, mstrid=>masterprocid, masterproc
+   use spmd_utils,       only: mpi_real8, mpi_character, mpi_success
+   use namelist_utils,   only: find_group_name
+   use ppgrid,           only: pcols, begchunk, endchunk
+   use phys_grid,        only: get_ncols_p, get_rlat_all_p, get_rlon_all_p
+   use constituents,     only: cnst_name, pcnst
+   use interpolate_data, only: lininterp_init, lininterp
+   use interpolate_data, only: lininterp_finish, interp_type
+   use cam_logfile,      only: iulog
+   use cam_abortutils,   only: endrun
+   use cam_pio_utils,    only: cam_pio_openfile
+   use ioFileMod,        only: getfil
+   use pio,              only: file_desc_t, pio_inq_dimid, pio_inq_dimlen
+   use pio,              only: pio_get_var, pio_inq_varid, PIO_NOWRITE
+   !
+   use oslo_aero_share,  only: l_dst_a2, l_dst_a3
 
-  implicit none
-  private
+   implicit none
+   private
 
-  ! public routines
-  public :: oslo_aero_dust_readnl
-  public :: oslo_aero_dust_init
-  public :: oslo_aero_dust_emis
+   ! public routines
+   public :: oslo_aero_dust_readnl
+   public :: oslo_aero_dust_init
+   public :: oslo_aero_dust_emis
 
-  ! private routines (previously in soil_erod_mod in CAM)
-  private :: soil_erod_init
+   ! private routines (previously in soil_erod_mod in CAM)
+   private :: soil_erod_init
 
-  character(len=6), public :: dust_names(10)
+   character(len=6), public :: dust_names(10)
 
-  integer , parameter :: numberOfDustModes = 2  !define in oslo_aero_share?
-  real(r8), parameter :: emis_fraction_in_mode(numberOfDustModes) = (/0.13_r8, 0.87_r8 /)
-  integer             :: tracerMap(numberOfDustModes) = (/-99, -99/) !index of dust tracers in the modes
+   integer , parameter :: numberOfDustModes = 2  !define in oslo_aero_share?
+   real(r8), parameter :: emis_fraction_in_mode(numberOfDustModes) = (/0.13_r8, 0.87_r8 /)
+   integer             :: tracerMap(numberOfDustModes) = (/-99, -99/) !index of dust tracers in the modes
 
-  integer , parameter, public :: dust_nbin = numberOfDustModes
+   integer , parameter, public :: dust_nbin = numberOfDustModes
 
-  !Related to soil erodibility
-  real(r8)          :: dust_emis_fact = -1.e36_r8        ! tuning parameter for dust emissions
-  character(len=cl) :: soil_erod_file = 'soil_erod_file' ! full pathname for soil erodibility dataset
+   !Related to soil erodibility
+   real(r8)          :: dust_emis_fact = -1.e36_r8        ! tuning parameter for dust emissions
+   character(len=cl) :: soil_erod_file = 'none' ! full pathname for soil erodibility dataset
 
-  logical, parameter, public :: dust_active = .TRUE.
+   logical, parameter, public :: dust_active = .TRUE.
 
-  real(r8), allocatable ::  soil_erodibility(:,:)  ! soil erodibility factor
-  real(r8) :: soil_erod_fact                       ! tuning parameter for dust emissions
+   real(r8), allocatable ::  soil_erodibility(:,:) ! soil erodibility factor
+   real(r8)              :: soil_erod_fact         ! tuning parameter for dust emissions
 
-!===============================================================================
+   real(r8), parameter ::  d2r  = pi/180._r8                 ! radians to degrees
+
+
+!=============================================================================
 contains
-!===============================================================================
+!=============================================================================
 
-  subroutine oslo_aero_dust_readnl(nlfile)
+   subroutine oslo_aero_dust_readnl(nlfile)
+      use shr_dust_emis_mod, only: is_dust_emis_zender
+      use shr_dust_emis_mod, only: is_zender_soil_erod_from_atm
+      use shr_dust_emis_mod, only: shr_dust_emis_readnl
 
-    character(len=*), intent(in) :: nlfile  ! filepath for file containing namelist input
+      character(len=*), intent(in) :: nlfile  ! filepath for namelist file
 
-    ! Local variables
-    integer :: unitn, ierr
-    character(len=*), parameter :: subname = 'dust_readnl'
+      ! Local variables
+      integer                     :: unitn, ierr
+      character(len=*), parameter :: subname = 'dust_readnl'
 
-    namelist /dust_nl/ dust_emis_fact, soil_erod_file
-    !-----------------------------------------------------------------------------
+      namelist /dust_nl/ dust_emis_fact, soil_erod_file
+      !---------------------------------------------------------------------------
 
-    ! Read namelist
-    if (masterproc) then
-       open( newunit=unitn, file=trim(nlfile), status='old' )
-       call find_group_name(unitn, 'dust_nl', status=ierr)
-       if (ierr == 0) then
-          read(unitn, dust_nl, iostat=ierr)
-          if (ierr /= 0) then
-             call endrun(subname // ':: ERROR reading namelist')
-          end if
-       end if
-       close(unitn)
-    end if
-    ! Broadcast namelist variables
-    call mpi_bcast(dust_emis_fact, 1, mpi_real8, mstrid, mpicom, ierr)
-    if (ierr /= mpi_success) call endrun(subname//" mpi_bcast: dust_emis_fact")
-    call mpi_bcast(soil_erod_file, len(soil_erod_file), mpi_character, mstrid, mpicom, ierr)
-    if (ierr /= mpi_success) call endrun(subname//" mpi_bcast: soil_erod_file")
+      ! Read namelist
+      if (masterproc) then
+         open( newunit=unitn, file=trim(nlfile), status='old' )
+         call find_group_name(unitn, 'dust_nl', status=ierr)
+         if (ierr == 0) then
+            read(unitn, dust_nl, iostat=ierr)
+            if (ierr /= 0) then
+               call endrun(subname // ':: ERROR reading namelist')
+            end if
+         end if
+         close(unitn)
+      end if
 
-  end subroutine oslo_aero_dust_readnl
+      ! Broadcast namelist variables
+      call mpi_bcast(dust_emis_fact, 1, mpi_real8, mstrid, mpicom, ierr)
+      if (ierr /= mpi_success) then
+         call endrun(subname//" mpi_bcast: dust_emis_fact")
+      end if
+      call mpi_bcast(soil_erod_file, len(soil_erod_file), mpi_character, &
+           mstrid, mpicom, ierr)
+      if (ierr /= mpi_success) then
+         call endrun(subname//" mpi_bcast: soil_erod_file")
+      end if
 
-  !===============================================================================
-  subroutine oslo_aero_dust_init()
+      call shr_dust_emis_readnl(mpicom, 'drv_flds_in')
 
-    ! local variables
-    integer :: imode
+      if ((soil_erod_file /= 'none') .and. &
+           (.not. is_zender_soil_erod_from_atm())) then
+         call endrun(subname//': should not specify soil_erod_file if Zender soil erosion is not in CAM')
+      end if
 
-    call soil_erod_init( dust_emis_fact, soil_erod_file )
+      if (masterproc) then
+         if (is_dust_emis_zender()) then
+            write(iulog,*) subname,': Zender_2003 dust emission method is being used.'
+         end if
+         if (is_zender_soil_erod_from_atm()) then
+            write(iulog, *) subname, ': Zender soil erod file is handled in atm'
+            write(iulog, *) subname, ': soil_erod_file = ', trim(soil_erod_file)
+            write(iulog, *) subname, ': dust_emis_fact = ', dust_emis_fact
+         else
+            !! XXgoldyXX: Remove this when Leung_2023 is implemented
+            call endrun(subname//': Leung_2023 dust emissions not implemented')
+         end if
+      end if
 
-    ! Set module variables
-    tracerMap(1) = l_dst_a2
-    tracerMap(2) = l_dst_a3
+   end subroutine oslo_aero_dust_readnl
 
-    dust_names(:)="      "
-    do imode=1,numberOfDustModes
-       dust_names(imode) = cnst_name(tracerMap(imode))
-    end do
+   !=============================================================================
+   subroutine oslo_aero_dust_init()
+      use shr_dust_emis_mod, only: is_zender_soil_erod_from_atm
 
-  end subroutine oslo_aero_dust_init
+      ! local variables
+      integer :: imode
 
-  !===============================================================================
-  subroutine oslo_aero_dust_emis(lchnk, ncol, dstflx, cflx)
+      if (is_zender_soil_erod_from_atm()) then
+         call soil_erod_init( dust_emis_fact, soil_erod_file )
+      end if
 
-    !-----------------------------------------------------------------------
-    ! Purpose: Interface to emission of all dusts.
-    ! Notice that the mobilization is calculated in the land model and
-    ! the soil erodibility factor is applied here.
-    !-----------------------------------------------------------------------
+      ! Set module variables
+      tracerMap(1) = l_dst_a2
+      tracerMap(2) = l_dst_a3
 
-    ! Arguments:
-    integer  , intent(in)    :: lchnk
-    integer  , intent(in)    :: ncol
-    real(r8) , intent(in)    :: dstflx(pcols,4)
-    real(r8) , intent(inout) :: cflx(pcols,pcnst) ! Surface fluxes
+      dust_names(:) = "      "
+      do imode = 1, numberOfDustModes
+         dust_names(imode) = cnst_name(tracerMap(imode))
+      end do
 
-    ! Local variables
-    integer  :: icol,imode
-    real(r8) :: soil_erod_tmp(pcols)
-    real(r8) :: totalEmissionFlux(pcols)
+   end subroutine oslo_aero_dust_init
 
-    ! Filter away unreasonable values for soil erodibility
-    ! (using low values e.g. gives emissions in greenland..)
-    where(soil_erodibility(:,lchnk) < 0.1_r8)
-       soil_erod_tmp(:)=0.0_r8
-    elsewhere
-       soil_erod_tmp(:)=soil_erodibility(:,lchnk)
-    end where
+   !=============================================================================
+   subroutine oslo_aero_dust_emis(lchnk, ncol, dstflx, cflx)
 
-    totalEmissionFlux(:) = 0.0_r8
-    do icol=1,ncol
-       totalEmissionFlux(icol) = totalEmissionFlux(icol) + sum(dstflx(icol,:))
-    end do
+      !-----------------------------------------------------------------------
+      ! Purpose: Interface to emission of all dusts.
+      ! Notice that the mobilization is calculated in the land model and
+      ! the soil erodibility factor is applied here.
+      !-----------------------------------------------------------------------
 
-    ! Note that following CESM use of "dust_emis_fact", the emissions are
-    ! scaled by the INVERSE of the factor!!
-    ! There is another random scale factor of 1.15 there. Adapting the exact
-    ! same formulation as MAM now and tune later
-    ! As of NE-380: Oslo dust emissions are 2/3 of CAM emissions
-    ! gives better AOD close to dust sources
+      ! Arguments:
+      integer,  intent(in)    :: lchnk
+      integer,  intent(in)    :: ncol
+      real(r8), intent(in)    :: dstflx(pcols,4)
+      real(r8), intent(inout) :: cflx(pcols,pcnst) ! Surface fluxes
 
-    do imode = 1,numberOfDustModes
-       cflx(:ncol, tracerMap(imode)) = -1.0_r8*emis_fraction_in_mode(imode) &
-            *totalEmissionFlux(:ncol)*soil_erod_tmp(:ncol)/(dust_emis_fact)*1.15_r8
-    end do
+      ! Local variables
+      integer  :: icol,imode
+      real(r8) :: soil_erod_tmp(pcols)
+      real(r8) :: totalEmissionFlux(pcols)
 
-  end subroutine oslo_aero_dust_emis
+      ! Filter away unreasonable values for soil erodibility
+      ! (using low values e.g. gives emissions in greenland..)
+      where(soil_erodibility(:,lchnk) < 0.1_r8)
+         soil_erod_tmp(:)=0.0_r8
+      elsewhere
+         soil_erod_tmp(:)=soil_erodibility(:,lchnk)
+      end where
 
-  !=============================================================================
-  subroutine soil_erod_init( dust_emis_fact, soil_erod_file )
+      totalEmissionFlux(:) = 0.0_r8
+      do icol=1,ncol
+         totalEmissionFlux(icol) = totalEmissionFlux(icol) + sum(dstflx(icol,:))
+      end do
 
-    ! arguments
-    real(r8),         intent(in) :: dust_emis_fact
-    character(len=*), intent(in) :: soil_erod_file
+      ! Note that following CESM use of "dust_emis_fact", the emissions are
+      ! scaled by the INVERSE of the factor!!
+      ! There is another random scale factor of 1.15 there. Adapting the exact
+      ! same formulation as MAM now and tune later
+      ! As of NE-380: Oslo dust emissions are 2/3 of CAM emissions
+      ! gives better AOD close to dust sources
 
-    ! localvaraibles
-    real(r8), allocatable :: soil_erodibility_in(:,:)
-    real(r8), allocatable :: dst_lons(:)
-    real(r8), allocatable :: dst_lats(:)
-    character(len=cl)     :: infile
-    integer               :: did, vid, nlat, nlon
-    type(file_desc_t)     :: ncid
-    type(interp_type)     :: lon_wgts, lat_wgts
-    real(r8)              :: to_lats(pcols), to_lons(pcols)
-    integer               :: c, ncols, ierr
-    real(r8), parameter   :: zero=0._r8
-    real(r8), parameter   :: twopi=2._r8*pi
+      do imode = 1,numberOfDustModes
+         cflx(:ncol, tracerMap(imode)) = -1.0_r8*emis_fraction_in_mode(imode) &
+              *totalEmissionFlux(:ncol)*soil_erod_tmp(:ncol)/(dust_emis_fact)*1.15_r8
+      end do
 
-    soil_erod_fact = dust_emis_fact
+   end subroutine oslo_aero_dust_emis
 
-    ! Summary to log file
-    if (masterproc) then
-       write(iulog,*) 'soil_erod_mod: soil erodibility dataset: ', trim(soil_erod_file)
-       write(iulog,*) 'soil_erod_mod: soil_erod_fact = ', soil_erod_fact
-    end if
+   !=============================================================================
+   subroutine soil_erod_init( dust_emis_fact, soil_erod_file )
 
-    ! read in soil erodibility factors, similar to Zender's boundary conditions
+      ! arguments
+      real(r8),         intent(in) :: dust_emis_fact
+      character(len=*), intent(in) :: soil_erod_file
 
-    ! Get file name.
-    call getfil(soil_erod_file, infile, 0)
-    call cam_pio_openfile (ncid, trim(infile), PIO_NOWRITE)
+      ! localvaraibles
+      real(r8), allocatable :: soil_erodibility_in(:,:)
+      real(r8), allocatable :: dst_lons(:)
+      real(r8), allocatable :: dst_lats(:)
+      character(len=cl)     :: infile
+      integer               :: did, vid, nlat, nlon
+      type(file_desc_t)     :: ncid
+      type(interp_type)     :: lon_wgts, lat_wgts
+      real(r8)              :: to_lats(pcols), to_lons(pcols)
+      integer               :: c, ncols, ierr
+      real(r8), parameter   :: zero=0._r8
+      real(r8), parameter   :: twopi=2._r8*pi
 
-    ! Get input data resolution.
-    ierr = pio_inq_dimid( ncid, 'lon', did )
-    ierr = pio_inq_dimlen( ncid, did, nlon )
+      soil_erod_fact = dust_emis_fact
 
-    ierr = pio_inq_dimid( ncid, 'lat', did )
-    ierr = pio_inq_dimlen( ncid, did, nlat )
+      ! Summary to log file
+      if (masterproc) then
+         write(iulog,*) 'soil_erod_mod: soil erodibility dataset: ', trim(soil_erod_file)
+         write(iulog,*) 'soil_erod_mod: soil_erod_fact = ', soil_erod_fact
+      end if
 
-    allocate(dst_lons(nlon))
-    allocate(dst_lats(nlat))
-    allocate(soil_erodibility_in(nlon,nlat))
+      ! read in soil erodibility factors, similar to Zender's boundary conditions
 
-    ierr = pio_inq_varid( ncid, 'lon', vid )
-    ierr = pio_get_var( ncid, vid, dst_lons  )
+      ! Get file name.
+      call getfil(soil_erod_file, infile, 0)
+      call cam_pio_openfile (ncid, trim(infile), PIO_NOWRITE)
 
-    ierr = pio_inq_varid( ncid, 'lat', vid )
-    ierr = pio_get_var( ncid, vid, dst_lats  )
+      ! Get input data resolution.
+      ierr = pio_inq_dimid( ncid, 'lon', did )
+      ierr = pio_inq_dimlen( ncid, did, nlon )
 
-    ierr = pio_inq_varid( ncid, 'mbl_bsn_fct_geo', vid )
-    ierr = pio_get_var( ncid, vid, soil_erodibility_in )
+      ierr = pio_inq_dimid( ncid, 'lat', did )
+      ierr = pio_inq_dimlen( ncid, did, nlat )
 
-    ! convert to radians and setup regridding
-    dst_lats(:) = d2r * dst_lats(:)
-    dst_lons(:) = d2r * dst_lons(:)
+      allocate(dst_lons(nlon))
+      allocate(dst_lats(nlat))
+      allocate(soil_erodibility_in(nlon,nlat))
 
-    allocate( soil_erodibility(pcols,begchunk:endchunk), stat=ierr )
-    if( ierr /= 0 ) then
-       write(iulog,*) 'soil_erod_init: failed to allocate soil_erodibility_in, ierr = ',ierr
-       call endrun('soil_erod_init: failed to allocate soil_erodibility_in')
-    end if
+      ierr = pio_inq_varid( ncid, 'lon', vid )
+      ierr = pio_get_var( ncid, vid, dst_lons  )
 
-    soil_erodibility(:,:)=0._r8
+      ierr = pio_inq_varid( ncid, 'lat', vid )
+      ierr = pio_get_var( ncid, vid, dst_lats  )
 
-    ! regrid
-    do c=begchunk,endchunk
-       ncols = get_ncols_p(c)
-       call get_rlat_all_p(c, pcols, to_lats)
-       call get_rlon_all_p(c, pcols, to_lons)
+      ierr = pio_inq_varid( ncid, 'mbl_bsn_fct_geo', vid )
+      ierr = pio_get_var( ncid, vid, soil_erodibility_in )
 
-       call lininterp_init(dst_lons, nlon, to_lons, ncols, 2, lon_wgts, zero, twopi)
-       call lininterp_init(dst_lats, nlat, to_lats, ncols, 1, lat_wgts)
+      ! convert to radians and setup regridding
+      dst_lats(:) = d2r * dst_lats(:)
+      dst_lons(:) = d2r * dst_lons(:)
 
-       call lininterp(soil_erodibility_in(:,:), nlon, nlat, soil_erodibility(:,c), ncols, lon_wgts, lat_wgts)
+      allocate( soil_erodibility(pcols,begchunk:endchunk), stat=ierr )
+      if( ierr /= 0 ) then
+         write(iulog,*) 'soil_erod_init: failed to allocate soil_erodibility_in, ierr = ',ierr
+         call endrun('soil_erod_init: failed to allocate soil_erodibility_in')
+      end if
 
-       call lininterp_finish(lat_wgts)
-       call lininterp_finish(lon_wgts)
-    end do
-    deallocate( soil_erodibility_in, stat=ierr )
-    if( ierr /= 0 ) then
-       write(iulog,*) 'soil_erod_init: failed to deallocate soil_erodibility_in, ierr = ',ierr
-       call endrun('soil_erod_init: failed to deallocate soil_erodibility_in')
-    end if
+      soil_erodibility(:,:)=0._r8
 
-    deallocate( dst_lats )
-    deallocate( dst_lons )
+      ! regrid
+      do c=begchunk,endchunk
+         ncols = get_ncols_p(c)
+         call get_rlat_all_p(c, pcols, to_lats)
+         call get_rlon_all_p(c, pcols, to_lons)
 
-  end  subroutine soil_erod_init
+         call lininterp_init(dst_lons, nlon, to_lons, ncols, 2, lon_wgts, zero, twopi)
+         call lininterp_init(dst_lats, nlat, to_lats, ncols, 1, lat_wgts)
+
+         call lininterp(soil_erodibility_in(:,:), nlon, nlat, soil_erodibility(:,c), ncols, lon_wgts, lat_wgts)
+
+         call lininterp_finish(lat_wgts)
+         call lininterp_finish(lon_wgts)
+      end do
+      deallocate( soil_erodibility_in, stat=ierr )
+      if( ierr /= 0 ) then
+         write(iulog,*) 'soil_erod_init: failed to deallocate soil_erodibility_in, ierr = ',ierr
+         call endrun('soil_erod_init: failed to deallocate soil_erodibility_in')
+      end if
+
+      deallocate( dst_lats )
+      deallocate( dst_lons )
+
+   end  subroutine soil_erod_init
 
 end module oslo_aero_dust

--- a/src_cam/chemistry.F90
+++ b/src_cam/chemistry.F90
@@ -24,6 +24,7 @@ module chemistry
   use ref_pres,         only : ptop_ref
   use phys_control,     only : waccmx_is   ! WACCM-X switch query function
   use phys_control,     only : use_hemco   ! HEMCO switch logical
+  use mo_chm_diags,     only : chem_has_ndep_flx => chm_prod_ndep_flx
 
   implicit none
   private
@@ -46,6 +47,7 @@ module chemistry
   public :: chem_read_restart
   public :: chem_init_restart
   public :: chem_emissions
+  public :: chem_has_ndep_flx
 
   integer, public :: imozart = -1       ! index of 1st constituent
 
@@ -1152,6 +1154,7 @@ end function chem_is_active
     use mo_neu_wetdep,       only : neu_wetdep_tend
     use aerodep_flx,         only : aerodep_flx_prescribed
     use short_lived_species, only : short_lived_species_writeic
+    use atm_stream_ndep,     only : ndep_stream_active
 
     implicit none
 
@@ -1270,12 +1273,14 @@ end function chem_is_active
                           cam_out%precc, cam_out%precl, cam_in%snowhland, ghg_chem, state%latmapback, &
                           drydepflx, wetdepflx, cam_in%cflx, cam_in%fireflx, cam_in%fireztop, &
                           nhx_nitrogen_flx, noy_nitrogen_flx, use_hemco, ptend%q, pbuf )
-    if (associated(cam_out%nhx_nitrogen_flx)) then
-       cam_out%nhx_nitrogen_flx(:ncol) = nhx_nitrogen_flx(:ncol)
-    endif
-    if (associated(cam_out%noy_nitrogen_flx)) then
-       cam_out%noy_nitrogen_flx(:ncol) = noy_nitrogen_flx(:ncol)
-    endif
+    if (.not. ndep_stream_active) then
+       if (associated(cam_out%nhx_nitrogen_flx)) then
+          cam_out%nhx_nitrogen_flx(:ncol) = nhx_nitrogen_flx(:ncol)
+       end if
+       if (associated(cam_out%noy_nitrogen_flx)) then
+          cam_out%noy_nitrogen_flx(:ncol) = noy_nitrogen_flx(:ncol)
+       endif
+    end if
 
     call t_stopf( 'chemdr' )
 

--- a/src_cam/mo_chm_diags.F90
+++ b/src_cam/mo_chm_diags.F90
@@ -1,23 +1,23 @@
 module mo_chm_diags
 
-  use shr_kind_mod, only : r8 => shr_kind_r8
-  use chem_mods,    only : gas_pcnst
-  use mo_tracname,  only : solsym
-  use chem_mods,    only : rxntot, nfs, gas_pcnst, indexm, adv_mass
-  use ppgrid,       only : pver
-  use mo_constants, only : rgrav, rearth
-  use mo_chem_utls, only : get_rxt_ndx, get_spc_ndx
-  use cam_history,  only : fieldname_len
-  use mo_jeuv,      only : neuv
-  use gas_wetdep_opts,only : gas_wetdep_method
-  use mo_drydep,    only : has_drydep
+  use shr_kind_mod,    only : r8 => shr_kind_r8
+  use chem_mods,       only : gas_pcnst
+  use mo_tracname,     only : solsym
+  use chem_mods,       only : rxntot, nfs, gas_pcnst, indexm, adv_mass
+  use ppgrid,          only : pver
+  use mo_constants,    only : rgrav, rearth
+  use mo_chem_utls,    only : get_rxt_ndx, get_spc_ndx
+  use cam_history,     only : fieldname_len
+  use mo_jeuv,         only : neuv
+  use gas_wetdep_opts, only : gas_wetdep_method
+  use mo_drydep,       only : has_drydep
   !
-  use ppgrid,          only : pcols                                               ! OSLO_AERO
-  use physics_buffer,  only : pbuf_get_field, pbuf_get_index, physics_buffer_desc ! OSLO_AERO
-  use constituents,    only : cnst_get_ind                                        ! OSLO_AERO
   ! OSLO_AERO begin
+  use ppgrid,          only : pcols
+  use physics_buffer,  only : pbuf_get_field, pbuf_get_index, physics_buffer_desc
   use oslo_aero_share, only : getCloudTracerIndexDirect, getCloudTracerName
-  use oslo_aero_share, only : aerosol_type_name, aerosolType, isAerosol, N_AEROSOL_TYPES
+  use oslo_aero_share, only : aerosol_type_name, aerosolType, isAerosol
+  use oslo_aero_share, only : N_AEROSOL_TYPES
   ! OSLO_AERO end
 
   implicit none
@@ -26,6 +26,7 @@ module mo_chm_diags
   public :: chm_diags_inti
   public :: chm_diags
   public :: het_diags
+  public :: chm_prod_ndep_flx
 
   integer :: id_n,id_no,id_no2,id_no3,id_n2o5,id_hno3,id_ho2no2,id_clono2,id_brono2
   integer :: id_isopfdn, id_isopfdnc, id_terpfdn !these are dinitrates
@@ -62,6 +63,8 @@ module mo_chm_diags
   character(len=fieldname_len) :: wetdep_name_area(gas_pcnst) ! OSLO_AERO
   real(r8), parameter :: N_molwgt = 14.00674_r8
   real(r8), parameter :: S_molwgt = 32.066_r8
+
+  logical, protected :: chm_prod_ndep_flx =.false.
 
 contains
 
@@ -339,6 +342,8 @@ contains
 
     toth_species = (/ id_ch4, id_h2o, id_h2 /)
 
+    chm_prod_ndep_flx = any(noy_species>0) .or. any(nhx_species>0)
+
     call addfld( 'NOX',     (/ 'lev' /), 'A', 'mol/mol', 'nox (N+NO+NO2)' )
     call addfld( 'NOY',     (/ 'lev' /), 'A', 'mol/mol', &
                  'noy = total nitrogen (N+NO+NO2+NO3+2N2O5+HNO3+HO2NO2+ORGNOY+NH4NO3)' )
@@ -605,9 +610,10 @@ contains
     !	... utility routine to output chemistry diagnostic variables
     !--------------------------------------------------------------------
 
-    use cam_history,  only : outfld
-    use phys_grid,    only : get_area_all_p
+    use cam_history,        only : outfld
+    use phys_grid,          only : get_area_all_p
     use species_sums_diags, only : species_sums_output
+    use constituents,       only : cnst_get_ind
 !
 ! CCMI
 !

--- a/src_cam/mo_drydep.F90
+++ b/src_cam/mo_drydep.F90
@@ -522,11 +522,13 @@ contains
     logical :: lexist
 
     if (len_trim(drydep_srf_file) == 0) then
-       write(iulog,*)'**************************************'
-       write(iulog,*)' get_landuse_and_soilw_from_file: INFO:'
-       write(iulog,*)' drydep_srf_file not set:'
-       write(iulog,*)' setting fraction_landuse to zero'
-       write(iulog,*)'**************************************'
+       if (masterproc) then
+          write(iulog,*)'**************************************'
+          write(iulog,*)' get_landuse_and_soilw_from_file: INFO:'
+          write(iulog,*)' drydep_srf_file not set:'
+          write(iulog,*)' setting fraction_landuse to zero'
+          write(iulog,*)'**************************************'
+       end if
        fraction_landuse = 0._r8
        return
     end if
@@ -538,12 +540,14 @@ contains
        call infld('fraction_landuse', piofile, 'ncol','class',1,pcols,1,n_land_type, begchunk,endchunk, &
             fraction_landuse, readvar, gridname='physgrid')
        if (.not. readvar) then
-          write(iulog,*)'**************************************'
-          write(iulog,*)'get_landuse_and_soilw_from_file: INFO:'
-          write(iulog,*)' fraction_landuse not read from file: '
-          write(iulog,*)' ', trim(locfn)
-          write(iulog,*)' setting all values to zero'
-          write(iulog,*)'**************************************'
+          if (masterproc) then
+             write(iulog,*)'**************************************'
+             write(iulog,*)'get_landuse_and_soilw_from_file: INFO:'
+             write(iulog,*)' fraction_landuse not read from file: '
+             write(iulog,*)' ', trim(locfn)
+             write(iulog,*)' setting all values to zero'
+             write(iulog,*)'**************************************'
+          end if
           fraction_landuse = 0._r8
        end if
 

--- a/src_cam/physpkg.F90
+++ b/src_cam/physpkg.F90
@@ -791,6 +791,7 @@ contains
     ! local variables
     integer :: lchnk
     integer :: ierr
+    integer :: ixq
 
     logical :: history_budget              ! output tendencies and state variables for
                                            ! temperature, water vapor, cloud
@@ -862,7 +863,7 @@ contains
     call aer_rad_props_init()
 
     ! initialize carma
-    call carma_init()
+    call carma_init(pbuf2d)
 
     ! Prognostic chemistry.
     call chem_init(phys_state,pbuf2d)
@@ -968,7 +969,8 @@ contains
 
     ! Initialize CAM CCPP constituent properties array
     ! for use in CCPP-ized physics schemes:
-    call ccpp_const_props_init()
+    call cnst_get_ind('Q', ixq)
+    call ccpp_const_props_init(ixq)
 
     ! Initialize qneg3 and qneg4
     call qneg_init()
@@ -1381,7 +1383,8 @@ contains
     use aoa_tracers,        only: aoa_tracers_timestep_tend
     use physconst,          only: rhoh2o
     use aero_model,         only: aero_model_drydep
-    use check_energy,       only: check_energy_chng, tot_energy_phys
+    use check_energy,       only: check_energy_timestep_init, check_energy_cam_chng
+    use check_energy,       only: tot_energy_phys
     use check_energy,       only: check_tracers_data, check_tracers_init, check_tracers_chng
     use time_manager,       only: get_nstep
     use cam_abortutils,     only: endrun
@@ -1424,7 +1427,6 @@ contains
     use aero_model,         only: aero_model_wetdep
     use aero_wetdep_cam,    only: wetdep_lq
     use physics_buffer,     only: col_type_subcol
-    use check_energy,       only: check_energy_timestep_init
     use carma_intr,         only: carma_wetdep_tend, carma_timestep_tend, carma_emission_tend
     use carma_flags_mod,    only: carma_do_aerosol, carma_do_emission, carma_do_detrain
     use carma_flags_mod,    only: carma_do_cldice, carma_do_cldliq, carma_do_wetdep
@@ -1517,7 +1519,7 @@ contains
     real(r8) surfric(pcols)            ! surface friction velocity
     real(r8) obklen(pcols)             ! Obukhov length
     real(r8) :: fh2o(pcols)            ! h2o flux to balance source from methane chemistry
-    real(r8) :: flx_heat(pcols)        ! Heat flux for check_energy_chng.
+    real(r8) :: flx_heat(pcols)        ! Heat flux for check_energy_cam_chng.
     real(r8) :: tmp_trac  (pcols,pver,pcnst) ! tmp space
     real(r8) :: tmp_pdel  (pcols,pver) ! tmp space
     real(r8) :: tmp_ps    (pcols)      ! tmp space
@@ -1634,7 +1636,7 @@ contains
 
     if (carma_do_emission) then
        ! carma emissions
-       call carma_emission_tend (state, ptend, cam_in, ztodt)
+       call carma_emission_tend (state, ptend, cam_in, ztodt, pbuf)
        call physics_update(state, ptend, ztodt, tend)
     end if
 
@@ -1663,7 +1665,7 @@ contains
 
     call physics_update(state, ptend, ztodt, tend)
 
-    call check_energy_chng(state, tend, "clubb_emissions_tend", nstep, ztodt, zero, zero, zero, zero)
+    call check_energy_cam_chng(state, tend, "clubb_emissions_tend", nstep, ztodt, zero, zero, zero, zero)
 
     call t_stopf('clubb_emissions_tend')
 
@@ -1691,9 +1693,9 @@ contains
        ! CARMA is doing
        ! detrainment, then the reserved condensate is snow.
        if (carma_do_detrain) then
-          call check_energy_chng(state, tend, "carma_tend", nstep, ztodt, zero, prec_str+rliq, snow_str+rliq, zero)
+          call check_energy_cam_chng(state, tend, "carma_tend", nstep, ztodt, zero, prec_str+rliq, snow_str+rliq, zero)
        else
-          call check_energy_chng(state, tend, "carma_tend", nstep, ztodt, zero, prec_str, snow_str, zero)
+          call check_energy_cam_chng(state, tend, "carma_tend", nstep, ztodt, zero, prec_str, snow_str, zero)
        end if
     end if
 
@@ -1768,7 +1770,7 @@ contains
              end if
 
              ! Use actual qflux (not lhf/latvap) for consistency with surface fluxes and revised code
-             call check_energy_chng(state, tend, "clubb_tend", nstep, ztodt, &
+             call check_energy_cam_chng(state, tend, "clubb_tend", nstep, ztodt, &
                 cam_in%cflx(:ncol,1)/cld_macmic_num_steps, &
                 flx_cnd(:ncol)/cld_macmic_num_steps, &
                 det_ice(:ncol)/cld_macmic_num_steps, &
@@ -1869,7 +1871,7 @@ contains
                    fh2o, surfric, obklen, flx_heat, cmfmc, dlf, det_s, det_ice, net_flx)
              end if
 
-             call check_energy_chng(state_sc, tend_sc, "microp_tend_subcol", &
+             call check_energy_cam_chng(state_sc, tend_sc, "microp_tend_subcol", &
                   nstep, ztodt, zero_sc, &
                   prec_str_sc(:state_sc%ncol)/cld_macmic_num_steps, &
                   snow_str_sc(:state_sc%ncol)/cld_macmic_num_steps, zero_sc)
@@ -1901,7 +1903,7 @@ contains
                   fh2o, surfric, obklen, flx_heat, cmfmc, dlf, det_s, det_ice, net_flx)
           end if
 
-          call check_energy_chng(state, tend, "microp_tend", nstep, ztodt, &
+          call check_energy_cam_chng(state, tend, "microp_tend", nstep, ztodt, &
                zero, prec_str(:ncol)/cld_macmic_num_steps, &
                snow_str(:ncol)/cld_macmic_num_steps, zero)
 
@@ -2057,7 +2059,7 @@ contains
                   fh2o, surfric, obklen, flx_heat, cmfmc, dlf, det_s, det_ice, net_flx)
     end if
 
-    call check_energy_chng(state, tend, "radheat", nstep, ztodt, zero, zero, zero, net_flx)
+    call check_energy_cam_chng(state, tend, "radheat", nstep, ztodt, zero, zero, zero, net_flx)
 
     call t_stopf('radiation')
 
@@ -2134,7 +2136,7 @@ contains
           call cam_snapshot_all_outfld_tphysac(cam_snapshot_after_num, state, tend, cam_in, cam_out, pbuf,&
                     fh2o, surfric, obklen, flx_heat, cmfmc, dlf, det_s, det_ice, net_flx)
        end if
-       call check_energy_chng(state, tend, "chem", nstep, ztodt, fh2o, zero, zero, zero)
+       call check_energy_cam_chng(state, tend, "chem", nstep, ztodt, fh2o, zero, zero, zero)
        call check_tracers_chng(state, tracerint, "chem_timestep_tend", nstep, ztodt, &
             cam_in%cflx)
     end if
@@ -2196,9 +2198,9 @@ contains
     call t_stopf('rayleigh_friction')
 
     if (do_clubb_sgs) then
-      call check_energy_chng(state, tend, "vdiff", nstep, ztodt, zero, zero, zero, zero)
+      call check_energy_cam_chng(state, tend, "vdiff", nstep, ztodt, zero, zero, zero, zero)
     else
-      call check_energy_chng(state, tend, "vdiff", nstep, ztodt, cam_in%cflx(:,1), zero, &
+      call check_energy_cam_chng(state, tend, "vdiff", nstep, ztodt, cam_in%cflx(:,1), zero, &
            zero, cam_in%shf)
     endif
 
@@ -2242,7 +2244,7 @@ contains
      call carma_timestep_tend(state, cam_in, cam_out, ptend, ztodt, pbuf, obklen=obklen, ustar=surfric)
      call physics_update(state, ptend, ztodt, tend)
 
-     call check_energy_chng(state, tend, "carma_tend", nstep, ztodt, zero, zero, zero, zero)
+     call check_energy_cam_chng(state, tend, "carma_tend", nstep, ztodt, zero, zero, zero, zero)
      call t_stopf('carma_timestep_tend')
    end if
 
@@ -2281,7 +2283,7 @@ contains
     end if
 
     ! Check energy integrals
-    call check_energy_chng(state, tend, "gwdrag", nstep, ztodt, zero, &
+    call check_energy_cam_chng(state, tend, "gwdrag", nstep, ztodt, zero, &
          zero, zero, flx_heat)
     call t_stopf('gw_tend')
 
@@ -2311,7 +2313,7 @@ contains
     end if
 
     ! Check energy integrals
-    call check_energy_chng(state, tend, "qborelax", nstep, ztodt, zero, zero, zero, zero)
+    call check_energy_cam_chng(state, tend, "qborelax", nstep, ztodt, zero, zero, zero, zero)
 
     ! Lunar tides
     call lunar_tides_tend( state, ptend )
@@ -2323,7 +2325,7 @@ contains
     end if
     call physics_update(state, ptend, ztodt, tend)
     ! Check energy integrals
-    call check_energy_chng(state, tend, "lunar_tides", nstep, ztodt, zero, zero, zero, zero)
+    call check_energy_cam_chng(state, tend, "lunar_tides", nstep, ztodt, zero, zero, zero, zero)
 
     ! Ion drag calculation
     call t_startf ( 'iondrag' )
@@ -2372,7 +2374,7 @@ contains
     endif
 
     ! Check energy integrals
-    call check_energy_chng(state, tend, "iondrag", nstep, ztodt, zero, zero, zero, zero)
+    call check_energy_cam_chng(state, tend, "iondrag", nstep, ztodt, zero, zero, zero, zero)
 
     call t_stopf  ( 'iondrag' )
 
@@ -2387,7 +2389,7 @@ contains
         call outfld( 'VTEND_NDG', ptend%v, pcols, lchnk)
       end if
       call physics_update(state,ptend,ztodt,tend)
-      call check_energy_chng(state, tend, "nudging", nstep, ztodt, zero, zero, zero, zero)
+      call check_energy_cam_chng(state, tend, "nudging", nstep, ztodt, zero, zero, zero, zero)
     endif
 
     !-------------- Energy budget checks vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
@@ -2538,7 +2540,7 @@ contains
     use convect_deep,    only: convect_deep_tend
     use time_manager,    only: is_first_step, get_nstep
     use convect_diagnostics,only: convect_diagnostics_calc
-    use check_energy,    only: check_energy_chng, check_energy_fix
+    use check_energy,    only: check_energy_cam_chng, check_energy_cam_fix
     use check_energy,    only: check_tracers_data, check_tracers_init
     use check_energy,    only: tot_energy_phys
     use dycore,          only: dycore_is
@@ -2720,9 +2722,9 @@ contains
     call tot_energy_phys(state, 'dyBF',vc=vc_dycore)
 
     if (.not.dycore_is('EUL')) then
-       call check_energy_fix(state, ptend, nstep, flx_heat)
+       call check_energy_cam_fix(state, ptend, nstep, flx_heat)
        call physics_update(state, ptend, ztodt, tend)
-       call check_energy_chng(state, tend, "chkengyfix", nstep, ztodt, zero, zero, zero, flx_heat)
+       call check_energy_cam_chng(state, tend, "chkengyfix", nstep, ztodt, zero, zero, zero, flx_heat)
        call outfld( 'EFIX', flx_heat    , pcols, lchnk   )
     end if
 
@@ -2852,7 +2854,7 @@ contains
     ! Check energy integrals, including "reserved liquid"
     flx_cnd(:ncol) = prec_dp(:ncol) + rliq(:ncol)
     snow_dp(:ncol) = snow_dp(:ncol) + rice(:ncol)
-    call check_energy_chng(state, tend, "convect_deep", nstep, ztodt, zero, flx_cnd, snow_dp, zero)
+    call check_energy_cam_chng(state, tend, "convect_deep", nstep, ztodt, zero, flx_cnd, snow_dp, zero)
     snow_dp(:ncol) = snow_dp(:ncol) - rice(:ncol)
 
     !===================================================
@@ -2927,6 +2929,14 @@ contains
     call t_startf('diag_export')
     call diag_export(cam_out)
     call t_stopf('diag_export')
+
+    ! output these here -- after updates by chem_timestep_tend or export_fields within the current time step
+    if (associated(cam_out%nhx_nitrogen_flx)) then
+       call outfld('a2x_NHXDEP', cam_out%nhx_nitrogen_flx, pcols, lchnk)
+    end if
+    if (associated(cam_out%noy_nitrogen_flx)) then
+       call outfld('a2x_NOYDEP', cam_out%noy_nitrogen_flx, pcols, lchnk)
+    end if
 
   end subroutine tphysbc
 

--- a/src_cam/vertical_diffusion.F90
+++ b/src_cam/vertical_diffusion.F90
@@ -199,7 +199,7 @@ subroutine vd_readnl(nlfile)
   ! Beljaars reads its own namelist.
   call beljaars_drag_readnl(nlfile)
 
-  if (eddy_scheme == 'diag_TKE' .or. eddy_scheme == 'SPCAM_m2005' ) call eddy_diff_readnl(nlfile)
+  if (eddy_scheme == 'diag_TKE') call eddy_diff_readnl(nlfile)
 
 end subroutine vd_readnl
 
@@ -244,7 +244,7 @@ subroutine vd_register()
   end if
 
   ! diag_TKE fields
-  if (eddy_scheme == 'diag_TKE' .or. eddy_scheme == 'SPCAM_m2005') then
+  if (eddy_scheme == 'diag_TKE') then
      call eddy_diff_register()
   end if
 
@@ -416,11 +416,11 @@ subroutine vertical_diffusion_init(pbuf2d)
   call phys_getopts(do_hb_above_clubb_out=do_hb_above_clubb)
 
   select case ( eddy_scheme )
-  case ( 'diag_TKE', 'SPCAM_m2005' )
+  case ( 'diag_TKE' )
      if( masterproc ) write(iulog,*) &
           'vertical_diffusion_init: eddy_diffusivity scheme: UW Moist Turbulence Scheme by Bretherton and Park'
      call eddy_diff_init(pbuf2d, ntop_eddy, nbot_eddy)
-  case ( 'HB', 'HBR', 'SPCAM_sam1mom')
+  case ( 'HB', 'HBR')
      if( masterproc ) write(iulog,*) 'vertical_diffusion_init: eddy_diffusivity scheme:  Holtslag and Boville'
      call init_hb_diff(gravit, cpair, ntop_eddy, nbot_eddy, pref_mid, &
           karman, eddy_scheme)
@@ -599,12 +599,14 @@ subroutine vertical_diffusion_init(pbuf2d)
      if (.not. do_pbl_diags) then
         call add_default( 'PBLH'      , 1, ' ' )
      end if
-  endif
+  end if
 
   if (history_eddy) then
-     call add_default( 'UFLX    ', 1, ' ' )
-     call add_default( 'VFLX    ', 1, ' ' )
-  endif
+     if (.not. do_pbl_diags) then
+        call add_default( 'UFLX    ', 1, ' ' )
+        call add_default( 'VFLX    ', 1, ' ' )
+     end if
+  end if
 
   if( history_budget ) then
      call add_default( vdiffnam(ixcldliq), history_budget_histfile_num, ' ' )
@@ -694,7 +696,6 @@ subroutine vertical_diffusion_tend( &
   !---------------------------------------------------- !
   use physics_buffer,     only : physics_buffer_desc, pbuf_get_field, pbuf_set_field
   use physics_types,      only : physics_state, physics_ptend, physics_ptend_init
-  use physics_types,      only : set_dry_to_wet, set_wet_to_dry
 
   use camsrfexch,         only : cam_in_t
   use cam_history,        only : outfld
@@ -889,9 +890,6 @@ subroutine vertical_diffusion_tend( &
   ! Main Computation Begins !
   ! ----------------------- !
 
-  ! Assume 'wet' mixing ratios in diffusion code.
-  call set_dry_to_wet(state, convert_cnst_type='dry')
-
   rztodt = 1._r8 / ztodt
   lchnk  = state%lchnk
   ncol   = state%ncol
@@ -999,7 +997,7 @@ subroutine vertical_diffusion_tend( &
   th(:ncol,:pver) = state%t(:ncol,:pver) * state%exner(:ncol,:pver)
 
   select case (eddy_scheme)
-  case ( 'diag_TKE', 'SPCAM_m2005' )
+  case ( 'diag_TKE' )
 
      call eddy_diff_tend(state, pbuf, cam_in, &
           ztodt, p, tint, rhoi, cldn, wstarent, &
@@ -1015,7 +1013,7 @@ subroutine vertical_diffusion_tend( &
           khfs(:ncol),    kqfs(:ncol), kbfs(:ncol),   obklen(:ncol))
 
 
-  case ( 'HB', 'HBR', 'SPCAM_sam1mom' )
+  case ( 'HB', 'HBR' )
 
      ! Modification : We may need to use 'taux' instead of 'tautotx' here, for
      !                consistency with the previous HB scheme.
@@ -1352,8 +1350,6 @@ subroutine vertical_diffusion_tend( &
         ptend%q(:ncol,:pver,m) = ptend%q(:ncol,:pver,m)*state%pdel(:ncol,:pver)/state%pdeldry(:ncol,:pver)
      endif
   end do
-  ! convert wet mmr back to dry before conservation check
-  call set_wet_to_dry(state, convert_cnst_type='dry')
 
   if (.not. do_pbl_diags) then
      slten(:ncol,:)         = ( sl(:ncol,:) - sl_prePBL(:ncol,:) ) * rztodt
@@ -1372,7 +1368,7 @@ subroutine vertical_diffusion_tend( &
   !                                                              !
   ! ------------------------------------------------------------ !
 
-    if( (eddy_scheme .eq. 'diag_TKE' .or. eddy_scheme .eq. 'SPCAM_m2005') .and. do_pseudocon_diff ) then
+    if( (eddy_scheme .eq. 'diag_TKE') .and. do_pseudocon_diff ) then
 
      ptend%q(:ncol,:pver,1) = qtten(:ncol,:pver)
      ptend%s(:ncol,:pver)   = slten(:ncol,:pver)


### PR DESCRIPTION
- Updated shadow files from cam6_4_041 to cam6_4_070
- Use dms_from_ocean from cam_control_mod to avoid circular dependency
- Detect Zender 2003 dust emission scheme in namelist read and endrun (for now) if Leung 2023 is specified.