### PR TITLE
Updates from cam6_4_070 to cam6_4_085

### DIFF
--- a/src/aero_model.F90
+++ b/src/aero_model.F90
@@ -93,6 +93,9 @@ contains
 !=============================================================================
 
   subroutine aero_model_readnl(nlfilename)
+    ! OSLO_AERO begin
+    use oslo_aero_dust,   only: oslo_aero_dust_readnl
+    ! OSLO_AERO end
 
     ! read aerosol namelist options
 
@@ -126,6 +129,9 @@ contains
 
     call oslo_aero_ctl_readnl(nlfilename)
     call oslo_aero_microp_readnl(nlfilename)
+   ! OSLO_AERO begin
+   call oslo_aero_dust_readnl(nlfilename)
+   ! OSLO_AERO end
 
   end subroutine aero_model_readnl
 
@@ -138,6 +144,7 @@ contains
 
   !=============================================================================
   subroutine aero_model_init( pbuf2d )
+     use mo_setsox, only: sox_inti
 
     ! args
     type(physics_buffer_desc), pointer :: pbuf2d(:,:)
@@ -150,6 +157,9 @@ contains
     !------------------------------------
 
     call phys_getopts(history_aerosol_out=history_aerosol, convproc_do_aer_out=convproc_do_aer)
+
+    ! aqueous chem initialization
+    call sox_inti()
 
     call aero_model_constants
     call init_interp_constants() ! table initialization constants
@@ -277,7 +287,7 @@ contains
          oslo_dgnumwet, oslo_wetdens, oslo_dgnumwet_processmodes, oslo_wetdens_processmodes, &
          cam_out, ptend)
 
-  endsubroutine aero_model_drydep
+  end subroutine aero_model_drydep
 
   !=============================================================================
   subroutine aero_model_wetdep( state, dt, dlf, cam_out, ptend, pbuf)
@@ -292,11 +302,12 @@ contains
     call oslo_aero_depos_wet(state%lchnk, state%ncol, state%psetcols, state%pmid, state%pdel, state%q, state%t, &
          dt, dlf, cam_out, ptend, pbuf)
 
-  endsubroutine aero_model_wetdep
+  end subroutine aero_model_wetdep
 
-  !=============================================================================
-  subroutine aero_model_surfarea(mmr, radmean, relhum, pmid, temp, strato_sad, sulfate, rho, ltrop, &
-       dlat, het1_ndx, pbuf, ncol, sfc, dm_aer, sad_trop, reff_trop )
+  !============================================================================
+  subroutine aero_model_surfarea(state, mmr, radmean, relhum, pmid, temp, &
+       strato_sad, sulfate, rho, ltrop, dlat, het1_ndx, pbuf, ncol, sfc, &
+       dm_aer, sad_trop, reff_trop )
 
     !-------------------------------------------------------------------------
     ! provides wet tropospheric aerosol surface area info for modal aerosols
@@ -304,6 +315,7 @@ contains
     !-------------------------------------------------------------------------
 
     ! arguments
+    type(physics_state), intent(in) :: state        ! Physics state variables
     real(r8), intent(in)    :: pmid(:,:)
     real(r8), intent(in)    :: temp(:,:)
     real(r8), intent(in)    :: mmr(:,:,:)
@@ -362,7 +374,8 @@ contains
   end subroutine aero_model_surfarea
 
   !=============================================================================
-  subroutine aero_model_strat_surfarea( ncol, mmr, pmid, temp, ltrop, pbuf, strato_sad, reff_strat )
+  subroutine aero_model_strat_surfarea( state, ncol, mmr, pmid, temp, &
+       ltrop, pbuf, strato_sad, reff_strat )
 
     !-------------------------------------------------------------------------
     ! provides WET stratospheric aerosol surface area info for modal aerosols
@@ -370,6 +383,7 @@ contains
     !-------------------------------------------------------------------------
 
     ! arguments
+    type(physics_state), intent(in) :: state        ! Physics state variables
     integer,  intent(in)    :: ncol
     real(r8), intent(in)    :: mmr(:,:,:)
     real(r8), intent(in)    :: pmid(:,:)
@@ -384,14 +398,13 @@ contains
 
   end subroutine aero_model_strat_surfarea
 
-  !=============================================================================
-  subroutine aero_model_gasaerexch( loffset, ncol, lchnk, troplev, delt, reaction_rates, &
-       tfld, pmid, pdel, mbar, relhum, &
-       zm,  qh2o, cwat, cldfr, cldnum, &
-       airdens, invariants, del_h2so4_gasprod,  &
-       vmr0, vmr, pbuf )
+  !===========================================================================
+  subroutine aero_model_gasaerexch( state, loffset, ncol, lchnk, troplev,     &
+       delt, reaction_rates, tfld, pmid, pdel, mbar, relhum, zm,  qh2o, cwat, &
+       cldfr, cldnum, airdens, invariants, del_h2so4_gasprod, vmr0, vmr, pbuf )
 
     ! arguments
+    type(physics_state), intent(in) :: state        ! Physics state variables
     integer,  intent(in)    :: loffset                ! offset applied to modal aero "pointers"
     integer,  intent(in)    :: ncol                   ! number columns in chunk
     integer,  intent(in)    :: lchnk                  ! chunk index
@@ -487,7 +500,7 @@ contains
     dvmrcwdt_sv1 = vmrcw
 
     ! aqueous chemistry ...
-    call setsox( ncol, lchnk, loffset, delt, pmid, pdel, tfld, mbar, cwat, &
+    call setsox( state, ncol, lchnk, loffset, delt, pmid, pdel, tfld, mbar, cwat, &
          cldfr, cldnum, airdens, invariants, vmrcw, vmr, xphlwc, &
          aqso4, aqh2so4, aqso4_h2o2, aqso4_o3)
 

--- a/src/oslo_aero_share.F90
+++ b/src/oslo_aero_share.F90
@@ -155,6 +155,12 @@ module oslo_aero_share
   real(r8), parameter :: e=2.718281828_r8
   real(r8), parameter :: eps=1.0e-30_r8
 
+  ! Names of aerosol tracer fields
+  character(len=6), parameter :: aerosol_names(21) = (/                      &
+       "SO4_NA", "SO4_A1", "SO4_A2", "SO4_AC", "SO4_PR", "BC_N  ", "BC_AX ", &
+       "BC_NI ", "BC_A  ", "BC_AI ", "BC_AC ", "OM_NI ", "OM_AI ", "OM_AC ", &
+       "DST_A2", "DST_A3", "SS_A1 ", "SS_A2 ", "SS_A3 ", "SOA_NA", "SOA_A1" /)
+
   !---------------------------
   ! Public constants
   !---------------------------

--- a/src/oslo_aero_sox_cldaero.F90
+++ b/src/oslo_aero_sox_cldaero.F90
@@ -103,18 +103,19 @@ contains
 
   end function sox_cldaero_create_obj
 
-  !===============================================================================
+  !=============================================================================
 
+  !-----------------------------------------------------------------------------
+  ! Update the mixing ratios
+  !-----------------------------------------------------------------------------
   subroutine sox_cldaero_update( &
-       ncol, lchnk, loffset, dtime, mbar, pdel, press, tfld, cldnum, cldfrc, cfact, xlwc, &
+       state, ncol, lchnk, loffset, dtime, mbar, pdel, press, tfld, cldnum, cldfrc, cfact, xlwc, &
        delso4_hprxn, xh2so4, xso4, xso4_init, nh3g, hno3g, xnh3, xhno3, xnh4c,  xno3c, xmsa, xso2, xh2o2, qcw, qin, &
        aqso4, aqh2so4, aqso4_h2o2, aqso4_o3, aqso4_h2o2_3d, aqso4_o3_3d)
-
-    !----------------------------------------------------------------------------------
-    ! Update the mixing ratios
-    !----------------------------------------------------------------------------------
+    use physics_types, only: physics_state
 
     ! arguments
+    type(physics_state), intent(in) :: state     ! Physics state variables
     integer,  intent(in)    :: ncol
     integer,  intent(in)    :: lchnk         ! chunk id
     integer,  intent(in)    :: loffset

--- a/src_cam/chemistry.F90
+++ b/src_cam/chemistry.F90
@@ -157,6 +157,7 @@ end function chem_is
 !
 !-----------------------------------------------------------------------
 
+    use string_utils,        only : strlist_get_ind
     use mo_sim_dat,          only : set_sim_dat
     use chem_mods,           only : gas_pcnst, adv_mass
     use mo_tracname,         only : solsym
@@ -168,8 +169,7 @@ end function chem_is
     use aero_model,          only : aero_model_register
     use physics_buffer,      only : pbuf_add_field, dtype_r8
     use upper_bc,            only : ubc_fixed_conc
-
-    implicit none
+    use oslo_aero_share,     only : aerosol_names
 
 !-----------------------------------------------------------------------
 ! Local variables
@@ -242,14 +242,15 @@ end function chem_is
        has_fixed_ubc = ubc_fixed_conc(solsym(m))
        has_fixed_ubflx = .false.
        ndropmixed = .false.
-       lng_name      = trim( solsym(m) )
+       lng_name = trim( solsym(m) )
        molectype = 'minor'
 
        qmin = 1.e-36_r8
 
-       if (index(lng_name,'_a') > 0) then ! modal aerosol species undergoes ndrop activation mixing
+       call strlist_get_ind(aerosol_names, solsym(m), n, abort=.false.)
+       if (n > 0) then
           ndropmixed = .true.
-       endif
+       end if
 
        if ( lng_name(1:5) .eq. 'num_a' ) then ! aerosol number density
           qmin = 1.e-5_r8
@@ -303,8 +304,9 @@ end function chem_is
        if ( islvd > 0 ) then
           short_lived_map(islvd) = m
        else
-          call cnst_add( solsym(m), adv_mass(m), cptmp, qmin, n, readiv=ic_from_cam2, cam_outfld=cam_outfld, &
-                         mixtype=mixtype, molectype=molectype, ndropmixed=ndropmixed, &
+          call cnst_add(solsym(m), adv_mass(m), cptmp, qmin, n, &
+               readiv=ic_from_cam2, cam_outfld=cam_outfld, &
+               mixtype=mixtype, molectype=molectype, ndropmixed=ndropmixed, &
                          fixed_ubc=has_fixed_ubc, fixed_ubflx=has_fixed_ubflx, &
                          longname=trim(lng_name) )
 

--- a/src_cam/chemistry.F90
+++ b/src_cam/chemistry.F90
@@ -189,6 +189,7 @@ end function chem_is
     logical :: cam_outfld
     character(len=128) :: mixtype
     character(len=128) :: molectype
+    logical :: ndropmixed
     integer :: islvd
 
 !-----------------------------------------------------------------------
@@ -240,10 +241,15 @@ end function chem_is
        ic_from_cam2  = .true.
        has_fixed_ubc = ubc_fixed_conc(solsym(m))
        has_fixed_ubflx = .false.
+       ndropmixed = .false.
        lng_name      = trim( solsym(m) )
        molectype = 'minor'
 
        qmin = 1.e-36_r8
+
+       if (index(lng_name,'_a') > 0) then ! modal aerosol species undergoes ndrop activation mixing
+          ndropmixed = .true.
+       endif
 
        if ( lng_name(1:5) .eq. 'num_a' ) then ! aerosol number density
           qmin = 1.e-5_r8
@@ -298,7 +304,8 @@ end function chem_is
           short_lived_map(islvd) = m
        else
           call cnst_add( solsym(m), adv_mass(m), cptmp, qmin, n, readiv=ic_from_cam2, cam_outfld=cam_outfld, &
-                         mixtype=mixtype, molectype=molectype, fixed_ubc=has_fixed_ubc, fixed_ubflx=has_fixed_ubflx, &
+                         mixtype=mixtype, molectype=molectype, ndropmixed=ndropmixed, &
+                         fixed_ubc=has_fixed_ubc, fixed_ubflx=has_fixed_ubflx, &
                          longname=trim(lng_name) )
 
           if( imozart == -1 ) then
@@ -336,9 +343,6 @@ end function chem_is
     use tracer_cnst,      only: tracer_cnst_defaultopts, tracer_cnst_setopts
     use tracer_srcs,      only: tracer_srcs_defaultopts, tracer_srcs_setopts
     use aero_model,       only: aero_model_readnl
-    ! OSLO_AERO begin
-    use oslo_aero_dust,   only: oslo_aero_dust_readnl
-    ! OSLO_AERO end
     use gas_wetdep_opts,  only: gas_wetdep_readnl
     use mo_drydep,        only: drydep_srf_file
     use mo_sulf,          only: sulf_readnl
@@ -547,9 +551,6 @@ end function chem_is
         tracer_srcs_fixed_tod_in = tracer_srcs_fixed_tod )
 
    call aero_model_readnl(nlfile)
-   ! OSLO_AERO begin
-   call oslo_aero_dust_readnl(nlfile)
-   ! OSLO_AERO end
 !
    call gas_wetdep_readnl(nlfile)
    call gcr_ionization_readnl(nlfile)
@@ -645,7 +646,6 @@ end function chem_is_active
     use mo_chem_utls,        only : get_spc_ndx
     use cam_abortutils,      only : endrun
     use aero_model,          only : aero_model_init
-    use mo_setsox,           only : sox_inti
     use constituents,        only : sflxnam
     use fire_emissions,      only : fire_emissions_init
     use short_lived_species, only : short_lived_species_initic
@@ -680,9 +680,6 @@ end function chem_is_active
                        history_budget_out = history_budget , &
                        history_budget_histfile_num_out = history_budget_histfile_num, &
                        history_cesm_forcing_out = history_cesm_forcing )
-
-    ! aqueous chem initialization
-    call sox_inti()
 
     ! Initialize aerosols
     call aero_model_init( pbuf2d )
@@ -1265,7 +1262,7 @@ end function chem_is_active
             ncldwtr(:ncol,k) = state%q(:ncol,k,ixndrop)
     end do
 
-    call gas_phase_chemdr(lchnk, ncol, imozart, state%q, &
+    call gas_phase_chemdr(state, lchnk, ncol, imozart, state%q, &
                           state%phis, state%zm, state%zi, calday, &
                           state%t, state%pmid, state%pdel, state%pint, state%rpdel, state%rpdeldry, &
                           cldw, tropLev, tropLevChem, ncldwtr, state%u, state%v, chem_dt, state%ps, &

--- a/src_cam/mo_gas_phase_chemdr.F90
+++ b/src_cam/mo_gas_phase_chemdr.F90
@@ -25,6 +25,7 @@ module mo_gas_phase_chemdr
   integer :: het1_ndx
   integer :: ndx_cldfr, ndx_cmfdqr, ndx_nevapr, ndx_cldtop, ndx_prain
   integer :: ndx_h2so4
+  integer :: jno2_pbuf_ndx=-1, jno2_rxt_ndx=-1
   ! OSLO_AERO begin
   logical :: inv_o3, inv_oh, inv_no3, inv_ho2
   integer :: id_o3, id_oh, id_no3, id_ho2
@@ -198,6 +199,8 @@ contains
        call add_default ('SAD_AERO',8,' ')
     endif
     call addfld( 'REFF_AERO',  (/ 'lev' /), 'I', 'cm',      'aerosol effective radius' )
+    call addfld( 'REFF_TROP',  (/ 'lev' /), 'I', 'cm',      'tropospheric aerosol effective radius' )
+    call addfld( 'REFF_STRAT', (/ 'lev' /), 'I', 'cm',      'stratospheric aerosol effective radius' )
     call addfld( 'SULF_TROP',  (/ 'lev' /), 'I', 'mol/mol', 'tropospheric aerosol SAD' )
     call addfld( 'QDSETT',     (/ 'lev' /), 'I', '/s',      'water vapor settling delta' )
     call addfld( 'QDCHEM',     (/ 'lev' /), 'I', '/s',      'water vapor chemistry delta')
@@ -244,10 +247,14 @@ contains
     ndx_cldtop = pbuf_get_index('CLDTOP')
 
     sad_pbf_ndx= pbuf_get_index('VOLC_SAD',errcode=err) ! prescribed  strat aerosols (volcanic)
-    if (.not.sad_pbf_ndx>0) sad_pbf_ndx = pbuf_get_index('SADSULF',errcode=err) ! CARMA's version of strat aerosols
 
     ele_temp_ndx = pbuf_get_index('TElec',errcode=err)! electron temperature index
     ion_temp_ndx = pbuf_get_index('TIon',errcode=err) ! ion temperature index
+
+    jno2_pbuf_ndx = pbuf_get_index('JNO2',errcode=err)
+    if (jno2_pbuf_ndx>0) then
+       jno2_rxt_ndx = get_rxt_ndx('jno2')
+    end if
 
     ! diagnostics for stratospheric heterogeneous reactions
     call addfld( 'GAMMA_HET1', (/ 'lev' /), 'I', '1', 'Reaction Probability' )
@@ -284,7 +291,7 @@ contains
 
 !-----------------------------------------------------------------------
 !-----------------------------------------------------------------------
-  subroutine gas_phase_chemdr(lchnk, ncol, imozart, q, &
+  subroutine gas_phase_chemdr(state, lchnk, ncol, imozart, q, &
                               phis, zm, zi, calday, &
                               tfld, pmid, pdel, pint, rpdel, rpdeldry, &
                               cldw, troplev, troplevchem, &
@@ -338,6 +345,7 @@ contains
     use perf_mod,          only : t_startf, t_stopf
     use gas_wetdep_opts,   only : gas_wetdep_method
     use physics_buffer,    only : physics_buffer_desc, pbuf_get_field, pbuf_old_tim_idx
+    use physics_types,     only : physics_state
     use infnan,            only : nan, assignment(=)
     use rate_diags,        only : rate_diags_calc, rate_diags_o3s_loss
     use mo_mass_xforms,    only : mmr2vmr, vmr2mmr, h2o_to_vmr, mmr2vmri
@@ -396,6 +404,7 @@ contains
     real(r8), intent(out) :: noy_nitrogen_flx(pcols)
     logical,        intent(in)    :: use_hemco                      ! use Harmonized Emissions Component (HEMCO)
 
+    type(physics_state),    intent(in) :: state     ! Physics state variables
     type(physics_buffer_desc), pointer :: pbuf(:)
 
     !-----------------------------------------------------------------------
@@ -506,6 +515,7 @@ contains
 
     real(r8) :: o3s_loss(ncol,pver)
     real(r8), pointer :: srf_ozone_fld(:)
+    real(r8), pointer :: jno2_fld_ptr(:,:)
 
     if ( ele_temp_ndx>0 .and. ion_temp_ndx>0 ) then
        call pbuf_get_field(pbuf, ele_temp_ndx, ele_temp_fld)
@@ -530,6 +540,10 @@ contains
     call pbuf_get_field(pbuf, ndx_cmfdqr,     cmfdqr, start=(/1,1/), kount=(/ncol,pver/))
     call pbuf_get_field(pbuf, ndx_nevapr,     nevapr, start=(/1,1/), kount=(/ncol,pver/))
     call pbuf_get_field(pbuf, ndx_cldtop,     cldtop )
+
+    if (jno2_pbuf_ndx>0.and.jno2_rxt_ndx>0) then
+       call pbuf_get_field(pbuf, jno2_pbuf_ndx, jno2_fld_ptr)
+    end if
 
     reff_strat(:,:) = 0._r8
 
@@ -679,7 +693,7 @@ contains
        strato_sad(:,:) = 0._r8
 
        ! Prognostic modal stratospheric sulfate: compute dry strato_sad
-       call aero_model_strat_surfarea( ncol, mmr, pmid, tfld, troplevchem, pbuf, strato_sad, reff_strat )
+       call aero_model_strat_surfarea( state,  ncol, mmr, pmid, tfld, troplevchem, pbuf, strato_sad, reff_strat )
 
     endif
 
@@ -816,7 +830,7 @@ contains
 
     cwat(:ncol,:pver) = cldw(:ncol,:pver)
 
-    call usrrxt( reaction_rates, tfld, ion_temp_fld, ele_temp_fld, invariants, h2ovmr, &
+    call usrrxt( state, reaction_rates, tfld, ion_temp_fld, ele_temp_fld, invariants, h2ovmr, &
                  pmid, invariants(:,:,indexm), sulfate, mmr, relhum, strato_sad, &
                  troplevchem, dlats, ncol, sad_trop, reff, cwat, mbar, pbuf )
 
@@ -827,6 +841,8 @@ contains
     call outfld( 'SAD_AERO', sad_trop(:ncol,:), ncol, lchnk )
 
     ! Add trop/strat components of effective radius for output
+    call outfld( 'REFF_TROP', reff(:ncol,:), ncol, lchnk )
+    call outfld( 'REFF_STRAT', reff_strat(:ncol,:), ncol, lchnk )
     reff(:ncol,:)=reff(:ncol,:)+reff_strat(:ncol,:)
     call outfld( 'REFF_AERO', reff(:ncol,:), ncol, lchnk )
 
@@ -870,6 +886,10 @@ contains
     do i = 1,phtcnt
        call outfld( tag_names(i), reaction_rates(:ncol,:,rxt_tag_map(i)), ncol, lchnk )
     enddo
+
+    if (jno2_pbuf_ndx>0.and.jno2_rxt_ndx>0) then
+       jno2_fld_ptr(:ncol,:) = reaction_rates(:ncol,:,jno2_rxt_ndx)
+    endif
 
     !-----------------------------------------------------------------------
     !     	... Adjust the photodissociation rates
@@ -1003,7 +1023,7 @@ contains
 ! Aerosol processes ...
 !
 
-    call aero_model_gasaerexch( imozart-1, ncol, lchnk, troplevchem, delt, reaction_rates, &
+    call aero_model_gasaerexch( state, imozart-1, ncol, lchnk, troplevchem, delt, reaction_rates, &
                                 tfld, pmid, pdel, mbar, relhum, &
                                 zm,  qh2o, cwat, cldfr, ncldwtr, &
                                 invariants(:,:,indexm), invariants, del_h2so4_gasprod,  &

--- a/src_cam/mo_setsox.F90
+++ b/src_cam/mo_setsox.F90
@@ -1,14 +1,15 @@
-
-module MO_SETSOX
+module mo_setsox
 
   use shr_kind_mod, only : r8 => shr_kind_r8
   use cam_logfile,  only : iulog
+  use physics_types,only : physics_state
+
+  implicit none
 
   private
   public :: sox_inti, setsox
   public :: has_sox
 
-  save
   logical            ::  inv_o3
   integer            ::  id_msa
 
@@ -19,29 +20,31 @@ module MO_SETSOX
   logical :: inv_so2, inv_nh3, inv_hno3, inv_h2o2, inv_ox, inv_nh4no3, inv_ho2
 
   logical :: cloud_borne = .false.
-  logical :: modal_aerosols = .false.
 
 contains
 
 !-----------------------------------------------------------------------
 !-----------------------------------------------------------------------
-  subroutine sox_inti
+  subroutine sox_inti()
     !-----------------------------------------------------------------------
     !	... initialize the hetero sox routine
     !-----------------------------------------------------------------------
 
-    use mo_chem_utls, only : get_spc_ndx, get_inv_ndx
-    use spmd_utils,   only : masterproc
-    use phys_control, only : phys_getopts
+    use mo_chem_utls,          only : get_spc_ndx, get_inv_ndx
+    use spmd_utils,            only : masterproc
+    use phys_control,          only : phys_getopts
+    use carma_flags_mod,       only : carma_do_cloudborne
     ! OSLO_AERO begin
     use oslo_aero_sox_cldaero, only : sox_cldaero_init
     ! OSLO_AERO_END
-    implicit none
+
+    logical :: modal_aerosols
 
     ! OSLO_AERO begin
     modal_aerosols = .true.
-    cloud_borne = .true.
     ! OSLO_AERO end
+
+    cloud_borne = modal_aerosols .or. carma_do_cloudborne
 
     !-----------------------------------------------------------------
     !       ... get species indicies
@@ -116,10 +119,15 @@ contains
     if( has_sox ) then
        if (masterproc) then
           write(iulog,*) '-----------------------------------------'
-          write(iulog,*) 'mozart will do sox aerosols'
+          write(iulog,*) 'mo_setsox will do sox aerosols'
           write(iulog,*) '-----------------------------------------'
        endif
     else
+       if (masterproc) then
+          write(iulog,*) '-----------------------------------------'
+          write(iulog,*) ' mo_setsox will not do sox aerosols'
+          write(iulog,*) '-----------------------------------------'
+       endif
        return
     end if
 
@@ -129,7 +137,7 @@ contains
 
 !-----------------------------------------------------------------------
 !-----------------------------------------------------------------------
-  subroutine SETSOX( &
+  subroutine setsox( state, &
        ncol,   &
        lchnk,  &
        loffset,&
@@ -180,11 +188,10 @@ contains
     use oslo_aero_sox_cldaero, only : cldaero_conc_t
     ! OSLO_AERO end
     !
-    implicit none
-    !
     !-----------------------------------------------------------------------
     !      ... Dummy arguments
     !-----------------------------------------------------------------------
+    type(physics_state), intent(in) :: state             ! Physics state variables
     integer,          intent(in)    :: ncol              ! num of columns in chunk
     integer,          intent(in)    :: lchnk             ! chunk id
     integer,          intent(in)    :: loffset           ! offset of chem tracers in the advected tracers array
@@ -616,7 +623,7 @@ contains
              end do ! iter
 
              if( .not. converged ) then
-                write(iulog,*) 'SETSOX: pH failed to converge @ (',i,',',k,'), % change=', &
+                write(iulog,*) 'setsox: pH failed to converge @ (',i,',',k,'), % change=', &
                      100._r8*delta
              end if
           else
@@ -693,7 +700,7 @@ contains
                   / xam                   ! /cm3(a)/s    / air-den     = mix-ratio/s
           endif
 
-          if ( .not. modal_aerosols ) then
+          if ( .not. cloud_borne) then    ! this seems to be specific to aerosols that are not cloud borne
              xh2o2(i,k) = xh2o2(i,k) + r2h2o2*dtime         ! updated h2o2 by het production
           endif
 
@@ -778,7 +785,7 @@ contains
                 patm_x = 1._r8
              endif
 
-             if (modal_aerosols) then
+             if (cloud_borne) then
 
                 pso4 = rah2o2 * 7.4e4_r8*EXP(6621._r8*work1(i)) * h2o2g * patm_x &
                      * 1.23_r8 *EXP(3120._r8*work1(i)) * so2g * patm_x
@@ -827,7 +834,7 @@ contains
                 end if
              END IF
 
-             if (modal_aerosols) then
+             if (cloud_borne) then
                 xdelso4hp(i,k)  =  xso4(i,k) - xso4_init(i,k)
              endif
              !...........................
@@ -860,9 +867,9 @@ contains
     end do ver_loop1
 
     call sox_cldaero_update( &
-         ncol, lchnk, loffset, dtime, mbar, pdel, press, tfld, cldnum, cldfrc, cfact, cldconc%xlwc, &
-         xdelso4hp, xh2so4, xso4, xso4_init, nh3g, hno3g, xnh3, xhno3, xnh4c,  xno3c, xmsa, xso2, xh2o2, qcw, qin, &
-         aqso4, aqh2so4, aqso4_h2o2, aqso4_o3, aqso4_h2o2_3d=aqso4_h2o2_3d, aqso4_o3_3d=aqso4_o3_3d )
+          state, ncol, lchnk, loffset, dtime, mbar, pdel, press, tfld, cldnum, cldfrc, cfact, cldconc%xlwc, &
+          xdelso4hp, xh2so4, xso4, xso4_init, nh3g, hno3g, xnh3, xhno3, xnh4c,  xno3c, xmsa, xso2, xh2o2, qcw, qin, &
+          aqso4, aqh2so4, aqso4_h2o2, aqso4_o3, aqso4_h2o2_3d=aqso4_h2o2_3d, aqso4_o3_3d=aqso4_o3_3d )
 
     xphlwc(:,:) = 0._r8
     do k = 1, pver
@@ -875,6 +882,6 @@ contains
 
     call sox_cldaero_destroy_obj(cldconc)
 
-  end subroutine SETSOX
+  end subroutine setsox
 
-end module MO_SETSOX
+end module mo_setsox

--- a/src_cam/mo_usrrxt.F90
+++ b/src_cam/mo_usrrxt.F90
@@ -3,6 +3,7 @@ module mo_usrrxt
   use shr_kind_mod,     only : r8 => shr_kind_r8
   use cam_logfile,      only : iulog
   use ppgrid,           only : pver, pcols
+  use cam_abortutils,   only : endrun
   ! OSLO_AERO begin
   use oslo_aero_share,  only: nmodes_oslo=> nmodes
   ! OSLO_AERO end
@@ -34,6 +35,9 @@ module mo_usrrxt
   integer :: usr_DMS_OH_ndx
   integer :: usr_HO2_aer_ndx
   integer :: usr_GLYOXAL_aer_ndx
+  integer :: usr_N_O2_ndx
+  integer :: usr_N2D_O2_ndx
+  integer :: usr_N2D_e_ndx
 
   integer :: tag_NO2_NO3_ndx
   integer :: tag_NO2_OH_ndx
@@ -275,6 +279,9 @@ contains
     usr_MPAN_M_ndx       = get_rxt_ndx( 'usr_MPAN_M' )
     usr_XOOH_OH_ndx      = get_rxt_ndx( 'usr_XOOH_OH' )
     usr_SO2_OH_ndx       = get_rxt_ndx( 'usr_SO2_OH' )
+    usr_N_O2_ndx         = get_rxt_ndx( 'usr_N_O2' )
+    usr_N2D_O2_ndx       = get_rxt_ndx( 'usr_N2D_O2' )
+    usr_N2D_e_ndx        = get_rxt_ndx( 'usr_N2D_e' )
     usr_DMS_OH_ndx       = get_rxt_ndx( 'usr_DMS_OH' )
     usr_HO2_aer_ndx      = get_rxt_ndx( 'usr_HO2_aer' )
     usr_GLYOXAL_aer_ndx  = get_rxt_ndx( 'usr_GLYOXAL_aer' )
@@ -571,7 +578,7 @@ contains
        write(iulog,'(10i5)') usr_O_O2_ndx,usr_HO2_HO2_ndx,tag_NO2_NO3_ndx,usr_N2O5_M_ndx,tag_NO2_OH_ndx,usr_HNO3_OH_ndx &
                             ,tag_NO2_HO2_ndx,usr_HO2NO2_M_ndx,usr_N2O5_aer_ndx,usr_NO3_aer_ndx,usr_NO2_aer_ndx &
                             ,usr_CO_OH_b_ndx,tag_C2H4_OH_ndx,tag_C3H6_OH_ndx,tag_CH3CO3_NO2_ndx,usr_PAN_M_ndx,usr_CH3COCH3_OH_ndx &
-                            ,usr_MCO3_NO2_ndx,usr_MPAN_M_ndx,usr_XOOH_OH_ndx,usr_SO2_OH_ndx,usr_DMS_OH_ndx,usr_HO2_aer_ndx &
+                            ,usr_MCO3_NO2_ndx,usr_MPAN_M_ndx,usr_XOOH_OH_ndx,usr_SO2_OH_ndx,usr_N2D_O2_ndx,usr_N2D_e_ndx,usr_N_O2_ndx,usr_DMS_OH_ndx,usr_HO2_aer_ndx &
                             ,usr_GLYOXAL_aer_ndx,usr_ISOPNITA_aer_ndx,usr_ISOPNITB_aer_ndx,usr_ONITR_aer_ndx,usr_HONITR_aer_ndx &
                             ,usr_TERPNIT_aer_ndx,usr_NTERPOOH_aer_ndx,usr_NC4CHO_aer_ndx,usr_NC4CH2OH_aer_ndx,usr_ISOPZD1O2_ndx &
                             ,usr_ISOPZD4O2_ndx,usr_ISOPFDN_aer_ndx,usr_ISOPFNP_aer_ndx,usr_ISOPN2B_aer_ndx,usr_ISOPN1D_aer_ndx &
@@ -596,7 +603,7 @@ contains
 
   end subroutine usrrxt_inti
 
-  subroutine usrrxt( rxt, temp, tempi, tempe, invariants, h2ovmr,  &
+  subroutine usrrxt( state, rxt, temp, tempi, tempe, invariants, h2ovmr,  &
                      pmid, m, sulfate, mmr, relhum, strato_sad, &
                      tropchemlev, dlat, ncol, sad_trop, reff_trop, cwat, mbar, pbuf )
 
@@ -604,13 +611,14 @@ contains
 !        ... set the user specified reaction rates
 !-----------------------------------------------------------------
 
-    use mo_constants,  only : pi, avo => avogadro, boltz_cgs, rgas
-    use chem_mods,     only : nfs, rxntot, gas_pcnst, inv_m_ndx=>indexm
-    use mo_setinv,     only : inv_o2_ndx=>o2_ndx, inv_h2o_ndx=>h2o_ndx
-    use physics_buffer,only : physics_buffer_desc
-    use carma_flags_mod, only : carma_hetchem_feedback
-    use aero_model,      only : aero_model_surfarea
-    use rad_constituents,only : rad_cnst_get_info
+    use mo_constants,     only : pi, avo => avogadro, boltz_cgs, rgas
+    use chem_mods,        only : nfs, rxntot, gas_pcnst, inv_m_ndx=>indexm
+    use mo_setinv,        only : inv_o2_ndx=>o2_ndx, inv_h2o_ndx=>h2o_ndx
+    use physics_buffer,   only : physics_buffer_desc
+    use physics_types,    only : physics_state
+    use carma_flags_mod,  only : carma_hetchem_feedback
+    use aero_model,       only : aero_model_surfarea
+    use rad_constituents, only : rad_cnst_get_info
 
     implicit none
 
@@ -636,6 +644,7 @@ contains
     real(r8), intent(inout) :: rxt(ncol,pver,rxntot)      ! gas phase rates
     real(r8), intent(out)   :: sad_trop(pcols,pver)       ! tropospheric surface area density (cm2/cm3)
     real(r8), intent(out)   :: reff_trop(pcols,pver)      ! tropospheric effective radius (cm)
+    type(physics_state),    intent(in) :: state           ! Physics state variables
     type(physics_buffer_desc), pointer :: pbuf(:)
 
 !-----------------------------------------------------------------
@@ -761,7 +770,7 @@ contains
     real(r8), parameter  :: pH            =  4.5e+00_r8
 
     real(r8), pointer :: sfc(:), dm_aer(:)
-    integer :: ntot_amode
+    integer :: ntot_amode, nbins
 
     real(r8), pointer :: sfc_array(:,:,:), dm_array(:,:,:)
 
@@ -770,6 +779,7 @@ contains
     real(r8) ::  nyield
     real(r8) ::  acorr
     real(r8) ::  exp_natom
+    character(len=*), parameter :: subname = 'usrrxt'
 
     ! get info about the modal aerosols
 
@@ -777,8 +787,13 @@ contains
     ! OSLO_AERO begin
     ntot_amode = nmodes_oslo
     ! OSLO_AERO end
+    call rad_cnst_get_info(0, nbins=nbins)
 
-    if (ntot_amode>0) then
+    if (nbins > 0) then
+       call endrun(subname // ':: ERROR CARMA not supported with Oslo Aero.')
+    end if
+
+    if (ntot_amode > 0) then
        allocate(sfc_array(pcols,pver,ntot_amode), dm_array(pcols,pver,ntot_amode) )
     else
        allocate(sfc_array(pcols,pver,5), dm_array(pcols,pver,5) )
@@ -797,7 +812,7 @@ contains
        else
 
           call aero_model_surfarea( &
-               mmr, rm1, relhum, pmid, temp, strato_sad, sulfate, m, tropchemlev, dlat, &
+               state, mmr, rm1, relhum, pmid, temp, strato_sad, sulfate, m, tropchemlev, dlat, &
                het1_ndx, pbuf, ncol, sfc_array, dm_array, sad_trop, reff_trop )
 
        endif
@@ -1085,6 +1100,39 @@ contains
        if( usr_CH3COCH3_OH_ndx > 0 ) then
           call comp_exp( exp_fac, -2000._r8*tinv, ncol )
           rxt(:,k,usr_CH3COCH3_OH_ndx) = 3.82e-11_r8 * exp_fac(:) + 1.33e-13_r8
+       end if
+
+!-----------------------------------------------------------------
+!       ... N + O2 -> NO + O
+! Rate coefficients calculated by J. Orlando, D. Kinnison, and J. Zhang (2024)
+! from data published in:
+! "Kinetics of the Reactions of N(4S) Atoms with O2 and CO2 over Wide Temperatures Ranges"
+! Abel Fernandez, A. Goumri, and Arthur Fontijn, 1998
+! https://doi.org/10.1021/jp972365k
+!-----------------------------------------------------------------
+       if( usr_N_O2_ndx > 0 ) then
+          call comp_exp( exp_fac, -2557._r8*tinv, ncol )
+          rxt(:,k,usr_N_O2_ndx) = 2.0e-18_r8 * temp(:ncol,k)**2.15_r8 * exp_fac(:)
+       end if
+
+!-----------------------------------------------------------------
+!       ... N2D + O2 -> NO + O
+! "On the rate coefficient of the N(2D)+O2->NO+O reaction in the terrestrial thermosphere"
+! Duff, J.W., H. Dothe, and R. D. Sharma, 2003
+! https://doi.org/10.1029/2002GL016720
+!-----------------------------------------------------------------
+       if( usr_N2D_O2_ndx > 0 ) then
+          rxt(:,k,usr_N2D_O2_ndx) = 6.2e-12_r8 * temp(:ncol,k)/300.0_r8
+       end if
+
+!-----------------------------------------------------------------
+!       ... N2D + e -> N + e  Roble, 1995
+! "Energetics of the Mesosphere and Thermosphere"
+! R. Roble, 1995
+! https://doi.org/10.1029/GM087p0001
+!-----------------------------------------------------------------
+       if( usr_N2D_e_ndx > 0 ) then
+          rxt(:,k,usr_N2D_e_ndx) = 3.6e-10_r8 * sqrt(tempe(:ncol,k)/300.0_r8)
        end if
 
 !-----------------------------------------------------------------
@@ -2007,7 +2055,7 @@ contains
             else
                sur(:) = sulfate(:,k)*m(:,k)/avo*wso4 &              ! xform mixing ratio to g/cm3
                         / amas &                                    ! xform g/cm3 to num particels/cm3
-                        * fare &                                    ! xform num particels/cm3 to cm2/cm3
+                        * fare &                                    ! xform num particles/cm3 to cm2/cm3
                         * xr(:)*xr(:)                               ! humidity factor
             endif
 !-----------------------------------------------------------------
@@ -2026,7 +2074,7 @@ contains
 !       so that velo = 3.75e3*sqrt(T)  (NH3)    gama=0.4
 !--------------------------------------------------------
 !-----------------------------------------------------------------
-!	... use this n2o5 -> 2*hno3 only in tropopause
+!	... use this n2o5 -> 2*hno3 only in troposphere
 !-----------------------------------------------------------------
 	    rxt(:,k,het1_ndx) = rxt(:,k,het1_ndx) &
                                 +.25_r8 * gam1 * sur(:) * 1.40e3_r8 * sqrt( temp(:ncol,k) )

--- a/src_cam/physpkg.F90
+++ b/src_cam/physpkg.F90
@@ -156,6 +156,8 @@ contains
     use dyn_comp,           only: dyn_register
     use offline_driver,     only: offline_driver_reg
     use hemco_interface,    only: HCOI_Chunk_Init
+    use surface_emissions_mod, only: surface_emissions_reg
+    use elevated_emissions_mod, only: elevated_emissions_reg
 
     !---------------------------Local variables-----------------------------
     !
@@ -260,6 +262,9 @@ contains
        ! OSLO_AERO begin
        clim_modal_aero = .false.
        ! OSLO_AERO end
+
+       call surface_emissions_reg()
+       call elevated_emissions_reg()
 
        ! register chemical constituents including aerosols ...
        call chem_register()
@@ -372,7 +377,6 @@ contains
     type(file_desc_t), pointer :: fh_ini, fh_topo
     character(len=8) :: fieldname
     real(r8), pointer :: tptr(:,:), tptr_2(:,:), tptr3d(:,:,:), tptr3d_2(:,:,:)
-    real(r8), pointer :: qpert(:,:)
 
     character(len=11) :: subname='phys_inidat' ! subroutine name
     integer :: tpert_idx, qpert_idx, pblh_idx
@@ -461,21 +465,13 @@ contains
     qpert_idx = pbuf_get_index( 'qpert',ierr)
     if (qpert_idx > 0) then
        call infld(fieldname, fh_ini, dim1name, dim2name, 1, pcols, begchunk, endchunk, &
-            tptr, found, gridname='physgrid')
+            tptr(:,:), found, gridname='physgrid')
        if(.not. found) then
-          tptr=0_r8
+          tptr(:,:) = 0._r8
           if (masterproc) write(iulog,*) trim(fieldname), ' initialized to 0.'
        end if
 
-       allocate(tptr3d_2(pcols,pcnst,begchunk:endchunk), stat=ierr)
-       if (ierr /= 0) then
-          call endrun(subname//': Failed to allocate tptr3d_2(pcols,pcnst,begchunk:endchunk)')
-       end if
-       tptr3d_2 = 0_r8
-       tptr3d_2(:,1,:) = tptr(:,:)
-
-       call pbuf_set_field(pbuf2d, qpert_idx, tptr3d_2)
-       deallocate(tptr3d_2)
+       call pbuf_set_field(pbuf2d, qpert_idx, tptr)
     end if
 
     fieldname='CUSH'
@@ -750,7 +746,6 @@ contains
     use tracers,            only: tracers_init
     use aoa_tracers,        only: aoa_tracers_init
     use rayleigh_friction,  only: rayleigh_friction_init
-    use pbl_utils,          only: pbl_utils_init
     use vertical_diffusion, only: vertical_diffusion_init
     use phys_debug_util,    only: phys_debug_init
     use phys_debug,         only: phys_debug_state_init
@@ -777,6 +772,8 @@ contains
     use cam_history,        only: addfld, register_vector_field, add_default
     use cam_budget,         only: cam_budget_init
     use phys_grid_ctem,     only: phys_grid_ctem_init
+    use surface_emissions_mod, only: surface_emissions_init
+    use elevated_emissions_mod, only: elevated_emissions_init
 
     use ccpp_constituent_prop_mod, only: ccpp_const_props_init
 
@@ -864,6 +861,8 @@ contains
 
     ! initialize carma
     call carma_init(pbuf2d)
+    call surface_emissions_init(pbuf2d)
+    call elevated_emissions_init(pbuf2d)
 
     ! Prognostic chemistry.
     call chem_init(phys_state,pbuf2d)
@@ -889,7 +888,6 @@ contains
 
     call rayleigh_friction_init()
 
-    call pbl_utils_init(gravit, karman, cpair, rair, zvir)
     call vertical_diffusion_init(pbuf2d)
 
     if ( waccmx_is('ionosphere') .or. waccmx_is('neutral') ) then
@@ -2420,7 +2418,15 @@ contains
         tmp_trac(:ncol,:pver,:pcnst) = state%q(:ncol,:pver,:pcnst)
         tmp_pdel(:ncol,:pver)        = state%pdel(:ncol,:pver)
         tmp_ps(:ncol)                = state%ps(:ncol)
+        if (trim(cam_take_snapshot_before) == "physics_dme_adjust") then
+           call cam_snapshot_all_outfld_tphysac(cam_snapshot_before_num, state, tend, cam_in, cam_out, pbuf,&
+                      fh2o, surfric, obklen, flx_heat, cmfmc, dlf, det_s, det_ice, net_flx)
+        end if
         call physics_dme_adjust(state, tend, qini, totliqini, toticeini, ztodt)
+        if (trim(cam_take_snapshot_after) == "physics_dme_adjust") then
+          call cam_snapshot_all_outfld_tphysac(cam_snapshot_after_num, state, tend, cam_in, cam_out, pbuf,&
+               fh2o, surfric, obklen, flx_heat, cmfmc, dlf, det_s, det_ice, net_flx)
+        end if
         call tot_energy_phys(state, 'phAM')
         call tot_energy_phys(state, 'dyAM', vc=vc_dycore)
         ! Restore pre-"physics_dme_adjust" tracers
@@ -2554,6 +2560,8 @@ contains
     use cam_snapshot,    only: cam_snapshot_all_outfld_tphysbc
     use cam_snapshot_common, only: cam_snapshot_ptend_outfld
     use dyn_tests_utils, only: vc_dycore
+    use surface_emissions_mod,only: surface_emissions_set
+    use elevated_emissions_mod,only: elevated_emissions_set
 
     ! Arguments
 
@@ -2769,6 +2777,10 @@ contains
     end if
 
     call t_stopf('energy_fixer')
+
+    call surface_emissions_set( lchnk, ncol, pbuf )
+    call elevated_emissions_set( lchnk, ncol, pbuf )
+
     !
     !===================================================
     ! Dry adjustment
@@ -2975,6 +2987,8 @@ subroutine phys_timestep_init(phys_state, cam_in, cam_out, pbuf2d)
   use nudging,             only: Nudge_Model, nudging_timestep_init
   use waccmx_phys_intr,    only: waccmx_phys_ion_elec_temp_timestep_init
   use phys_grid_ctem,      only: phys_grid_ctem_diags
+  use surface_emissions_mod,only: surface_emissions_adv
+  use elevated_emissions_mod,only: elevated_emissions_adv
   ! OSLO_AERO begin
   use oslo_aero_ocean,     only: oslo_aero_ocean_adv
   ! OSLO_AERO end
@@ -2998,6 +3012,8 @@ subroutine phys_timestep_init(phys_state, cam_in, cam_out, pbuf2d)
 
   ! Chemistry surface values
   call chem_surfvals_set()
+  call surface_emissions_adv(pbuf2d, phys_state)
+  call elevated_emissions_adv(pbuf2d, phys_state)
 
   ! Solar irradiance
   call solar_data_advance()

--- a/src_cam/vertical_diffusion.F90
+++ b/src_cam/vertical_diffusion.F90
@@ -67,7 +67,6 @@ use physconst,        only :          &
      mwdry  , &     ! Molecular weight of dry air
      avogad         ! Avogadro's number
 use cam_history,      only : fieldname_len
-use perf_mod
 use cam_logfile,      only : iulog
 use ref_pres,         only : do_molec_diff, nbot_molec
 use phys_control,     only : phys_getopts
@@ -78,7 +77,6 @@ use oslo_aero_share,  only: getNumberOfAerosolTracers, fillAerosolTracerList
 
 implicit none
 private
-save
 
 ! ----------------- !
 ! Public interfaces !
@@ -136,15 +134,18 @@ integer              :: clubbtop_idx = -1
 
 logical              :: diff_cnsrv_mass_check        ! do mass conservation check
 logical              :: do_iss                       ! switch for implicit turbulent surface stress
-logical              :: prog_modal_aero = .true.     ! set true if prognostic modal aerosols are present
-integer              :: pmam_ncnst = 0               ! number of prognostic modal aerosol constituents
-integer, allocatable :: pmam_cnst_idx(:)             ! constituent indices of prognostic modal aerosols
 
 logical              :: do_pbl_diags = .false.
 logical              :: waccmx_mode = .false.
 logical              :: do_hb_above_clubb = .false.
 
 real(r8),allocatable :: kvm_sponge(:)
+
+! OSLO_AERO begin
+logical              :: prog_modal_aero = .true.
+integer              :: pmam_ncnst = 0   ! number of prognostic modal aerosol constituents
+integer, allocatable :: pmam_cnst_idx(:) ! constituent indices of prognostic modal aerosols
+! OSLO_AERO end
 
 contains
 
@@ -235,8 +236,8 @@ subroutine vd_register()
   call pbuf_add_field('tauresx',  'global', dtype_r8, (/pcols/),        tauresx_idx)
   call pbuf_add_field('tauresy',  'global', dtype_r8, (/pcols/),        tauresy_idx)
 
-  call pbuf_add_field('tpert', 'global', dtype_r8, (/pcols/),                       tpert_idx)
-  call pbuf_add_field('qpert', 'global', dtype_r8, (/pcols,pcnst/),                 qpert_idx)
+  call pbuf_add_field('tpert', 'global', dtype_r8, (/pcols/),           tpert_idx)
+  call pbuf_add_field('qpert', 'global', dtype_r8, (/pcols/),           qpert_idx)
 
   if (trim(shallow_scheme) == 'UNICON') then
      call pbuf_add_field('qtl_flx',  'global', dtype_r8, (/pcols, pverp/), qtl_flx_idx)
@@ -273,12 +274,10 @@ subroutine vertical_diffusion_init(pbuf2d)
   use hb_diff,           only : init_hb_diff
   use molec_diff,        only : init_molec_diff
   use diffusion_solver,  only : init_vdiff, new_fieldlist_vdiff, vdiff_select
-  use constituents,      only : cnst_get_ind, cnst_get_type_byind, cnst_name, cnst_get_molec_byind
+  use constituents,      only : cnst_get_ind, cnst_get_type_byind, cnst_name, cnst_get_molec_byind, cnst_ndropmixed
   use spmd_utils,        only : masterproc
   use ref_pres,          only : press_lim_idx, pref_mid
   use physics_buffer,    only : pbuf_set_field, pbuf_get_index, physics_buffer_desc
-  use rad_constituents,  only : rad_cnst_get_info, rad_cnst_get_mode_num_idx, &
-       rad_cnst_get_mam_mmr_idx
   use trb_mtn_stress_cam,only : trb_mtn_stress_init
   use beljaars_drag_cam, only : beljaars_drag_init
   use upper_bc,          only : ubc_init
@@ -700,25 +699,27 @@ subroutine vertical_diffusion_tend( &
   use camsrfexch,         only : cam_in_t
   use cam_history,        only : outfld
 
-  use trb_mtn_stress_cam, only : trb_mtn_stress_tend
-  use beljaars_drag_cam,  only : beljaars_drag_tend
-  use eddy_diff_cam,      only : eddy_diff_tend
-  use hb_diff,            only : compute_hb_diff, compute_hb_free_atm_diff
-  use wv_saturation,      only : qsat
-  use molec_diff,         only : compute_molec_diff, vd_lu_qdecomp
-  use constituents,       only : qmincg, qmin, cnst_type
-  use diffusion_solver,   only : compute_vdiff, any, operator(.not.)
-  use air_composition,    only : cpairv, rairv !Needed for calculation of upward H flux
-  use time_manager,       only : get_nstep
-  use constituents,       only : cnst_get_type_byind, cnst_name, &
-       cnst_mw, cnst_fixed_ubc, cnst_fixed_ubflx
-  use physconst,          only : pi
-  use pbl_utils,          only : virtem, calc_obklen, calc_ustar
-  use upper_bc,           only : ubc_get_vals, ubc_fixed_temp
-  use upper_bc,           only : ubc_get_flxs
-  use coords_1d,          only : Coords1D
-  use phys_control,       only : cam_physpkg_is
-  use ref_pres,           only : ptop_ref
+  use trb_mtn_stress_cam,   only : trb_mtn_stress_tend
+  use beljaars_drag_cam,    only : beljaars_drag_tend
+  use eddy_diff_cam,        only : eddy_diff_tend
+  use hb_diff,              only : compute_hb_diff, compute_hb_free_atm_diff
+  use wv_saturation,        only : qsat
+  use molec_diff,           only : compute_molec_diff, vd_lu_qdecomp
+  use constituents,         only : qmincg, qmin, cnst_type
+  use diffusion_solver,     only : compute_vdiff, any, operator(.not.)
+  use air_composition,      only : cpairv, rairv !Needed for calculation of upward H flux
+  use time_manager,         only : get_nstep
+  use constituents,         only : cnst_get_type_byind, cnst_name, &
+                                   cnst_mw, cnst_fixed_ubc, cnst_fixed_ubflx, cnst_ndropmixed
+  use physconst,            only : pi
+  use atmos_phys_pbl_utils, only: calc_virtual_temperature, calc_ideal_gas_rrho, calc_friction_velocity,                             &
+                                  calc_kinematic_heat_flux, calc_kinematic_water_vapor_flux, calc_kinematic_buoyancy_flux, &
+                                  calc_obukhov_length
+  use upper_bc,             only : ubc_get_vals, ubc_fixed_temp
+  use upper_bc,             only : ubc_get_flxs
+  use coords_1d,            only : Coords1D
+  use phys_control,         only : cam_physpkg_is
+  use ref_pres,             only : ptop_ref
 
   ! --------------- !
   ! Input Arguments !
@@ -1007,10 +1008,12 @@ subroutine vertical_diffusion_tend( &
 
      ! The diag_TKE scheme does not calculate the Monin-Obukhov length, which is used in dry deposition calculations.
      ! Use the routines from pbl_utils to accomplish this. Assumes ustar and rrho have been set.
-     call virtem(ncol, th(:ncol,pver),state%q(:ncol,pver,1), thvs(:ncol))
-     call calc_obklen(ncol, th(:ncol,pver), thvs(:ncol), cam_in%cflx(:ncol,1), &
-          cam_in%shf(:ncol), rrho(:ncol), ustar(:ncol), &
-          khfs(:ncol),    kqfs(:ncol), kbfs(:ncol),   obklen(:ncol))
+      thvs  (:ncol) = calc_virtual_temperature(th(:ncol,pver), state%q(:ncol,pver,1), zvir)
+
+      khfs  (:ncol) = calc_kinematic_heat_flux(cam_in%shf(:ncol), rrho(:ncol), cpair)
+      kqfs  (:ncol) = calc_kinematic_water_vapor_flux(cam_in%cflx(:ncol,1), rrho(:ncol))
+      kbfs  (:ncol) = calc_kinematic_buoyancy_flux(khfs(:ncol), zvir, th(:ncol,pver), kqfs(:ncol))
+      obklen(:ncol) = calc_obukhov_length(thvs(:ncol), ustar(:ncol), gravit, karman, kbfs(:ncol))
 
 
   case ( 'HB', 'HBR' )
@@ -1063,14 +1066,13 @@ subroutine vertical_diffusion_tend( &
       ! is only handling other things, e.g. some boundary conditions, tms,
       ! and molecular diffusion.
 
-      call virtem(ncol, th(:ncol,pver),state%q(:ncol,pver,1), thvs(:ncol))
-
-      call calc_ustar( ncol, state%t(:ncol,pver), state%pmid(:ncol,pver), &
-           cam_in%wsx(:ncol), cam_in%wsy(:ncol), rrho(:ncol), ustar(:ncol))
-      ! Use actual qflux, not lhf/latvap as was done previously
-      call calc_obklen( ncol, th(:ncol,pver), thvs(:ncol), cam_in%cflx(:ncol,1), &
-           cam_in%shf(:ncol), rrho(:ncol), ustar(:ncol),  &
-           khfs(:ncol), kqfs(:ncol), kbfs(:ncol), obklen(:ncol))
+      thvs  (:ncol) = calc_virtual_temperature(th(:ncol,pver), state%q(:ncol,pver,1), zvir)
+      rrho  (:ncol) = calc_ideal_gas_rrho(rair, state%t(:ncol,pver), state%pmid(:ncol,pver))
+      ustar (:ncol) = calc_friction_velocity(cam_in%wsx(:ncol), cam_in%wsy(:ncol), rrho(:ncol))
+      khfs  (:ncol) = calc_kinematic_heat_flux(cam_in%shf(:ncol), rrho(:ncol), cpair)
+      kqfs  (:ncol) = calc_kinematic_water_vapor_flux(cam_in%cflx(:ncol,1), rrho(:ncol))
+      kbfs  (:ncol) = calc_kinematic_buoyancy_flux(khfs(:ncol), zvir, th(:ncol,pver), kqfs(:ncol))
+      obklen(:ncol) = calc_obukhov_length(thvs(:ncol), ustar(:ncol), gravit, karman, kbfs(:ncol))
       ! These tendencies all applied elsewhere.
       kvm = 0._r8
       kvh = 0._r8


### PR DESCRIPTION
- Updated Oslo Aero shadow files (src_cam) plus aero_model.F90 to account for modifications in ESCOMP/CAM between cam6_4_070 and cam6_4_085.
- vertical_diffusion.F90 is still using `pmam_cnst_idx` to decide which constituents to skip for vertical diffusion. We probably want to move to the new `ndropmixed` constituent property. This property is used by CLUBB to decide which transport tendencies to not apply:

> !  Droplet number is transported in dropmixnuc, therefore we
> !  do NOT want CLUBB to apply transport tendencies to avoid double
> !  counting.  Else, we apply tendencies.

Do do this, I have added the `ndropmixed` property to the following constituents, without modifying vertical_diffusion (for now):
```
SO4_NA    SO4_A1    SO4_A2    SO4_AC
SO4_PR    BC_N      BC_AX     BC_NI 
BC_A      BC_AI     BC_AC     OM_NI 
OM_AI     OM_AC     DST_A2    DST_A3
SS_A1     SS_A2     SS_A3     SOA_NA
SOA_A1
```