### PR TITLE
Modified mixtures avaiable for ice particle formation

### DIFF
--- a/src/oslo_aero_hetfrz.F90
+++ b/src/oslo_aero_hetfrz.F90
@@ -1108,12 +1108,12 @@ contains
 
     ! if aw*Si<=1, the freezing point depression is strong enough to prevent freezing
 
-    if (aw(id_bc)*supersatice > 1._r8 ) then
-       do_bc   = .true.
-       rgimm_bc = 2*vwice*sigma_iw/(kboltz*t*LOG(aw(id_bc)*supersatice))
-    else
+!    if (aw(id_bc)*supersatice > 1._r8 ) then
+!       do_bc   = .true.
+!       rgimm_bc = 2*vwice*sigma_iw/(kboltz*t*LOG(aw(id_bc)*supersatice))
+!    else
        do_bc = .false.
-    end if
+!    end if
 
     if (aw(id_dst1)*supersatice > 1._r8 ) then
        do_dst1 = .true.

--- a/src/oslo_aero_hetfrz.F90
+++ b/src/oslo_aero_hetfrz.F90
@@ -1106,14 +1106,7 @@ contains
     rgimm_dust_a1 = rgimm
     rgimm_dust_a3 = rgimm
 
-    ! if aw*Si<=1, the freezing point depression is strong enough to prevent freezing
-
-!    if (aw(id_bc)*supersatice > 1._r8 ) then
-!       do_bc   = .true.
-!       rgimm_bc = 2*vwice*sigma_iw/(kboltz*t*LOG(aw(id_bc)*supersatice))
-!    else
-       do_bc = .false.
-!    end if
+    do_bc = .false.
 
     if (aw(id_dst1)*supersatice > 1._r8 ) then
        do_dst1 = .true.

--- a/src/oslo_aero_nucleate_ice.F90
+++ b/src/oslo_aero_nucleate_ice.F90
@@ -42,7 +42,7 @@ module oslo_aero_nucleate_ice
   use nucleate_ice,      only: nucleati_init, nucleati  ! portable module
   !
   use oslo_aero_share,   only: l_dst_a2, l_dst_a3, MODE_IDX_DST_A2, MODE_IDX_DST_A3, rhopart, qqcw_get_field
-  use oslo_aero_share,   only: MODE_IDX_DST_A2, MODE_IDX_DST_A3, MODE_IDX_SO4_AC,MODE_IDX_OMBC_INTMIX_COAT_AIT
+  use oslo_aero_share,   only: MODE_IDX_DST_A2, MODE_IDX_DST_A3, MODE_IDX_SO4_AC,MODE_IDX_OMBC_INTMIX_COAT_AIT,MODE_IDX_SO4SOA_AIT 
   use oslo_aero_share,   only: volumeToNumber
   use oslo_aero_share,   only: nmodes
 
@@ -452,7 +452,7 @@ contains
              ! dust = coarse mode
              ! since modal has internal mixtures.
              ! Oslo aerosols have two modes.. Need mode-fractions
-             so4_num = (numberConcentration(icol,ilev,MODE_IDX_SO4_AC))*1.0e-6_r8
+             so4_num = (numberConcentration(icol,ilev,MODE_IDX_SO4_AC)+numberConcentration(icol,ilev,MODE_IDX_SO4SOA_AIT))*1.0e-6_r8
              dst_num = (numberConcentration(icol,ilev,MODE_IDX_DST_A2) + numberConcentration(icol,ilev,MODE_IDX_DST_A3))*1.0e-6_r8
              !soot_num =  numberConcentration(icol,ilev,MODE_IDX_OMBC_INTMIX_COAT_AIT)*1.0e-6_r8
              dust_coarse_fraction = numberConcentration(icol,ilev,MODE_IDX_DST_A3)*1.e-6_r8 / (dst_num+1.e-100_r8)


### PR DESCRIPTION
Included sulfate aitken mode in the potential number of IN as done n CESM3; Turned off BC immersion freezing by setting logical variable do_bc equal false everywhere

Described and discussed in  https://github.com/NorESMhub/noresm3_dev_simulations/discussions/96