### PR TITLE
Reduced output from CAM-Oslo in noresm3

### DIFF
--- a/src/aero_model.F90
+++ b/src/aero_model.F90
@@ -173,7 +173,7 @@ contains
   subroutine aero_model_init( pbuf2d )
 
    use string_utils, only: int2str
-   use mo_setsox, only: sox_inti
+   use mo_setsox,    only: sox_inti
 
    ! args
    type(physics_buffer_desc), pointer :: pbuf2d(:,:)

--- a/src/aero_model.F90
+++ b/src/aero_model.F90
@@ -44,6 +44,8 @@ module aero_model
   use oslo_aero_share,          only: lifeCycleNumberMedianRadius, rhopart, lifeCycleSigma
   use oslo_aero_share,          only: l_so4_a2, l_bc_n, l_bc_ax, l_dms, l_isoprene, l_monoterp
   use oslo_aero_share,          only: MODE_IDX_BC_NUC, MODE_IDX_BC_EXT_AC
+  use oslo_aero_share,          only: getNumberofTracersInMode, getCloudTracerIndexDirect, getCloudTracerName
+  use oslo_aero_share,          only: getTracerIndex
   use oslo_aero_control,        only: oslo_aero_ctl_readnl, use_aerocom
   use oslo_aero_depos,          only: oslo_aero_depos_init
   use oslo_aero_depos,          only: oslo_aero_depos_dry, oslo_aero_depos_wet, oslo_aero_wetdep_init
@@ -53,8 +55,6 @@ module aero_model
   use oslo_aero_seasalt,        only: oslo_aero_seasalt_init, oslo_aero_seasalt_emis, seasalt_active
   use oslo_aero_dust,           only: oslo_aero_dust_init, oslo_aero_dust_emis
   use oslo_aero_ocean,          only: oslo_aero_ocean_init, oslo_aero_dms_emis
-  use oslo_aero_share,          only: getNumberofTracersInMode, getCloudTracerIndexDirect, getCloudTracerName
-  use oslo_aero_share,          only: getCloudTracerName, getTracerIndex, aero_register
   use oslo_aero_sox_cldaero,    only: sox_cldaero_init
   use oslo_aero_microp,         only: oslo_aero_microp_readnl
   use oslo_aero_sw_tables,      only: initopt
@@ -947,9 +947,12 @@ contains
   subroutine calcaersize_sub( ncol, t, h2ommr, pmid, pdel,wetnumberMedianDiameter,wetrho,   &
        wetNumberMedianDiameter_processmode, wetrho_processmode)
 
-    ! Seland Calculates mean volume size and hygroscopic growth for use in  dry deposition
+     use oslo_aero_share, only: max_tracers_per_mode, rhtab, rdivr0
+     use oslo_aero_share, only: getNumberOfBackgroundTracersInMode
+     use oslo_aero_share, only: getDryDensity, tracerInProcessMode
+     use oslo_aero_share, only: processModeNumberMedianRadius, processModeSigma
 
-    use oslo_aero_share
+    ! Seland Calculates mean volume size and hygroscopic growth for use in  dry deposition
 
     integer,  intent(in)  :: ncol               ! number of columns
     real(r8), intent(in)  :: t(pcols,pver)      ! layer temperatures (K)

--- a/src/aero_model.F90
+++ b/src/aero_model.F90
@@ -10,8 +10,9 @@ module aero_model
   use spmd_utils,               only: mpi_logical, mpi_real8, mpi_character, mpi_integer,  mpi_success
   use namelist_utils,           only: find_group_name
   use constituents,             only: pcnst, cnst_name, cnst_get_ind
-  use ppgrid,                   only: pcols, pver, pverp
+  use ppgrid,                   only: pcols, pver, pverp, begchunk, endchunk
   use phys_control,             only: phys_getopts, cam_physpkg_is
+  use phys_control,             only: history_aerosol_base
   use cam_abortutils,           only: endrun
   use cam_logfile,              only: iulog
   use perf_mod,                 only: t_startf, t_stopf
@@ -41,7 +42,7 @@ module aero_model
   use oslo_aero_share,          only: chemistryIndex, physicsIndex
   use oslo_aero_share,          only: qqcw_get_field, numberOfProcessModeTracers
   use oslo_aero_share,          only: lifeCycleNumberMedianRadius, rhopart, lifeCycleSigma
-  use oslo_aero_share,          only: l_so4_a2, l_bc_n, l_bc_ax
+  use oslo_aero_share,          only: l_so4_a2, l_bc_n, l_bc_ax, l_dms, l_isoprene, l_monoterp
   use oslo_aero_share,          only: MODE_IDX_BC_NUC, MODE_IDX_BC_EXT_AC
   use oslo_aero_control,        only: oslo_aero_ctl_readnl, use_aerocom
   use oslo_aero_depos,          only: oslo_aero_depos_init
@@ -75,6 +76,22 @@ module aero_model
   public :: aero_model_strat_surfarea ! stratospheric aerosol wet surface area for chemistry
 
   private :: aero_model_constants
+
+  ! GS and AQ arrays used for source fields summed in oslo_aero_share.F90-summation_fields_writeout()
+  ! GS_SOA = GS_SOA_LV + GS_SOA_SV, we use l_soa_lv and l_soa_sv for logic
+  ! GS_H2SO4 and AQ_H2SO4, we use l_h2so4 for logic
+  ! AQ_SO4_A2_OCW, we use l_so4_a2 for logic inside cloud tracer loop
+  ! GS_DMS, we use l_dms for logic
+  ! GS_SO2 and AQ_SO2, we us e l_so2 for logic
+  real(r8), public, protected, allocatable   :: GS_SOA(:,:)
+  real(r8), public, protected, allocatable   :: GS_H2SO4(:,:)
+  real(r8), public, protected, allocatable   :: GS_DMS(:,:)
+  real(r8), public, protected, allocatable   :: GS_SO2(:,:)
+  real(r8), public, protected, allocatable   :: GS_isoprene(:,:)
+  real(r8), public, protected, allocatable   :: GS_monoterp(:,:)
+  real(r8), public, protected, allocatable   :: AQ_H2SO4(:,:)
+  real(r8), public, protected, allocatable   :: AQ_SO4_A2_OCW(:,:)
+  real(r8), public, protected, allocatable   :: AQ_SO2(:,:)
 
   ! Misc private data
   integer :: pblh_idx= 0
@@ -137,23 +154,84 @@ contains
 
   !=============================================================================
   subroutine aero_model_register()
+      use oslo_aero_share, only: aero_register,                   &
+                                 sulfur_mass_fraction_register,   &
+                                 soa_yield_register
+      use oslo_aero_depos, only: oslo_aero_depos_register
 
-    call aero_register()
+      call aero_register()
+
+      call oslo_aero_depos_register()
+
+      call sulfur_mass_fraction_register()
+
+      call soa_yield_register()
 
   end subroutine aero_model_register
 
   !=============================================================================
   subroutine aero_model_init( pbuf2d )
-     use mo_setsox, only: sox_inti
 
-    ! args
-    type(physics_buffer_desc), pointer :: pbuf2d(:,:)
+   use string_utils, only: int2str
+   use mo_setsox, only: sox_inti
 
-    ! local vars
-    integer           :: icnst,id
-    character(len=20) :: dummy
-    logical           :: history_aerosol ! Output MAM or SECT aerosol tendencies
-    character(len=2)  :: unit_basename  ! Units 'kg' or '1'
+   ! args
+   type(physics_buffer_desc), pointer :: pbuf2d(:,:)
+
+   ! local vars
+   integer           :: icnst,id
+   integer           :: l_aero
+   character(len=20) :: dummy
+   logical           :: history_aerosol ! Output MAM or SECT aerosol tendencies
+   character(len=2)  :: unit_basename  ! Units 'kg' or '1'
+   integer :: astat
+   !------------------------------------
+   ! allocate module variables
+   allocate( GS_SOA(pcols, begchunk:endchunk), stat=astat )
+   if( astat/= 0 ) then
+      call endrun('aero_model_init: failed to allocate GS_SOA array; error = '//int2str(astat))
+   end if
+   GS_SOA(:,:) = 0.0_r8
+   allocate( GS_H2SO4(pcols, begchunk:endchunk), stat=astat )
+   if( astat/= 0 ) then
+      call endrun('aero_model_init: failed to allocate GS_H2SO4 array; error = '//int2str(astat))
+   end if
+   GS_H2SO4(:,:) = 0.0_r8
+   allocate( GS_DMS(pcols, begchunk:endchunk), stat=astat )
+   if( astat/= 0 ) then
+      call endrun('aero_model_init: failed to allocate GS_DMS array; error = '//int2str(astat))
+   end if
+   GS_DMS(:,:) = 0.0_r8
+   allocate( GS_SO2(pcols, begchunk:endchunk), stat=astat )
+   if( astat/= 0 ) then
+      call endrun('aero_model_init: failed to allocate GS_SO2 array; error = '//int2str(astat))
+   end if
+   GS_SO2(:,:) = 0.0_r8
+   allocate( GS_isoprene(pcols, begchunk:endchunk), stat=astat )
+   if( astat/= 0 ) then
+      call endrun('aero_model_init: failed to allocate GS_isoprene array; error = '//int2str(astat))
+   end if
+   GS_isoprene(:,:) = 0.0_r8
+   allocate( GS_monoterp(pcols, begchunk:endchunk), stat=astat )
+   if( astat/= 0 ) then
+      call endrun('aero_model_init: failed to allocate GS_monoterp array; error = '//int2str(astat))
+   end if
+   GS_monoterp(:,:) = 0.0_r8
+   allocate( AQ_H2SO4(pcols, begchunk:endchunk), stat=astat )
+   if( astat/= 0 ) then
+      call endrun('aero_model_init: failed to allocate AQ_H2SO4 array; error = '//int2str(astat))
+   end if
+   AQ_H2SO4(:,:) = 0.0_r8
+   allocate( AQ_SO4_A2_OCW(pcols, begchunk:endchunk), stat=astat )
+   if( astat/= 0 ) then
+      call endrun('aero_model_init: failed to allocate AQ_SO4_A2_OCW array; error = '//int2str(astat))
+   end if
+   AQ_SO4_A2_OCW(:,:) = 0.0_r8
+   allocate( AQ_SO2(pcols, begchunk:endchunk), stat=astat )
+   if( astat/= 0 ) then
+      call endrun('aero_model_init: failed to allocate AQ_SO2 array; error = '//int2str(astat))
+   end if
+   AQ_SO2(:,:) = 0.0_r8
     !------------------------------------
 
     call phys_getopts(history_aerosol_out=history_aerosol, convproc_do_aer_out=convproc_do_aer)
@@ -223,6 +301,22 @@ contains
              end if
           end if
        endif
+
+      call cnst_get_ind(solsym(icnst), l_aero, abort=.false. )
+      if ( l_aero == l_dms .or. l_aero == l_isoprene .or. l_aero == l_monoterp ) then
+         call addfld( 'sink_'//trim(solsym(icnst)),horiz_only, 'A', unit_basename//'/m2/s ', &
+            trim(solsym(icnst))//' sink')
+         if ( l_aero == l_dms ) then
+            call addfld( 'sink_'//trim(solsym(icnst))//'_S',horiz_only, 'A', 'kg*S/m2/s ', &
+               trim(solsym(icnst))//' sink, sulfur mass only')
+         endif
+         if ( history_aerosol_base ) then
+            call add_default( 'sink_'//trim(solsym(icnst)), 1, ' ')
+            if ( l_aero == l_dms ) then
+               call add_default( 'sink_'//trim(solsym(icnst))//'_S', 1, ' ')
+            endif
+         endif
+      endif
     enddo
 
     call addfld ('NUCLRATE',(/'lev'/), 'A','#/cm3/s','Nucleation rate')
@@ -403,6 +497,10 @@ contains
        delt, reaction_rates, tfld, pmid, pdel, mbar, relhum, zm,  qh2o, cwat, &
        cldfr, cldnum, airdens, invariants, del_h2so4_gasprod, vmr0, vmr, pbuf )
 
+    ! use
+    use oslo_aero_share,    only : sulfurMassFraction
+    use oslo_aero_share,    only : l_soa_lv, l_soa_sv, l_h2so4, l_so4_a2, l_dms, l_isoprene, l_monoterp, l_so2
+
     ! arguments
     type(physics_state), intent(in) :: state        ! Physics state variables
     integer,  intent(in)    :: loffset                ! offset applied to modal aero "pointers"
@@ -431,6 +529,7 @@ contains
     ! local vars
     integer, parameter :: nmodes_aq_chem = 1
     integer  :: icol,ilev
+    integer  :: l_aero
     integer  :: imode,icnst,itrac
     integer  :: nstep
     real(r8) :: wrk(ncol)
@@ -460,6 +559,15 @@ contains
     nstep = get_nstep()
 
     delt_inverse = 1.0_r8 / delt
+    GS_SOA(:ncol,lchnk) = 0._r8
+    GS_H2SO4(:ncol,lchnk) = 0._r8
+    GS_DMS(:ncol,lchnk) = 0._r8
+    GS_SO2(:ncol,lchnk) = 0._r8
+    GS_isoprene(:ncol,lchnk) = 0._r8
+    GS_monoterp(:ncol,lchnk) = 0._r8
+    AQ_H2SO4(:ncol,lchnk) = 0._r8
+    AQ_SO4_A2_OCW(:ncol,lchnk) = 0._r8
+    AQ_SO2(:ncol,lchnk) = 0._r8
 
     ! Get height of boundary layer (needed for boundary layer nucleation)
     call pbuf_get_field(pbuf, pblh_idx, pblh)
@@ -471,8 +579,31 @@ contains
        do ilev = 1,pver
           wrk(:ncol) = wrk(:ncol) + dvmrdt(:ncol,ilev,icnst)*adv_mass(icnst)/mbar(:ncol,ilev)*pdel(:ncol,ilev)/gravit
        end do
+
+       call cnst_get_ind(trim(solsym(icnst)), l_aero, abort=.false.)
+       if ( l_aero == l_soa_lv .or. l_aero == l_soa_sv ) then
+          GS_SOA(:ncol,lchnk) = GS_SOA(:ncol,lchnk) + wrk(:ncol)
+       else if ( l_aero == l_h2so4 ) then
+          GS_H2SO4(:ncol,lchnk) = GS_H2SO4(:ncol,lchnk) + wrk(:ncol)
+       else if ( l_aero == l_dms ) then
+          GS_DMS(:ncol, lchnk) = GS_DMS(:ncol,lchnk) + wrk(:ncol)
+       else if ( l_aero == l_so2) then
+          GS_SO2(:ncol, lchnk) = GS_SO2(:ncol,lchnk) + wrk(:ncol)
+       else if ( l_aero == l_isoprene ) then
+          GS_isoprene(:ncol, lchnk) = GS_isoprene(:ncol,lchnk) + wrk(:ncol)
+       else if ( l_aero == l_monoterp ) then
+          GS_monoterp(:ncol, lchnk) = GS_monoterp(:ncol,lchnk) + wrk(:ncol)
+       endif
+
        name = 'GS_'//trim(solsym(icnst))
        call outfld( name, wrk(:ncol), ncol, lchnk )
+
+       if ( l_aero == l_dms .or. l_aero == l_isoprene .or. l_aero == l_monoterp) then
+         call outfld( 'sink_'//trim(solsym(icnst)), wrk(:ncol), ncol, lchnk )
+         if ( l_aero == l_dms ) then
+            call outfld( 'sink_'//trim(solsym(icnst))//'_S', ( wrk(:ncol) * sulfurMassFraction(l_aero) ) , ncol, lchnk )
+         endif
+      endif
     enddo
 
     ! Get mass mixing ratios at start of time step
@@ -523,6 +654,14 @@ contains
        do ilev = 1,pver
           wrk(:ncol) = wrk(:ncol) + dvmrdt_sv1(:ncol,ilev,icnst)*adv_mass(icnst)/mbar(:ncol,ilev)*pdel(:ncol,ilev)/gravit
        end do
+
+       call cnst_get_ind(trim(solsym(icnst)), l_aero, abort=.false.)
+       if ( l_aero == l_h2so4) then
+          AQ_H2SO4(:ncol,lchnk) = AQ_H2SO4(:ncol,lchnk) + wrk(:ncol)
+       else if ( l_aero == l_so2 ) then
+          AQ_SO2(:ncol,lchnk) = AQ_SO2(:ncol,lchnk) + wrk(:ncol)
+       endif
+
        name = 'AQ_'//trim(solsym(icnst))
        call outfld( name, wrk(:ncol), ncol, lchnk )
 
@@ -536,6 +675,10 @@ contains
              do ilev=1,pver
                 wrk(:ncol) = wrk(:ncol) + dvmrcwdt_sv1(:ncol,ilev,icnst)*adv_mass(icnst)/mbar(:ncol,ilev)*pdel(:ncol,ilev)/gravit
              end do
+
+             if ( l_aero == l_so4_a2 ) then
+               AQ_SO4_A2_OCW(:ncol,lchnk) = AQ_SO4_A2_OCW(:ncol,lchnk) + wrk(:ncol)
+             endif
              call outfld( name, wrk(:ncol), ncol, lchnk )
           end if
        end if

--- a/src/oslo_aero_coag.F90
+++ b/src/oslo_aero_coag.F90
@@ -441,11 +441,8 @@ contains
     character(128)    :: long_name                       ![-] needed for diagnostics
     real(r8)          :: coltend(pcols, gas_pcnst)
     real(r8)          :: tracer_coltend(pcols)
-    logical           :: history_aerosol
 
     totalLoss(:,:,:)=0.0_r8
-
-    call phys_getopts(history_aerosol_out = history_aerosol)
 
     do ilev = 1,pver
        do icol = 1,ncol
@@ -559,26 +556,24 @@ contains
     end do
 
     !Output for diagnostics
-    if(history_aerosol)then
-       coltend(:ncol,:) = 0.0_r8
-       do itrac=1,gas_pcnst
-          !Check if species contributes to coagulation
-          if(lifeCycleReceiver(itrac) > 0)then
-             !Loss from the donor specie
-             tracer_coltend(:ncol) = sum(totalLoss(:ncol, :,itrac)*pdel(:ncol,:),2)/gravit*delt_inverse
-             coltend(:ncol,itrac) = coltend(:ncol,itrac) - tracer_coltend(:ncol) !negative, loss for donor
-             coltend(:ncol,lifeCycleReceiver(itrac)) = coltend(:ncol,lifeCycleReceiver(itrac)) + tracer_coltend(:ncol)
-          endif
-       end do
-       do itrac=1,gas_pcnst
-          if(lifeCycleReceiver(itrac) > 0)then
-             long_name= trim(solsym(itrac))//"coagTend"
-             call outfld(long_name, coltend(:ncol,itrac), ncol, lchnk)
-             long_name= trim(solsym(lifeCycleReceiver(itrac)))//"coagTend"
-             call outfld(long_name, coltend(:ncol,lifeCycleReceiver(itrac)),ncol,lchnk)
-          end if
-       end do
-    endif
+   coltend(:ncol,:) = 0.0_r8
+   do itrac=1,gas_pcnst
+      !Check if species contributes to coagulation
+      if(lifeCycleReceiver(itrac) > 0)then
+         !Loss from the donor specie
+         tracer_coltend(:ncol) = sum(totalLoss(:ncol, :,itrac)*pdel(:ncol,:),2)/gravit*delt_inverse
+         coltend(:ncol,itrac) = coltend(:ncol,itrac) - tracer_coltend(:ncol) !negative, loss for donor
+         coltend(:ncol,lifeCycleReceiver(itrac)) = coltend(:ncol,lifeCycleReceiver(itrac)) + tracer_coltend(:ncol)
+      endif
+   end do
+   do itrac=1,gas_pcnst
+      if(lifeCycleReceiver(itrac) > 0)then
+         long_name= trim(solsym(itrac))//"coagTend"
+         call outfld(long_name, coltend(:ncol,itrac), ncol, lchnk)
+         long_name= trim(solsym(lifeCycleReceiver(itrac)))//"coagTend"
+         call outfld(long_name, coltend(:ncol,lifeCycleReceiver(itrac)),ncol,lchnk)
+      end if
+   end do
   end subroutine coagtend
 
   !================================================================
@@ -620,9 +615,6 @@ contains
     real(r8), pointer :: fldcw(:,:)
     real(r8)          :: coltend(pcols, gas_pcnst)
     real(r8)          :: tracer_coltend(pcols)
-    logical           :: history_aerosol
-
-    call phys_getopts(history_aerosol_out = history_aerosol)
 
     cloudLoss(:,:,:)=0.0_r8
     do ilev = 1,pver
@@ -706,27 +698,26 @@ contains
        end do
     end do
 
-    ! Output for diagnostics
-    if (history_aerosol)then
-       coltend(:ncol,:) = 0.0_r8
-       do itrac = 1,gas_pcnst
-          !Check if species contributes to coagulation
-          if(CloudAerReceiver(itrac) > 0)then
-             !Loss from the donor specie
-             tracer_coltend(:ncol) = sum(cloudLoss(:ncol,:,itrac)*pdel(:ncol,:),2)/gravit*delt_inverse
-             coltend(:ncol,itrac) = coltend(:ncol,itrac) - tracer_coltend(:ncol) !negative, loss for donor
-             coltend(:ncol,CloudAerReceiver(itrac)) = coltend(:ncol,CloudAerReceiver(itrac)) + tracer_coltend(:ncol)
-          endif
-       end do
-       do itrac = 1,gas_pcnst
-          if(CloudAerReceiver(itrac) > 0)then
-             long_name= trim(solsym(itrac))//"clcoagTend"
-             call outfld(long_name, coltend(:ncol,itrac), ncol, lchnk)
-             long_name= trim(solsym(CloudAerReceiver(itrac)))//"_OCWclcoagTend"
-             call outfld(long_name, coltend(:ncol,CloudAerReceiver(itrac)),ncol,lchnk)
-          end if
-       end do
-    endif
+   ! Output for diagnostics
+   coltend(:ncol,:) = 0.0_r8
+   do itrac = 1,gas_pcnst
+      !Check if species contributes to coagulation
+      if(CloudAerReceiver(itrac) > 0)then
+         !Loss from the donor specie
+         tracer_coltend(:ncol) = sum(cloudLoss(:ncol,:,itrac)*pdel(:ncol,:),2)/gravit*delt_inverse
+         coltend(:ncol,itrac) = coltend(:ncol,itrac) - tracer_coltend(:ncol) !negative, loss for donor
+         coltend(:ncol,CloudAerReceiver(itrac)) = coltend(:ncol,CloudAerReceiver(itrac)) + tracer_coltend(:ncol)
+      endif
+   end do
+   do itrac = 1,gas_pcnst
+      if(CloudAerReceiver(itrac) > 0)then
+         long_name= trim(solsym(itrac))//"clcoagTend"
+         call outfld(long_name, coltend(:ncol,itrac), ncol, lchnk)
+         long_name= trim(solsym(CloudAerReceiver(itrac)))//"_OCWclcoagTend"
+         call outfld(long_name, coltend(:ncol,CloudAerReceiver(itrac)),ncol,lchnk)
+      end if
+   end do
+
   end subroutine clcoag
 
   !================================================================

--- a/src/oslo_aero_condtend.F90
+++ b/src/oslo_aero_condtend.F90
@@ -310,7 +310,6 @@ contains
     ! Volume of added  material from condensate;  surface area of core particle;
     real(r8)            :: volume_shell, area_core,vol_monolayer
     real (r8)           :: frac_transfer               ! Fraction of hydrophobic material converted to an internally mixed mode
-    logical             :: history_aerosol
     character(128)      :: long_name                   ! [-] needed for diagnostics
 
     ! needed for h2so4 and soa nucleation treatment
@@ -549,71 +548,66 @@ contains
        end do !physical index ilev
     end do    !physical index icol
 
-    !Output for diagnostics
-    call phys_getopts(history_aerosol_out = history_aerosol)
+   !Output for diagnostics
+   coltend(:ncol,:) = 0.0_r8
+   do icol=1,gas_pcnst
+      !Check if species contributes to condensation
+      if(lifeCycleReceiver(icol) > 0)then
+         !Loss from the donor specie
+         tracer_coltend(:ncol) = sum(totalLoss(:ncol, :,icol)*pdel(:ncol,:),2)/gravit/dt
+         coltend(:ncol,icol) = coltend(:ncol,icol) - tracer_coltend(:ncol) !negative (loss for donor)
+         coltend(:ncol,lifeCycleReceiver(icol)) = coltend(:ncol,lifeCycleReceiver(icol)) + tracer_coltend(:ncol)
+      endif
+   end do
 
-    if(history_aerosol)then
-       coltend(:ncol,:) = 0.0_r8
-       do icol=1,gas_pcnst
-          !Check if species contributes to condensation
-          if(lifeCycleReceiver(icol) > 0)then
-             !Loss from the donor specie
-             tracer_coltend(:ncol) = sum(totalLoss(:ncol, :,icol)*pdel(:ncol,:),2)/gravit/dt
-             coltend(:ncol,icol) = coltend(:ncol,icol) - tracer_coltend(:ncol) !negative (loss for donor)
-             coltend(:ncol,lifeCycleReceiver(icol)) = coltend(:ncol,lifeCycleReceiver(icol)) + tracer_coltend(:ncol)
-          endif
-       end do
+   ! Remove so4_n ---> directly into so4_na
+   coltend(:ncol,chemistryIndex(l_so4_na)) = coltend(:ncol,chemistryIndex(l_so4_na)) + &
+      sum(                                         &
+      gasLost(:ncol,:,COND_VAP_H2SO4)           &
+      *fracNucl(:ncol,:,COND_VAP_H2SO4)*pdel(:ncol,:) , 2 &
+      )/gravit/dt
 
-       ! Remove so4_n ---> directly into so4_na
-       coltend(:ncol,chemistryIndex(l_so4_na)) = coltend(:ncol,chemistryIndex(l_so4_na)) + &
-            sum(                                         &
-            gasLost(:ncol,:,COND_VAP_H2SO4)           &
-            *fracNucl(:ncol,:,COND_VAP_H2SO4)*pdel(:ncol,:) , 2 &
-            )/gravit/dt
+   !Take into account H2SO4 (gas) condensed in budget
+   coltend(:ncol,chemistryIndex(l_so4_a1)) = coltend(:ncol,chemistryIndex(l_so4_a1)) + &
+      sum(                                         &
+      gasLost(:ncol,:,COND_VAP_H2SO4)           &
+      *(1.0_r8 - fracNucl(:ncol,:,COND_VAP_H2SO4))*pdel(:ncol,:) , 2 &
+      )/gravit/dt
 
-       !Take into account H2SO4 (gas) condensed in budget
-       coltend(:ncol,chemistryIndex(l_so4_a1)) = coltend(:ncol,chemistryIndex(l_so4_a1)) + &
-            sum(                                         &
-            gasLost(:ncol,:,COND_VAP_H2SO4)           &
-            *(1.0_r8 - fracNucl(:ncol,:,COND_VAP_H2SO4))*pdel(:ncol,:) , 2 &
-            )/gravit/dt
+   !Take into account soa_lv (gas) nucleated in budget
+   coltend(:ncol,chemistryIndex(l_soa_na)) = coltend(:ncol,chemistryIndex(l_soa_na)) + &
+      sum(                                         &
+      gasLost(:ncol,:,COND_VAP_ORG_LV)              &
+      *fracNucl(:ncol,:,COND_VAP_ORG_LV)*pdel(:ncol,:) , 2 &
+      )/gravit/dt
 
-       !Take into account soa_lv (gas) nucleated in budget
-       coltend(:ncol,chemistryIndex(l_soa_na)) = coltend(:ncol,chemistryIndex(l_soa_na)) + &
-            sum(                                         &
-            gasLost(:ncol,:,COND_VAP_ORG_LV)              &
-            *fracNucl(:ncol,:,COND_VAP_ORG_LV)*pdel(:ncol,:) , 2 &
-            )/gravit/dt
+   !Take into account soa gas condensed in the budget (both LV and SV)
+   coltend(:ncol,chemistryIndex(l_soa_a1)) = coltend(:ncol,chemistryIndex(l_soa_a1)) + &
+      sum(                                         &
+      gasLost(:ncol,:,COND_VAP_ORG_LV)           &
+      *(1.0_r8 - fracNucl(:ncol,:,COND_VAP_ORG_LV))*pdel(:ncol,:) , 2 &
+      )/gravit/dt                        &
+      +                                  &
+      sum(                                         &
+      gasLost(:ncol,:,COND_VAP_ORG_SV)*pdel(:ncol,:) , 2 &
+      )/gravit/dt
 
-       !Take into account soa gas condensed in the budget (both LV and SV)
-       coltend(:ncol,chemistryIndex(l_soa_a1)) = coltend(:ncol,chemistryIndex(l_soa_a1)) + &
-            sum(                                         &
-            gasLost(:ncol,:,COND_VAP_ORG_LV)           &
-            *(1.0_r8 - fracNucl(:ncol,:,COND_VAP_ORG_LV))*pdel(:ncol,:) , 2 &
-            )/gravit/dt                        &
-            +                                  &
-            sum(                                         &
-            gasLost(:ncol,:,COND_VAP_ORG_SV)*pdel(:ncol,:) , 2 &
-            )/gravit/dt
-
-       do icol=1,gas_pcnst
-          if(lifeCycleReceiver(icol) > 0 )then
-             long_name= trim(solsym(icol))//"condTend"
-             call outfld(long_name, coltend(:,icol), pcols, lchnk)
-             long_name= trim(solsym(lifeCycleReceiver(icol)))//"condTend"
-             call outfld(long_name, coltend(:,lifeCycleReceiver(icol)),pcols,lchnk)
-          end if
-       end do
-       long_name=trim(solsym(chemistryIndex(l_so4_a1)))//"condTend"
-       call outfld(long_name, coltend(:,chemistryIndex(l_so4_a1)),pcols,lchnk)
-       long_name=trim(solsym(chemistryIndex(l_soa_a1)))//"condTend"
-       call outfld(long_name, coltend(:,chemistryIndex(l_soa_a1)),pcols,lchnk)
-       long_name=trim(solsym(chemistryIndex(l_so4_na)))//"condTend"
-       call outfld(long_name, coltend(:,chemistryIndex(l_so4_na)),pcols,lchnk)
-       long_name=trim(solsym(chemistryIndex(l_soa_na)))//"condTend"
-       call outfld(long_name, coltend(:,chemistryIndex(l_soa_na)),pcols,lchnk)
-
-    endif
+   do icol=1,gas_pcnst
+      if(lifeCycleReceiver(icol) > 0 )then
+         long_name= trim(solsym(icol))//"condTend"
+         call outfld(long_name, coltend(:,icol), pcols, lchnk)
+         long_name= trim(solsym(lifeCycleReceiver(icol)))//"condTend"
+         call outfld(long_name, coltend(:,lifeCycleReceiver(icol)),pcols,lchnk)
+      end if
+   end do
+   long_name=trim(solsym(chemistryIndex(l_so4_a1)))//"condTend"
+   call outfld(long_name, coltend(:,chemistryIndex(l_so4_a1)),pcols,lchnk)
+   long_name=trim(solsym(chemistryIndex(l_soa_a1)))//"condTend"
+   call outfld(long_name, coltend(:,chemistryIndex(l_soa_a1)),pcols,lchnk)
+   long_name=trim(solsym(chemistryIndex(l_so4_na)))//"condTend"
+   call outfld(long_name, coltend(:,chemistryIndex(l_so4_na)),pcols,lchnk)
+   long_name=trim(solsym(chemistryIndex(l_soa_na)))//"condTend"
+   call outfld(long_name, coltend(:,chemistryIndex(l_soa_na)),pcols,lchnk)
 
   end subroutine condtend
 

--- a/src/oslo_aero_depos.F90
+++ b/src/oslo_aero_depos.F90
@@ -110,10 +110,11 @@ contains
       use ppgrid,          only: pcols
 
       ! Register a pbuf field for
-      call pbuf_add_field('WD_A_H2SO4', 'physpkg', dtype_r8, (/pcols/), idx_wd_a_h2so4)
+      call pbuf_add_field('WD_A_H2SO4', 'global', dtype_r8, (/pcols/), idx_wd_a_h2so4)
    end subroutine oslo_aero_depos_register
 
   subroutine oslo_aero_depos_init( pbuf2d )
+    use time_manager,   only: is_first_step
     use physics_buffer, only: pbuf_set_field
 
     ! Set oslo aeroslo deposition history output
@@ -139,7 +140,9 @@ contains
     nevapr_shcu_idx = pbuf_get_index('NEVAPR_SHCU')
 
     call phys_getopts( history_aerosol_out = history_aerosol )
-    call pbuf_set_field(pbuf2d, idx_wd_a_h2so4, 0.0_r8)
+    if (is_first_step()) then
+       call pbuf_set_field(pbuf2d, idx_wd_a_h2so4, 0.0_r8)
+    end if
 
     is_in_output(:) =.false.
     drydep_lq(:) =.false.
@@ -957,7 +960,6 @@ contains
          call outfld('wet_'//trim(aerosol_type_name(l_atype)), -1.0_r8 * (sflx_SFWET_arosol_type(:ncol,l_atype)), ncol, lchnk)
       else if ( l_atype == AEROSOL_TYPE_SULFATE ) then
          ! Add in wd_a_h2so4
-         idx_wd_a_h2so4 = pbuf_get_index('WD_A_H2SO4')
          call pbuf_get_field(pbuf, idx_wd_a_h2so4, wd_a_h2so4)
 
          call outfld('wet_'//trim(aerosol_type_name(l_atype)),                &

--- a/src/oslo_aero_depos.F90
+++ b/src/oslo_aero_depos.F90
@@ -10,6 +10,9 @@ module oslo_aero_depos
   use ppgrid,                  only: pcols, pver, pverp, begchunk, endchunk
   use constituents,            only: pcnst, cnst_name, cnst_get_ind
   use phys_control,            only: phys_getopts, cam_physpkg_is
+  use phys_control,            only: history_aerosol_base,        &
+                                     history_aerosol_decomposed,  &
+                                     history_aerosol_debug_output
   use cam_abortutils,          only: endrun
   use cam_logfile,             only: iulog
   use camsrfexch,              only: cam_out_t
@@ -28,15 +31,17 @@ module oslo_aero_depos
   use oslo_aero_share,         only: is_process_mode, processModeMap, processModeSigma, lifeCycleSigma
   use oslo_aero_share,         only: belowCloudScavengingCoefficientProcessModes, belowCloudScavengingCoefficient
   use oslo_aero_share,         only: getCloudTracerIndex, GetCloudTracerIndexDirect, getCloudTracerName, qqcw_get_field
+  use oslo_aero_share,         only: aerosol_type_name, N_AEROSOL_TYPES, aerosolType, AEROSOL_TYPE_SULFATE
   use oslo_aero_share,         only: l_bc_ax, l_bc_ni, l_bc_ai, l_bc_a, l_bc_ac
   use oslo_aero_share,         only: l_bc_n, l_om_ni, l_om_ai, l_om_ac, l_dst_a2, l_dst_a3
-  use oslo_aero_share,         only: l_ss_a2, l_ss_a3, l_so4_a2  
+  use oslo_aero_share,         only: l_ss_a2, l_ss_a3, l_so4_a2
   use oslo_aero_dust_sediment, only: oslo_aero_dust_sediment_tend, oslo_aero_dust_sediment_vel
 
   implicit none
   private          ! Make default type private to the module
 
   ! Public interfaces
+  public :: oslo_aero_depos_register
   public :: oslo_aero_depos_init
   public :: oslo_aero_depos_dry ! dry deposition
   public :: oslo_aero_depos_wet ! wet deposition
@@ -92,6 +97,7 @@ module oslo_aero_depos
   integer :: nevapr_dpcu_idx = 0
   integer :: ixcldice, ixcldliq
 
+  integer :: idx_wd_a_h2so4 = -1
   integer :: tracer_index(0:nmodes, max_tracers_per_mode)
   integer :: num_tracers_in_mode(0:nmodes)
 
@@ -99,7 +105,16 @@ module oslo_aero_depos
 contains
 !===============================================================================
 
+   subroutine oslo_aero_depos_register()
+      use physics_buffer,  only: pbuf_add_field, dtype_r8
+      use ppgrid,          only: pcols
+
+      ! Register a pbuf field for
+      call pbuf_add_field('WD_A_H2SO4', 'physpkg', dtype_r8, (/pcols/), idx_wd_a_h2so4)
+   end subroutine oslo_aero_depos_register
+
   subroutine oslo_aero_depos_init( pbuf2d )
+    use physics_buffer, only: pbuf_set_field
 
     ! Set oslo aeroslo deposition history output
 
@@ -109,6 +124,7 @@ contains
     ! local variables
     integer            :: imode, itrac
     integer            :: lchnk
+    integer            :: l_atype
     integer            :: tracerIndex
     integer            :: astat, id
     real(r8), pointer  :: qqcw(:,:)
@@ -123,6 +139,7 @@ contains
     nevapr_shcu_idx = pbuf_get_index('NEVAPR_SHCU')
 
     call phys_getopts( history_aerosol_out = history_aerosol )
+    call pbuf_set_field(pbuf2d, idx_wd_a_h2so4, 0.0_r8)
 
     is_in_output(:) =.false.
     drydep_lq(:) =.false.
@@ -172,12 +189,15 @@ contains
 
           ! Extra wd ouptut
           if ( history_aerosol ) then
-             call add_default (trim(aName)//'SFWET', 1, ' ')
              call add_default (trim(aName)//'SFSIC', 1, ' ')
              call add_default (trim(aName)//'SFSIS', 1, ' ')
              call add_default (trim(aName)//'SFSBC', 1, ' ')
              call add_default (trim(aName)//'SFSBS', 1, ' ')
           endif
+
+         if ( history_aerosol .or. history_aerosol_decomposed ) then
+            call add_default (trim(aName)//'SFWET', 1, ' ')
+         endif
 
           ! Dry deposition fluxes and velocity
           call addfld (trim(aName)//'DDF',horiz_only, 'A', unit_basename//'/m2/s ', &
@@ -193,10 +213,13 @@ contains
 
           ! extra drydep output
           if ( history_aerosol ) then
-             call add_default (trim(aName)//'DDF', 1, ' ')
              call add_default (trim(aName)//'TBF', 1, ' ')
              call add_default (trim(aName)//'GVF', 1, ' ')
              !call add_default (trim(aName)//'DDV', 1, ' ')
+          endif
+
+          if ( history_aerosol .or. history_aerosol_decomposed ) then
+            call add_default (trim(aName)//'DDF', 1, ' ')
           endif
 
           ! some tracers are not in cloud water
@@ -231,6 +254,39 @@ contains
        end do !tracers
     enddo    !modes
 
+    do l_atype=1,N_AEROSOL_TYPES
+
+      call addfld( 'dry_'//trim(aerosol_type_name(l_atype)), horiz_only, 'A', unit_basename//'/m2/s ',  &
+         trim(aerosol_type_name(l_atype))//' dry deposition flux at bottom (grav + turb)')
+      call addfld('wet_'//trim(aerosol_type_name(l_atype)), horiz_only, 'A', unit_basename//'/m2/s', &
+         trim(aerosol_type_name(l_atype))//' wet deposition flux at surface')
+
+      if ( l_atype == AEROSOL_TYPE_SULFATE ) then
+         call addfld( 'dry_'//trim(aerosol_type_name(l_atype))//'_S', horiz_only, 'A', unit_basename//'*S/m2/s ',  &
+            trim(aerosol_type_name(l_atype))//' dry deposition flux at bottom (grav + turb), sulfur mass only')
+         call addfld('wet_'//trim(aerosol_type_name(l_atype))//'_S', horiz_only, 'A', unit_basename//'*S/m2/s', &
+            trim(aerosol_type_name(l_atype))//' wet deposition flux at surface, sulfur mass only')
+         call addfld('wd_a_h2so4_debug', horiz_only, 'A', unit_basename//'*S/m2/s', &
+            'wd_a_h2so4_debug - used to debug in-model summation of sulfur mass in aerosols')
+      endif
+
+      ! we require history_aerosol_base flag to add the fields to default output
+      if ( history_aerosol_base ) then
+
+         call add_default('dry_'//trim(aerosol_type_name(l_atype)), 1, ' ')
+         call add_default('wet_'//trim(aerosol_type_name(l_atype)), 1, ' ')
+
+         if ( l_atype == AEROSOL_TYPE_SULFATE ) then
+            call add_default('dry_'//trim(aerosol_type_name(l_atype))//'_S', 1, ' ')
+            call add_default('wet_'//trim(aerosol_type_name(l_atype))//'_S', 1, ' ')
+         endif
+
+      endif
+      if ( history_aerosol_debug_output .and. l_atype == AEROSOL_TYPE_SULFATE ) then
+         call add_default('wd_a_h2so4_debug', 1, ' ')
+      endif
+   end do
+
     !initialize cloud concentrations (initialize cloud bourne constituents in physics buffer)
     if (is_first_step()) then
        do itrac = 1, pcnst
@@ -252,6 +308,9 @@ contains
        pbuf, obklen, ustar, dt, &
        dgncur_awet, wetdens, dgncur_awet_processmode, wetdens_processmode, &
        cam_out, ptend)
+
+   ! use
+   use oslo_aero_share, only          : sulfurMassFraction
 
     ! Arguments:
     integer  ,           intent(in)    :: lchnk
@@ -289,10 +348,13 @@ contains
     integer :: imode                     ! aerosol mode index
     integer :: itrac                        ! tracer index
     integer :: icol
+    integer :: l_atype                   ! aerosol type index
 
     real(r8) :: tvs(pcols,pver)
     real(r8) :: rho(pcols,pver)          ! air density in kg/m3
     real(r8) :: sflx(pcols)              ! deposition flux
+    real(r8) :: sflx_DDF_arosol_type(pcols, N_AEROSOL_TYPES) ! deposition flux for the aerosol types, no weighted sums
+    real(r8) :: sflx_DDF_SULFATE_S(pcols) ! deposition flux for the sulfate aerosol type, sulfur mass only
     real(r8)::  dep_trb(pcols)           ! kg/m2/s
     real(r8)::  dep_grv(pcols)           ! kg/m2/s (total of grav and trb)
     real(r8) :: pvmzaer(pcols,pverp)     ! sedimentation velocity in Pa
@@ -319,6 +381,8 @@ contains
 
     aerdepdryis(:,:)=0._r8
     aerdepdrycw(:,:)=0._r8
+    sflx_DDF_arosol_type(:,:) = 0._r8
+    sflx_DDF_SULFATE_S(:) = 0._r8
 
     ! calc ram and fv over ocean and sea ice ...
     call calcram( ncol,landfrac, icefrac, ocnfrac, obklen, &
@@ -494,6 +558,14 @@ contains
 
              endif
 
+            ! accumulate the deposition flux for the aerosol type
+            ! All will have a version without weighted sum, that is ...DDF
+            ! sulfate will have a version with weighted sum, that is ...SDDF
+            sflx_DDF_arosol_type(:, aerosolType(itrac)) = sflx_DDF_arosol_type(:, aerosolType(itrac)) + sflx(:ncol)
+            if ( aerosolType(itrac) ==  AEROSOL_TYPE_SULFATE ) then
+               sflx_DDF_SULFATE_S(:) = sflx_DDF_SULFATE_S(:) + ( sflx(:ncol) * sulfurMassFraction(itrac) )
+            endif
+
           enddo   ! lspec = 0, nspec_amode(imode)+1
        enddo   ! lphase = 1, 2
     enddo   ! imode = 1, ntot_amode
@@ -507,11 +579,22 @@ contains
             cam_out%dstdry1, cam_out%dstdry2, cam_out%dstdry3, cam_out%dstdry4)
     endif
 
+   do l_atype=1,N_AEROSOL_TYPES
+      ! add the dry deposition rate of the compound aerosols to output
+      call outfld('dry_'//trim(aerosol_type_name(l_atype)), sflx_DDF_arosol_type(:ncol,l_atype), ncol, lchnk)
+      if ( l_atype == AEROSOL_TYPE_SULFATE ) then
+         call outfld('dry_'//trim(aerosol_type_name(l_atype))//'_S', sflx_DDF_SULFATE_S(:ncol), ncol, lchnk)
+      endif
+   end do
+
   end subroutine oslo_aero_depos_dry
 
   !===============================================================================
   subroutine oslo_aero_depos_wet ( lchnk, ncol, psetcols, pmid, pdel, q, t, &
        dt, dlf, cam_out, ptend, pbuf)
+
+   ! use
+   use oslo_aero_share, only          : sulfurMassFraction, l_h2so4
 
     integer ,            intent(in)    :: lchnk            ! chunk identifier
     integer ,            intent(in)    :: ncol             ! number of atmospheri columns
@@ -528,6 +611,7 @@ contains
 
     ! Local variables
     integer  :: imode                             ! tracer index
+    integer  :: l_atype                           ! aerosol type index
     integer  :: icol,ilev,itrac
     real(r8) :: iscavt(pcols, pver)
     real(r8) :: icscavt(pcols, pver)
@@ -537,6 +621,8 @@ contains
     real(r8) :: sol_factb, sol_facti
     real(r8) :: sol_factic(pcols,pver)
     real(r8) :: sflx(pcols)                   ! deposition flux
+    real(r8) :: sflx_SFWET_arosol_type(pcols, N_AEROSOL_TYPES) ! deposition flux for the aerosol types, aerosol mass
+    real(r8) :: sflx_SFWET_SULFATE_S(pcols)   ! deposition flux for sulfate, sulfur mass only
     real(r8) :: scavcoef(pcols,pver)          ! Dana and Hales coefficient (/mm) (0.1)
     integer  :: jnv                           ! index for scavcoefnv 3rd dimension
     integer  :: lphase                        ! index for interstitial / cloudborne aerosol
@@ -563,6 +649,7 @@ contains
     real(r8) :: zeroAerosolConcentration(pcols,pver)
     real(r8), pointer :: fldcw(:,:)
     real(r8), pointer :: fracis(:,:,:)   ! fraction of transported species that are insoluble
+    real(r8), pointer :: wd_a_h2so4(:)
     type(wetdep_inputs_t) :: dep_inputs
     !-----------------------------------------------------------------------
 
@@ -571,6 +658,8 @@ contains
     is_done(:,:) = .false.
 
     zeroAerosolConcentration(:,:)=0.0_r8
+    sflx_SFWET_arosol_type(:,:) = 0._r8
+    sflx_SFWET_SULFATE_S(:) = 0._r8
 
     ! Wet deposition of mozart aerosol species.
     ptend%name  = ptend%name//'+mz_aero_wetdep'
@@ -683,9 +772,9 @@ contains
 
              ! Increase scavenging efficiency for large soluble particles.
              if ((lphase==1).and.((itrac==l_ss_a2).or.(itrac==l_ss_a3).or.(itrac==l_so4_a2))) then
-                 sol_factic=1.0_r8 
-                 f_act_conv=1.0_r8 
-             end if     
+                 sol_factic=1.0_r8
+                 f_act_conv=1.0_r8
+             end if
 
              if ((lphase == 1) .and. (lspec <= num_tracers_in_mode(imode))) then
                 ptend%lq(itrac) = .TRUE.
@@ -843,9 +932,43 @@ contains
 
              endif
 
+            ! accumulate the deposition flux for the aerosol type
+            sflx(:ncol) = 0._r8
+            if ( lphase == 1 ) then
+               sflx(:ncol) = aerdepwetis(:ncol,itrac)
+            else ! lphase == 2
+               sflx(:ncol) = aerdepwetcw(:ncol,itrac)
+            endif
+
+            ! accumulate the deposition flux for the aerosol type, aerosol mass
+            ! if it is sulfate we accumulate in sflx_SFWET_SULFATE_S in addition
+            sflx_SFWET_arosol_type(:, aerosolType(itrac)) = sflx_SFWET_arosol_type(:, aerosolType(itrac)) + sflx(:ncol)
+            if ( aerosolType(itrac) == AEROSOL_TYPE_SULFATE ) then
+               sflx_SFWET_SULFATE_S(:) = sflx_SFWET_SULFATE_S(:) + ( sflx(:ncol) * sulfurMassFraction(itrac) )
+            endif
+
           enddo   ! lspec = 0, nspec_amode(imode)+1
        enddo   ! lphase = 1, 2
     enddo   ! imode = 1, ntot_amode
+
+   ! add the wet deposition rate of the compound aerosols except sulfur to output
+    do l_atype=1,N_AEROSOL_TYPES
+      if ( l_atype /= AEROSOL_TYPE_SULFATE ) then
+         call outfld('wet_'//trim(aerosol_type_name(l_atype)), -1.0_r8 * (sflx_SFWET_arosol_type(:ncol,l_atype)), ncol, lchnk)
+      else if ( l_atype == AEROSOL_TYPE_SULFATE ) then
+         ! Add in wd_a_h2so4
+         idx_wd_a_h2so4 = pbuf_get_index('WD_A_H2SO4')
+         call pbuf_get_field(pbuf, idx_wd_a_h2so4, wd_a_h2so4)
+
+         call outfld('wet_'//trim(aerosol_type_name(l_atype)),                &
+         -1.0_r8 * ( sflx_SFWET_arosol_type(:ncol,l_atype) + wd_a_h2so4(:ncol) ),    &
+            ncol, lchnk)
+         call outfld('wet_'//trim(aerosol_type_name(l_atype))//'_S',                                        &
+            -1.0_r8 * ( sflx_SFWET_SULFATE_S(:ncol) + ( wd_a_h2so4(:ncol) * sulfurMassFraction(l_h2so4) )),     &
+            ncol, lchnk)
+         call outfld('wd_a_h2so4_debug', wd_a_h2so4(:ncol), ncol, lchnk)
+      endif
+   end do
 
     ! if the user has specified prescribed aerosol dep fluxes then
     ! do not set cam_out dep fluxes according to the prognostic aerosols

--- a/src/oslo_aero_diagnostics.F90
+++ b/src/oslo_aero_diagnostics.F90
@@ -19,9 +19,12 @@ contains
       character(len=20) :: varname
 
       call addfld ('AODVIS  ',horiz_only,  'A','unitless' ,'Aerosol optical depth at 0.442-0.625um') ! CAM4-Oslo: 0.35-0.64um
-      call addfld ('ABSVIS  ',horiz_only,  'A','unitless' ,'Aerosol absorptive optical depth at 0.442-0.625um') ! CAM4-Oslo: 0.35-0.64um
-      call addfld ('AODVVOLC ',horiz_only, 'A','unitless' ,'CMIP6 volcanic aerosol optical depth at 0.442-0.625um') ! CAM4-Oslo: 0.35-0.64um
-      call addfld ('ABSVVOLC ',horiz_only, 'A','unitless' ,'CMIP6 volcanic aerosol absorptive optical depth at 0.442-0.625um') ! CAM4-Oslo: 0.35-0.64um
+       ! value for ABSVIS in CAM4-Oslo: 0.35-0.64um
+      call addfld ('ABSVIS  ',horiz_only,  'A','unitless' ,'Aerosol absorptive optical depth at 0.442-0.625um')
+      ! value for AODVVOLC in CAM4-Oslo: 0.35-0.64um
+      call addfld ('AODVVOLC ',horiz_only, 'A','unitless' ,'CMIP6 volcanic aerosol optical depth at 0.442-0.625um')
+      ! valud or ABSVVOLC in CAM4-Oslo: 0.35-0.64um
+      call addfld ('ABSVVOLC ',horiz_only, 'A','unitless' ,'CMIP6 volcanic aerosol absorptive optical depth at 0.442-0.625um')
       call addfld ('CAODVIS ',horiz_only,  'A','unitless' ,'Clear air aerosol optical depth')
       call addfld ('CABSVIS ',horiz_only,  'A','unitless' ,'Clear air aerosol absorptive optical depth')
       call addfld ('CLDFREE ',horiz_only,  'A','unitless' ,'Cloud free fraction wrt CAODVIS and CABSVIS')
@@ -59,7 +62,6 @@ contains
          call add_default ('CAODVIS ', 1, ' ')
          call add_default ('CABSVIS ', 1, ' ')
          call add_default ('CLDFREE ', 1, ' ')
-      !call add_default ('N_AERORG', 1, ' ')
          call add_default ('SSAVIS  ', 1, ' ')
          call add_default ('ASYMMVIS', 1, ' ')
          call add_default ('EXTVIS  ', 1, ' ')

--- a/src/oslo_aero_diagnostics.F90
+++ b/src/oslo_aero_diagnostics.F90
@@ -2,6 +2,7 @@ module oslo_aero_diagnostics
 
 use shr_kind_mod      , only: r8 => shr_kind_r8
 use cam_history       , only: addfld, add_default, horiz_only
+use phys_control      , only: history_aerosol_base, history_aerosol_radiation
 use oslo_aero_control , only: use_aerocom
 use oslo_aero_share   , only: nbmodes
 
@@ -45,33 +46,38 @@ contains
       call addfld ('FSDSCDRF',horiz_only, 'A','W/m^2   ','SW downwelling clear sky flux at surface')
       call addfld ('FLUS    ',horiz_only, 'A','W/m^2   ','LW surface upwelling flux')
 
-      call add_default ('AODVIS  ', 1, ' ')
-      call add_default ('ABSVIS  ', 1, ' ')
-      call add_default ('AODVVOLC', 1, ' ')
-      call add_default ('ABSVVOLC', 1, ' ')
-      call add_default ('DAYFOC  ', 1, ' ')
-      call add_default ('CAODVIS ', 1, ' ')
-      call add_default ('CABSVIS ', 1, ' ')
-      call add_default ('CLDFREE ', 1, ' ')
-      call add_default ('N_AER   ', 1, ' ')
-     !call add_default ('N_AERORG', 1, ' ')
-      call add_default ('SSAVIS  ', 1, ' ')
-      call add_default ('ASYMMVIS', 1, ' ')
-      call add_default ('EXTVIS  ', 1, ' ')
-      call add_default ('BVISVOLC', 1, ' ')
-      call add_default ('FSNT_DRF', 1, ' ')
-      call add_default ('FSNTCDRF', 1, ' ')
-      call add_default ('FSNS_DRF', 1, ' ')
-      call add_default ('FSNSCDRF', 1, ' ')
-      call add_default ('QRS_DRF ', 1, ' ')
-      call add_default ('QRSC_DRF', 1, ' ')
-      call add_default ('FLNT_DRF', 1, ' ')
-      call add_default ('FLNTCDRF', 1, ' ')
-      call add_default ('FSUTADRF', 1, ' ')
-      call add_default ('FSDS_DRF', 1, ' ')
-      call add_default ('FSUS_DRF', 1, ' ')
-      call add_default ('FSDSCDRF', 1, ' ')
-      call add_default ('FLUS    ', 1, ' ')
+      if ( history_aerosol_base ) then
+        call add_default ('AODVIS  ', 1, ' ')
+        call add_default ('ABSVIS  ', 1, ' ')
+         call add_default ('N_AER   ', 1, ' ')
+         call add_default ('DAYFOC  ', 1, ' ')
+      endif
+
+      if ( history_aerosol_radiation ) then
+         call add_default ('AODVVOLC', 1, ' ')
+         call add_default ('ABSVVOLC', 1, ' ')
+         call add_default ('CAODVIS ', 1, ' ')
+         call add_default ('CABSVIS ', 1, ' ')
+         call add_default ('CLDFREE ', 1, ' ')
+      !call add_default ('N_AERORG', 1, ' ')
+         call add_default ('SSAVIS  ', 1, ' ')
+         call add_default ('ASYMMVIS', 1, ' ')
+         call add_default ('EXTVIS  ', 1, ' ')
+         call add_default ('BVISVOLC', 1, ' ')
+         call add_default ('FSNT_DRF', 1, ' ')
+         call add_default ('FSNTCDRF', 1, ' ')
+         call add_default ('FSNS_DRF', 1, ' ')
+         call add_default ('FSNSCDRF', 1, ' ')
+         call add_default ('QRS_DRF ', 1, ' ')
+         call add_default ('QRSC_DRF', 1, ' ')
+         call add_default ('FLNT_DRF', 1, ' ')
+         call add_default ('FLNTCDRF', 1, ' ')
+         call add_default ('FSUTADRF', 1, ' ')
+         call add_default ('FSDS_DRF', 1, ' ')
+         call add_default ('FSUS_DRF', 1, ' ')
+         call add_default ('FSDSCDRF', 1, ' ')
+         call add_default ('FLUS    ', 1, ' ')
+      endif
 
       if (use_aerocom) then
          call addfld ('AKCXS   ',horiz_only, 'A','mg/m2   ','Scheme excess aerosol mass burden')

--- a/src/oslo_aero_ndrop.F90
+++ b/src/oslo_aero_ndrop.F90
@@ -106,7 +106,6 @@ contains
     character(len=32)  :: tmpname_cw
     character(len=128) :: long_name
     character(len=8)   :: unit
-    logical            :: history_amwg ! output the variables used by the AMWG diag package
     character(len=10)  :: modeString
     character(len=20)  :: varname
     !-------------------------------------------------------------------------------
@@ -192,7 +191,7 @@ contains
 
     ! Add dropmixnuc tendencies for all modal aerosol species
 
-    call phys_getopts(history_amwg_out=history_amwg, history_aerosol_out=history_aerosol)
+    call phys_getopts(history_aerosol_out=history_aerosol)
 
     n_aerosol_tracers = getNumberOfAerosolTracers()
     call fillAerosolTracerList(aerosolTracerList)
@@ -1462,13 +1461,11 @@ contains
     call outfld('NDROPMIX', ndropmix(:ncol,:), ncol, lchnk)
     call outfld('WTKE    ', wtke(:ncol,:),     ncol, lchnk)
 
-    if (history_aerosol) then
-       call ccncalc_oslo(state, pbuf, cs, hasAerosol, numberConcentration, volumeConcentration, &
-            hygroscopicity, lnSigma, ccn)
-       do isat = 1, psat
-          call outfld(ccn_name(isat), ccn(:,:,isat), pcols, lchnk)
-       enddo
-    end if
+   call ccncalc_oslo(state, pbuf, cs, hasAerosol, numberConcentration, volumeConcentration, &
+      hygroscopicity, lnSigma, ccn)
+   do isat = 1, psat
+      call outfld(ccn_name(isat), ccn(:,:,isat), pcols, lchnk)
+   enddo
 
     tendencyCounted(:)=.FALSE.
     do imode = 1, ntot_amode

--- a/src/oslo_aero_ocean.F90
+++ b/src/oslo_aero_ocean.F90
@@ -125,6 +125,8 @@ contains
   !===============================================================================
   subroutine oslo_aero_ocean_init()
 
+   use phys_control,   only : history_aerosol_forcing
+
     ! local variables
     integer  :: astat
     integer  :: ispec
@@ -183,7 +185,9 @@ contains
             cycle_yr(ispec), fixed_ymd, fixed_tod, data_type(ispec) )
     enddo
     call addfld( 'odms', horiz_only,  'A',  'nmol/L', 'DMS upper ocean concentration' )
-    call add_default('odms', 1, ' ')
+   if ( history_aerosol_forcing ) then
+      call add_default('odms', 1, ' ')
+   endif
 
   endsubroutine oslo_aero_ocean_init
 

--- a/src/oslo_aero_share.F90
+++ b/src/oslo_aero_share.F90
@@ -14,7 +14,7 @@ module oslo_aero_share
   use physconst,      only: pi
   !
   implicit none
-  public          ! Make default type private to the module
+  public          ! This is a public module with protected variables
 
   !---------------------------
   ! Public interfaces
@@ -51,9 +51,6 @@ module oslo_aero_share
   !---------------------------
   ! Public parameters
   !---------------------------
-
-  ! Logic for use with CAM-Nor-physics
-  logical :: use_oslo_aero = .true.
 
   ! Define lognormal size parameters for each size mode (dry, at point of emission/production)
   integer, parameter :: nmodes   = 14
@@ -164,15 +161,20 @@ module oslo_aero_share
        "DST_A2", "DST_A3", "SS_A1 ", "SS_A2 ", "SS_A3 ", "SOA_NA", "SOA_A1" /)
 
   !---------------------------
-  ! Public constants
+  ! Public variables
   !---------------------------
-
   real(r8) :: nk(0:nmodes,nbinsTab)     !dN/dlogr for modes
   real(r8) :: normnk(0:nmodes,nbinsTab) !dN for modes (sums to one over size range)
   real(r8) :: rBinEdge(nBinsTab+1)
   real(r8) :: rBinMidpoint(nBinsTab)
   real(r8) :: volumeToNumber(0:nmodes)  !m3 ==> #
   real(r8) :: numberToSurface(0:nmodes) !# ==> m2
+  real(r8) :: numberFractionAvailableAqChem(nbmodes)
+  real(r8) :: rhopart(pcnst)
+
+  !---------------------------
+  ! Public constants
+  !---------------------------
 
   ! Constants used in interpolation
   ! Internal mixtures of process-tagged mass
@@ -190,20 +192,20 @@ module oslo_aero_share
   ! faq  : mass fraction of sulfate which is produced in wet-phase, SO4aq/SO4.
   !        The remaining SO4 mass, SO4*(1-faq), is from condensation.
 
-  real(r8) :: rh(10)
-  real(r8) :: fombg(6), fbcbg(6), fac(6), fbc(6), faq(6)
-  real(r8) :: cate(4,16)
-  real(r8) :: cat(5:10,6)
+  real(r8), protected :: rh(10)
+  real(r8), protected :: fombg(6), fbcbg(6), fac(6), fbc(6), faq(6)
+  real(r8), protected :: cate(4,16)
+  real(r8), protected :: cat(5:10,6)
 
   ! relative humidity (RH, as integer for output variable names) for use in AeroCom code
-  integer  :: RF(6)
+  integer, protected  :: RF(6)
 
   ! AeroCom specific RH input variables for use in opticsAtConstRh.F90
-  integer  :: irhrf1(6)
-  real(r8) :: xrhrf(6)
+  integer, protected  :: irhrf1(6)
+  real(r8), protected :: xrhrf(6)
 
-  integer :: tracerInProcessMode(numberOfProcessModeTracers)
-  integer :: processModeMap(pcnst)
+  integer, protected :: tracerInProcessMode(numberOfProcessModeTracers)
+  integer, protected :: processModeMap(pcnst)
 
   ! NUMBERS BELOW ARE ESSENTIAL TO CALCULATE HYGROSCOPICITY AND THEREFORE INDIRECT EFFECT!
   ! These numbers define the "hygroscopicity parameter" Numbers are selected so that they give reasonable hygroscipity
@@ -229,73 +231,71 @@ module oslo_aero_share
   !           Koepke, Hess, Schult and Shettle: Max-Plack-Institut fur Meteorolgie, report No. 243 "GLOBAL AEROSOL DATA SET"
   !           These values give "B" of 1.20 instead of 1.16 in MIRAGE paper.
 
-  character(len=8) :: aerosol_type_name(N_AEROSOL_TYPES) = &
+  character(len=8), protected :: aerosol_type_name(N_AEROSOL_TYPES) = &
        (/"SULFATE ", "BC      ","OM      ", "DUST    ", "SALT    " /)
-  real(r8) :: aerosol_type_density(N_AEROSOL_TYPES) =               &
+  real(r8), protected :: aerosol_type_density(N_AEROSOL_TYPES) =               &
        (/1769.0_r8, 1800.0_r8,  1500.0_r8, 2600.0_r8,  2200.0_r8 /)   !kg/m3
-  real(r8) :: aerosol_type_molecular_weight(N_AEROSOL_TYPES) =      &
+  real(r8), protected :: aerosol_type_molecular_weight(N_AEROSOL_TYPES) =      &
        (/132.0_r8,  12.0_r8,    168.2_r8,  135.0_r8,   58.44_r8  /)   !kg/kmol
-  real(r8) :: aerosol_type_osmotic_coefficient(N_AEROSOL_TYPES) =   &
+  real(r8), protected :: aerosol_type_osmotic_coefficient(N_AEROSOL_TYPES) =   &
        (/0.7_r8,    1.111_r8,     1.0_r8,    1.0_r8,     1.0_r8    /) ![-]
-  real(r8) :: aerosol_type_soluble_mass_fraction(N_AEROSOL_TYPES) = &
+  real(r8), protected :: aerosol_type_soluble_mass_fraction(N_AEROSOL_TYPES) = &
        (/1.0_r8,    1.67e-7_r8, 0.8725_r8, 0.1_r8,     0.885_r8  /)   ![-]
-  real(r8) :: aerosol_type_number_of_ions(N_AEROSOL_TYPES) =        &
+  real(r8), protected :: aerosol_type_number_of_ions(N_AEROSOL_TYPES) =        &
        (/3.0_r8,    1.0_r8,     1.0_r8,    2.0_r8,     2.0_r8    /)   ![-]
 
-  real(r8) :: rhopart(pcnst)
-  real(r8) :: sgpart(pcnst)
-  real(r8) :: osmoticCoefficient(pcnst)
-  real(r8) :: numberOfIons(pcnst)
-  real(r8) :: solubleMassFraction(pcnst)
-  real(r8) :: sulfurMassFraction(pcnst)
-  real(r8) :: sulfurMassFraction_MSA
-  real(r8) :: SOAyield_isoprene
-  real(r8) :: SOAyield_monoterp
-  integer  :: aerosolType(pcnst)
-  real(r8) :: numberFractionAvailableAqChem(nbmodes)
-  real(r8) :: invrhopart(pcnst)
+  real(r8), protected :: sgpart(pcnst)
+  real(r8), protected :: osmoticCoefficient(pcnst)
+  real(r8), protected :: numberOfIons(pcnst)
+  real(r8), protected :: solubleMassFraction(pcnst)
+  real(r8), protected :: sulfurMassFraction(pcnst)
+  real(r8), protected :: sulfurMassFraction_MSA
+  real(r8), protected :: SOAyield_isoprene
+  real(r8), protected :: SOAyield_monoterp
+  integer, protected  :: aerosolType(pcnst)
+  real(r8), protected :: invrhopart(pcnst)
 
   !These tables describe how the tracers behave chemically
-  integer, dimension(numberOfExternallyMixedModes) :: externallyMixedMode = &
-       (/MODE_IDX_BC_EXT_AC,  &
-       MODE_IDX_SO4SOA_NUC, &
-       MODE_IDX_BC_NUC,     &
+  integer, protected :: externallyMixedMode(numberOfExternallyMixedModes) = &
+       (/MODE_IDX_BC_EXT_AC,                                                &
+       MODE_IDX_SO4SOA_NUC,                                                 &
+       MODE_IDX_BC_NUC,                                                     &
        MODE_IDX_OMBC_INTMIX_AIT /)
 
-  integer, dimension(numberOfInternallyMixedMOdes) :: internallyMixedMode = &
-       (/MODE_IDX_SO4SOA_AIT,           &
-       MODE_IDX_BC_AIT,               &
-       MODE_IDX_OMBC_INTMIX_COAT_AIT, &
-       MODE_IDX_SO4_AC,               &
-       MODE_IDX_DST_A2,               &
-       MODE_IDX_DST_A3,               &
-       MODE_IDX_SS_A1,                &
-       MODE_IDX_SS_A2,                &
+  integer, protected :: internallyMixedMode(numberOfInternallyMixedMOdes) = &
+       (/MODE_IDX_SO4SOA_AIT,                                               &
+       MODE_IDX_BC_AIT,                                                     &
+       MODE_IDX_OMBC_INTMIX_COAT_AIT,                                       &
+       MODE_IDX_SO4_AC,                                                     &
+       MODE_IDX_DST_A2,                                                     &
+       MODE_IDX_DST_A3,                                                     &
+       MODE_IDX_SS_A1,                                                      &
+       MODE_IDX_SS_A2,                                                      &
        MODE_IDX_SS_A3 /)
 
   ! species indices for individual camuio species
-  integer :: l_so4_na, l_so4_a1, l_so4_a2, l_so4_ac
-  integer :: l_bc_n, l_bc_ax, l_bc_ni, l_bc_a, l_bc_ai,l_bc_ac
-  integer :: l_om_ni, l_om_ai, l_om_ac
-  integer :: l_so4_pr
-  integer :: l_dst_a2, l_dst_a3
-  integer :: l_ss_a1, l_ss_a2, l_ss_a3, l_h2so4
-  integer :: l_soa_na, l_soa_a1, l_soa_lv, l_soa_sv
-  integer :: l_so2, l_dms, l_monoterp, l_isoprene
+  integer, protected :: l_so4_na, l_so4_a1, l_so4_a2, l_so4_ac
+  integer, protected :: l_bc_n, l_bc_ax, l_bc_ni, l_bc_a, l_bc_ai,l_bc_ac
+  integer, protected :: l_om_ni, l_om_ai, l_om_ac
+  integer, protected :: l_so4_pr
+  integer, protected :: l_dst_a2, l_dst_a3
+  integer, protected :: l_ss_a1, l_ss_a2, l_ss_a3, l_h2so4
+  integer, protected :: l_soa_na, l_soa_a1, l_soa_lv, l_soa_sv
+  integer, protected :: l_so2, l_dms, l_monoterp, l_isoprene
 
-  integer :: n_aerosol_tracers !number of aerosol tracers
-  integer :: imozart
+  integer, protected :: n_aerosol_tracers !number of aerosol tracers
+  integer, protected :: imozart
 
   ! Number of transported tracers in each mode
-  integer  :: tracer_in_mode(0:nmodes, max_tracers_per_mode)
+  integer, protected  :: tracer_in_mode(0:nmodes, max_tracers_per_mode)
 
   ! Growth of aerosols, duplicated in oslo_aero_sw_tables
-  real(r8) :: rdivr0(10,pcnst)
+  real(r8), protected :: rdivr0(10,pcnst)
 
-  real(r8) :: rhtab(10) = (/ 0.0_r8, 0.37_r8, 0.47_r8, 0.65_r8, 0.75_r8, 0.80_r8, 0.85_r8, 0.90_r8, 0.95_r8, 0.98_r8/)
+  real(r8), protected :: rhtab(10) = (/ 0.0_r8, 0.37_r8, 0.47_r8, 0.65_r8, 0.75_r8, 0.80_r8, 0.85_r8, 0.90_r8, 0.95_r8, 0.98_r8/)
 
-  integer  :: cloudTracerIndex(pcnst)
-  character(len=20) :: cloudTracerName(pcnst)
+  integer, protected  :: cloudTracerIndex(pcnst)
+  character(len=20), protected :: cloudTracerName(pcnst)
 
   integer, private :: qqcw(pcnst)=-1 ! Remaps modal_aero indices into pbuf
 

--- a/src/oslo_aero_share.F90
+++ b/src/oslo_aero_share.F90
@@ -21,6 +21,8 @@ module oslo_aero_share
   !---------------------------
 
   public :: aero_register           ! register consituents
+  public :: sulfur_mass_fraction_register
+  public :: soa_yield_register
   public :: is_process_mode         ! Check is an aerosol specie is a process mode
   public :: isAerosol               ! Check is specie is aerosol (i.e. gases get .FALSE. here)
   public :: getTracerIndex
@@ -245,6 +247,10 @@ module oslo_aero_share
   real(r8) :: osmoticCoefficient(pcnst)
   real(r8) :: numberOfIons(pcnst)
   real(r8) :: solubleMassFraction(pcnst)
+  real(r8) :: sulfurMassFraction(pcnst)
+  real(r8) :: sulfurMassFraction_MSA
+  real(r8) :: SOAyield_isoprene
+  real(r8) :: SOAyield_monoterp
   integer  :: aerosolType(pcnst)
   real(r8) :: numberFractionAvailableAqChem(nbmodes)
   real(r8) :: invrhopart(pcnst)
@@ -275,6 +281,7 @@ module oslo_aero_share
   integer :: l_dst_a2, l_dst_a3
   integer :: l_ss_a1, l_ss_a2, l_ss_a3, l_h2so4
   integer :: l_soa_na, l_soa_a1, l_soa_lv, l_soa_sv
+  integer :: l_so2, l_dms, l_monoterp, l_isoprene
 
   integer :: n_aerosol_tracers !number of aerosol tracers
   integer :: imozart
@@ -376,6 +383,12 @@ contains
 
     ! gas phase h2so4
     call cnst_get_ind('H2SO4'  ,l_h2so4, abort=.true.)
+
+    ! gas phase species
+    call cnst_get_ind('SO2'    ,l_so2,   abort=.true.) !sulfur dioxide
+    call cnst_get_ind('DMS'    ,l_dms,   abort=.true.) !dimethyl sulfide
+    call cnst_get_ind('monoterp'  ,l_monoterp, abort=.true.) !monoterpenes
+    call cnst_get_ind('isoprene'  ,l_isoprene, abort=.true.) !isoprene
 
     ! Register the tracers in modes
     call registerTracersInMode()
@@ -479,6 +492,54 @@ contains
     call inittabrh
 
   end subroutine aero_register
+
+   !===============================================================================
+
+   subroutine sulfur_mass_fraction_register
+      !-----------------------------------------------------------------------
+      ! Register the sulfur mass fraction for the different tracers
+      ! where sulfur is present. Both for the aerosol tracers and the
+      ! gas phase tracers.
+      !-----------------------------------------------------------------------
+
+      sulfurMassFraction(:) = 0.0_r8
+      ! DMS is CH3SCH3 so the sulfur mass fraction is assumed ~32/62=M_S/M_DMS
+      sulfurMassFraction(l_dms) = 32.0_r8/62.0_r8
+      ! for so2 the sulfur mass fraction is assumed ~1/1.998=M_S/M_SO2
+      sulfurMassFraction(l_so2) = 1.0_r8/1.998_r8
+      ! for sulfates the sulfur mass fraction is variable depending on the
+      ! sulfate compound. For sulfate produced by aqueous-phase chemistry
+      ! the sulfur mass fraction is assumed to come from partly naturalised sulfates
+      ! The sulfur mass fraction is therefor assumed ~1/3.59 since = M_S/M_NH4HSO4
+      sulfurMassFraction(l_so4_a2) = 1.0_r8/3.59_r8
+      ! for remaining sulfates the sulfur mass fraction is assumed ~1/3.06 = M_S / M_H2SO4
+      sulfurMassFraction(l_so4_na) = 1.0_r8/3.06_r8
+      sulfurMassFraction(l_so4_a1) = 1.0_r8/3.06_r8
+      sulfurMassFraction(l_so4_ac) = 1.0_r8/3.06_r8
+      sulfurMassFraction(l_so4_pr) = 1.0_r8/3.06_r8
+      ! for h2so4 the sulfur mass fraction is assumed ~1/3.06 = M_S / M_H2SO4
+      sulfurMassFraction(l_h2so4) = 1.0_r8/3.06_r8
+
+      ! for msa the sulfur mass fraction is assumed ~32/96 = M_S / M_CH3SO3H
+      sulfurMassFraction_MSA = 32.0_r8/96.0_r8
+
+   end subroutine sulfur_mass_fraction_register
+
+   !===============================================================================
+
+   subroutine soa_yield_register
+      !-----------------------------------------------------------------------
+      ! Register the SOA yield for the different tracers which
+      ! can produce SOA.
+      !-----------------------------------------------------------------------
+
+      ! SOA is given the proxy composition of C10H16O2  (so ~168g/mol)
+      ! Isoprene is C5H8 soa SOA mass fraction is assumed ~168/68=M_SOA/M_C5H8
+      SOAyield_isoprene = 168.0_r8/68.0_r8
+      ! Monoterpene is C10H16 so SOA mass fraction is assumed ~168/136=M_SOA / M_C10H16
+      SOAyield_monoterp = 168.0_r8/136.0_r8
+
+   end subroutine soa_yield_register
 
   !=============================================================================
   function getNumberOfAerosolTracers()RESULT(numberOfTracers)

--- a/src_cam/chemistry.F90
+++ b/src_cam/chemistry.F90
@@ -48,8 +48,24 @@ module chemistry
   public :: chem_init_restart
   public :: chem_emissions
   public :: chem_has_ndep_flx
+  !OSLO_AERO begin
+  public :: summation_fields_init
+  public :: summation_fields_writeout
+  !OSLO_AERO end
 
   integer, public :: imozart = -1       ! index of 1st constituent
+
+   ! OSLO_AERO begin
+   ! SF summations used for emission fields summed in summation_fields_writeout()
+   ! SFBC = SFBC_A + SFBC_AC + SFBC_AX + SFBC_AI + SFBC_NI + SFBC_N, which implies that we can use the aerosolType()
+   ! SFOM = SFOM_AI + SFOM_AC + SFOM_NI, which implies that we can use the aerosolType()
+   ! SFSULFATE = SFSO4_PR, which implies using l_so4_pr
+   ! SFSO2 = SFSO2, which implies that we can use the l_so2 index
+   real(r8), public, protected, allocatable :: SFBC(:,:)
+   real(r8), public, protected, allocatable :: SFOM(:,:)
+   real(r8), public, protected, allocatable :: SFSULFATE(:,:)
+   real(r8), public, protected, allocatable :: SFSO2(:,:)
+   ! OSLO_AERO end
 
   ! Namelist variables
 
@@ -653,6 +669,12 @@ end function chem_is_active
     use short_lived_species, only : short_lived_species_initic
     use ocean_emis,          only : ocean_emis_init, ocean_emis_species
     use mo_srf_emissions,    only : has_emis
+    ! OSLO_AERO begin
+    use string_utils,        only : int2str
+    use phys_control,        only : history_aerosol_base
+    use oslo_aero_share,     only : N_AEROSOL_TYPES, aerosol_type_name
+      use oslo_aero_share,   only : l_dms, l_so2, l_isoprene, l_monoterp
+    ! OSLO_AERO end
 
     type(physics_buffer_desc), pointer :: pbuf2d(:,:)
     type(physics_state), intent(in):: phys_state(begchunk:endchunk)
@@ -667,6 +689,9 @@ end function chem_is_active
     logical :: history_aerosol
     logical :: history_chemistry
     logical :: history_cesm_forcing
+    !OSLO_AERO begin
+    integer :: astat
+    !OSLO_AERO end
 
     character(len=2)  :: unit_basename  ! Units 'kg' or '1'
     logical :: history_budget                 ! output tendencies and state variables for CAM
@@ -685,6 +710,31 @@ end function chem_is_active
 
     ! Initialize aerosols
     call aero_model_init( pbuf2d )
+
+    !OSLO_AERO begin
+      ! allocate the SF summations used for emission fields summed in summation_fields_writeout()
+      ! then set them to zero
+    allocate( SFBC(pcols, begchunk:endchunk), stat=astat )
+    if( astat/= 0 ) then
+       call endrun('chem_init: failed to allocate SFBC array; error = '//int2str(astat))
+    end if
+    SFBC(:,:) = 0.0_r8
+    allocate( SFOM(pcols, begchunk:endchunk), stat=astat )
+    if( astat/= 0 ) then
+       call endrun('chem_init: failed to allocate SFOM array; error = '//int2str(astat))
+    end if
+    SFOM(:,:) = 0.0_r8
+    allocate( SFSULFATE(pcols, begchunk:endchunk), stat=astat )
+    if( astat/= 0 ) then
+       call endrun('chem_init: failed to allocate SFSULFATE array; error = '//int2str(astat))
+    end if
+    SFSULFATE(:,:) = 0.0_r8
+    allocate( SFSO2(pcols, begchunk:endchunk), stat=astat )
+    if( astat/= 0 ) then
+       call endrun('chem_init: failed to allocate SFSO2 array; error = '//int2str(astat))
+    end if
+    SFSO2(:,:) = 0.0_r8
+    !OSLO_AERO end
 
 !-----------------------------------------------------------------------
 ! Get liq and ice cloud water indicies
@@ -813,6 +863,25 @@ end function chem_is_active
                 call add_default( sflxnam(n), 1, ' ' )
              endif
 
+             !OSLO_AERO begin
+            if ( n == l_dms .or. n == l_isoprene .or. n == l_monoterp) then
+
+               call addfld('emis_'//trim(sflxnam(n)(3:)), horiz_only, 'A', 'kg/m2/s', &
+                     trim(sflxnam(n)(3:))//' emissions')
+               if ( n == l_dms ) then
+                  call addfld('emis_'//trim(sflxnam(n)(3:))//'_S', horiz_only, 'A', 'kg*S/m2/s', &
+                     trim(sflxnam(n)(3:))//' emissions, sulfur mass only')
+               endif
+
+               if ( history_aerosol .or. history_aerosol_base ) then
+                  call add_default( 'emis_'//trim(sflxnam(n)(3:)), 1, ' ' )
+                  if ( n == l_dms ) then
+                     call add_default( 'emis_'//trim(sflxnam(n)(3:))//'_S', 1, ' ' )
+                  endif
+               endif
+            endif
+            !OSLO_AERO end
+
              if ( history_cesm_forcing ) then
                 if ( spc_name == 'NO' .or. spc_name == 'NH3' ) then
                    call add_default( sflxnam(n), 1, ' ' )
@@ -823,6 +892,18 @@ end function chem_is_active
        endif
     end do
 
+   ! OSLO_AERO begin
+   ! emissions of SALT and DUST can be calculated from the SF**** variables, therefore we need to add them to the history
+   call addfld ('emis_SALT', horiz_only, 'A',  'kg/m2/s',   &
+      'SALT emission')
+   call addfld ('emis_DUST', horiz_only, 'A',  'kg/m2/s',   &
+      'DUST emission')
+   if ( history_aerosol_base ) then
+      call add_default( 'emis_SALT', 1, ' ' )
+      call add_default( 'emis_DUST', 1, ' ' )
+   endif
+   ! OSLO_AERO end
+
     ! Add chemical tendency of water vapor to water budget output
     if ( history_budget ) then
       call add_default ('CT_H2O'  , history_budget_histfile_num, ' ')
@@ -832,6 +913,11 @@ end function chem_is_active
     if (is_first_step() .and. srf_ozone_pbf_ndx>0) then
        call pbuf_set_field(pbuf2d, srf_ozone_pbf_ndx, 0._r8)
     end if
+
+   !OSLO_AERO begin
+   ! intialize the fields used for summation of aerosol output
+   call summation_fields_init()
+   !OSLO_AERO end
 
   contains
 
@@ -861,6 +947,17 @@ end function chem_is_active
     use hco_cc_emissions, only: hco_set_srf_emissions
     use fire_emissions,   only: fire_emissions_srf
     use ocean_emis,       only: ocean_emis_getflux
+    ! OSLO_AERO begin
+    use oslo_aero_share,  only: l_dms, l_isoprene, l_monoterp
+    use oslo_aero_share,  only: aerosolType, sulfurMassFraction
+    use oslo_aero_share,  only: N_AEROSOL_TYPES
+    use oslo_aero_share,  only: AEROSOL_TYPE_SALT,  &
+                                AEROSOL_TYPE_DUST,  &
+                                AEROSOL_TYPE_BC,    &
+                                AEROSOL_TYPE_OM,    &
+                                l_so4_pr,           &
+                                l_so2
+    ! OSLO_AERO end
 
     ! Arguments:
 
@@ -875,6 +972,9 @@ end function chem_is_active
 
     real(r8) :: sflx(pcols,gas_pcnst)
     real(r8) :: megflx(pcols)
+    ! OSLO_AERO begin
+    real(r8) :: aero_emis(pcols, N_AEROSOL_TYPES)
+    ! OSLO_AERO end
 
     lchnk = state%lchnk
     ncol = state%ncol
@@ -884,6 +984,15 @@ end function chem_is_active
        n = map2chm(m)
        if (n>0) cam_in%cflx(:,m) = 0._r8
     enddo
+
+    ! OSLO_AERO begin
+   ! initialize an array to hold the aerosol emissions for each aerosol type
+    aero_emis(:,:) = 0.0_r8
+    SFBC(:,lchnk) = 0.0_r8
+    SFOM(:,lchnk) = 0.0_r8
+    SFSULFATE(:,lchnk) = 0.0_r8
+    SFSO2(:,lchnk) = 0.0_r8
+    ! OSLO_AERO end
 
     ! aerosol emissions ...
     call aero_model_emissions( state, cam_in )
@@ -929,8 +1038,39 @@ end function chem_is_active
           ! if (srf_emis_diag(m)) then
              call outfld( sflxnam(m), cam_in%cflx(:ncol,m), ncol,lchnk )
           ! endif
+
+         !OSLO_AERO begin
+         ! output emissions for DMS, isoprene, and monoterpenes
+            if ( m == l_dms .or. m == l_isoprene .or. m == l_monoterp) then
+            call outfld('emis_'//trim(sflxnam(m)(3:)), cam_in%cflx(:ncol,m), ncol,lchnk )
+            if ( m == l_dms ) then
+               call outfld('emis_'//trim(sflxnam(m)(3:))//'_S', ( cam_in%cflx(:ncol,m) * sulfurMassFraction(m) ), ncol,lchnk )
+            endif
+         endif
+
+         ! add salt and dust emissions to the compunded aerosol emissions
+         ! handle summation for the compound SF fields that is used for
+         ! emissions in summation_fields_writeout()
+         if ( aerosolType(m) == AEROSOL_TYPE_SALT .or. aerosolType(m) == AEROSOL_TYPE_DUST ) then
+            aero_emis(:,aerosolType(m)) = aero_emis(:,aerosolType(m)) + cam_in%cflx(:,m)
+         else if ( aerosolType(m) == AEROSOL_TYPE_BC ) then
+            SFBC(:, lchnk) = SFBC(:, lchnk) + cam_in%cflx(:,m)
+         else if ( aerosolType(m) == AEROSOL_TYPE_OM ) then
+            SFOM(:, lchnk) = SFOM(:, lchnk) + cam_in%cflx(:,m)
+         else if ( m == l_so4_pr ) then
+            SFSULFATE(:, lchnk) = SFSULFATE(:, lchnk) + cam_in%cflx(:,m)
+         else if ( m == l_so2 ) then
+            SFSO2(:, lchnk) = SFSO2(:, lchnk) + cam_in%cflx(:,m)
+         endif
+         !OSLO_AERO end
        endif
     enddo
+
+   ! OSLO_AERO begin
+   ! output the compounded aerosol emissions
+   call outfld('emis_SALT', aero_emis(:,AEROSOL_TYPE_SALT), ncol, lchnk)
+   call outfld('emis_DUST', aero_emis(:,AEROSOL_TYPE_DUST), ncol, lchnk)
+   ! OSLO_AERO end
 
     ! fire surface emissions if not elevated forcing
     call fire_emissions_srf( lchnk, ncol, cam_in%fireflx, cam_in%cflx )
@@ -1252,7 +1392,9 @@ end function chem_is_active
 ! call Neu wet dep scheme
 !-----------------------------------------------------------------------
     call neu_wetdep_tend(lchnk,ncol,state%q,state%pmid,state%pdel,state%zi,state%t,dt, &
-         prain, nevapr, cldfr, cmfdqr, ptend%q, wetdepflx)
+         prain, nevapr, cldfr, cmfdqr, ptend%q, wetdepflx,                             &
+         pbuf                                                                          & ! OSLO_AERO
+         )
 
 !-----------------------------------------------------------------------
 ! compute tendencies and surface fluxes
@@ -1280,6 +1422,9 @@ end function chem_is_active
           cam_out%noy_nitrogen_flx(:ncol) = noy_nitrogen_flx(:ncol)
        endif
     end if
+
+    ! call summation field calculations
+    call summation_fields_writeout( lchnk=state%lchnk, ncol=state%ncol )
 
     call t_stopf( 'chemdr' )
 
@@ -1403,5 +1548,364 @@ end function chem_is_active
     call read_tracer_cnst_restart(File)
     call read_tracer_srcs_restart(File)
   end subroutine chem_read_restart
+
+!-------------------------------------------------------------------
+  subroutine summation_fields_init()
+   ! =======================================================================
+   !
+   !   SUBROUTINE: summation_fields_init
+   !
+   !   DESCRIPTION: Initializes summation field history.
+   !                Current fields are:
+   !                - DMS: chemical loss
+   !                - SO2: emission/sulfur emmissions,
+   !                    source /sulfur source, sink/sulfur sink
+   !                    and chemical loss
+   !                - SULFATE: emission/sulfur emmissions
+   !                    and source /sulfur source
+   !                - BC: emission
+   !                - OM: emission and source
+   !
+   ! =======================================================================
+
+   ! -----------------------------------------------------------------------
+   ! import variables
+   ! -----------------------------------------------------------------------
+   use cam_history,        only  : addfld, add_default, horiz_only
+   use phys_control,       only  : history_aerosol_base,    &
+                                   history_gas,             &
+                                   history_aerosol_debug_output
+
+   ! -----------------------------------------------------------------------
+   ! Initialisation of fields, orderered as in DESCRIPTION
+   ! -----------------------------------------------------------------------
+   ! DMS
+   call addfld ('chloss_DMS_S', horiz_only, 'A',  'kg*S/m2/s',   &
+      'Chemical loss of DMS, sulfur mass only.')
+   call addfld ('chlossg_DMS_S', horiz_only, 'A',  'kg*S/m2/s',   &
+      'Chemical loss of DMS as gas, sulfur mass only.')
+   ! SO2
+   call addfld ('emis_SO2', horiz_only, 'A',  'kg/m2/s',   &
+      'SO2 emission.')
+   call addfld ('emis_SO2_S', horiz_only, 'A',  'kg*S/m2/s',   &
+      'SO2 emission, sulfur mass only.')
+   call addfld ('sour_SO2_S', horiz_only, 'A',  'kg*S/m2/s',   &
+      'SO2 source, sulfur mass only.')
+   call addfld ('sink_SO2_S', horiz_only, 'A',  'kg*S/m2/s',   &
+      'SO2 sink, sulfur mass only.')
+   call addfld ('chloss_SO2_S', horiz_only, 'A',  'kg*S/m2/s',   &
+      'Chemical loss of SO2, sulfur mass only.')
+   call addfld ('chlossg_SO2_S', horiz_only, 'A',  'kg*S/m2/s',   &
+      'Chemical loss of SO2 as gas, sulfur mass only.')
+   ! SULFATE
+   call addfld ('emis_SULFATE', horiz_only, 'A',  'kg/m2/s',   &
+      'SULFATE emission.')
+   call addfld ('emis_SULFATE_S', horiz_only, 'A',  'kg*S/m2/s',   &
+      'SULFATE emission, sulfur mass only.')
+   call addfld ('sour_SULFATE', horiz_only, 'A',  'kg/m2/s',   &
+      'SULFATE source.')
+   call addfld ('sour_SULFATE_S', horiz_only, 'A',  'kg*S/m2/s',   &
+      'SULFATE source, sulfur mass only.')
+   ! BC
+   call addfld ('emis_BC', horiz_only, 'A',  'kg/m2/s',   &
+      'BC emission.')
+   ! OM
+   call addfld ('emis_OM', horiz_only, 'A',  'kg/m2/s',   &
+      'OM emission.')
+   call addfld ('sour_OM', horiz_only, 'A',  'kg/m2/s',   &
+      'OM source.')
+
+   ! TEMPORARY FIELDS
+   call addfld ('tot_dms_lost_as_S', horiz_only, 'A',  'kg/m2/s',   &
+      'tmp field, REMOVE BFR PR.')
+   call addfld ('msa_prod_from_dms_as_S', horiz_only, 'A',  'kg/m2/s',   &
+   'tmp field, REMOVE BFR PR.')
+   call addfld ('SO2_formed_from_DMS_as_S', horiz_only, 'A',  'kg/m2/s',   &
+      'tmp field, REMOVE BFR PR.')
+
+   if ( history_aerosol_debug_output ) then
+      call add_default('tot_dms_lost_as_S', 1, ' ')
+      call add_default('SO2_formed_from_DMS_as_S', 1, ' ')
+      call add_default('msa_prod_from_dms_as_S', 1, ' ')
+   endif
+
+   if ( history_aerosol_base ) then
+      ! SO2
+      call add_default( 'emis_SO2', 1, ' ' )
+      call add_default( 'emis_SO2_S', 1, ' ' )
+      call add_default( 'sour_SO2_S', 1, ' ' )
+      call add_default( 'sink_SO2_S', 1, ' ' )
+      ! SULFATE
+      call add_default( 'emis_SULFATE', 1, ' ' )
+      call add_default( 'emis_SULFATE_S', 1, ' ' )
+      call add_default( 'sour_SULFATE', 1, ' ' )
+      call add_default( 'sour_SULFATE_S', 1, ' ' )
+      ! BC
+      call add_default( 'emis_BC', 1, ' ' )
+      ! OM
+      call add_default( 'emis_OM', 1, ' ' )
+      call add_default( 'sour_OM', 1, ' ' )
+
+   endif
+
+   if ( history_gas ) then
+      ! DMS
+      call add_default( 'chloss_DMS_S', 1, ' ' )
+      call add_default( 'chlossg_DMS_S', 1, ' ' )
+      ! SO2
+      call add_default( 'chloss_SO2_S', 1, ' ' )
+      call add_default( 'chlossg_SO2_S', 1, ' ' )
+
+   endif
+
+end subroutine summation_fields_init
+
+!-------------------------------------------------------------------
+!-------------------------------------------------------------------
+
+subroutine summation_fields_writeout(lchnk, ncol)
+   ! =======================================================================
+   !
+   !   SUBROUTINE: summation_fields_writeout
+   !
+   !   DESCRIPTION: calculates and writes out summation fields for fields
+   !                that are a sum of fields from different modules.
+   !                Implemented fields are:
+   !                - DMS: chemical loss
+   !                - SO2: emission/sulfur emmissions,
+   !                    source /sulfur source,
+   !                    sink/sulfur sink
+   !                    and chemical loss
+   !                - SULFATE: emission/sulfur emmissions,
+   !                    source /sulfur source, *
+   !
+   !                - BC: emission
+   !                - OM: emission and source
+   !                The outfld calls are performed at the end since some
+   !                of the arrays are part of multiple output fields.
+   !
+   !                * wet deposition of SULFATE is a summation field
+   !                * but is not written out here. It is written out in
+   !                * summation_fields_writeout_ac() (after coupling
+   !                * because it uses SFWET fields which are not
+   !                * available before coupling (bc)).
+   !
+   !   ARGUMENTS:
+   !     integer, intent(in)  :: lchnk
+   !         LCHNK DESCRIPTION!
+   !     integer, intent(in)  :: ncol
+   !         NCOL DESCRIPTION!
+   !
+   ! =======================================================================
+
+   ! -----------------------------------------------------------------------
+   ! import variables
+   ! -----------------------------------------------------------------------
+   use ppgrid,             only  : pcols, begchunk, endchunk
+   use cam_history,        only  : outfld
+   use oslo_aero_share,    only  : sulfurMassFraction,      & ! for sulfur mass versions of numbers
+                                   sulfurMassFraction_MSA,  & ! for SO2_formed_from_DMS_as_S
+                                   SOAyield_isoprene,       & ! for SO2_formed_from_DMS_as_S
+                                   SOAyield_monoterp          ! for SO2_formed_from_DMS_as_S
+   use oslo_aero_share,    only  : l_so2,    &
+                                   l_so4_a2, &
+                                   l_so4_pr, &
+                                   l_h2so4,  &
+                                   l_bc_ax,  &
+                                   l_bc_n,   &
+                                   l_bc_ni,  &
+                                   l_om_ni,  &
+                                   l_dms
+   use mo_extfrc,          only  : CMXF_fields  ! for SO2, SULFATE, BC and OM emissions and sources
+   use aero_model,         only  : GS_SOA,                           & ! for OM source
+                                   GS_H2SO4, AQ_H2SO4, AQ_SO4_A2_OCW,& ! for SULFATE source
+                                   GS_SO2, AQ_SO2,                   & ! for SO2 sink
+                                   GS_DMS, GS_isoprene, GS_monoterp    ! for SO2_formed_from_DMS_as_S
+   use mo_chm_diags,       only  : DF_SO2                              ! for SO2 sink
+   use mo_neu_wetdep,      only  : WD_A_SO2_NEU                        ! for SO2 sink if gas_wetdep_method == NEU
+
+   ! -----------------------------------------------------------------------
+   ! Arguments summation_fields_writeout
+   ! -----------------------------------------------------------------------
+   integer,   intent(in)         :: lchnk
+   integer,   intent(in)         :: ncol
+
+   ! -----------------------------------------------------------------------
+   ! Local variables summation_fields_writeout
+   ! -----------------------------------------------------------------------
+   real(r8)                      :: tot_dms_lost_as_S(pcols)
+   real(r8)                      :: msa_prod_from_dms_as_S(pcols)
+   real(r8)                      :: SO2_formed_from_DMS_as_S(pcols)
+   real(r8)                      :: chloss_DMS_S(pcols)
+   real(r8)                      :: chlossg_DMS_S(pcols)
+   real(r8)                      :: emis_SO2(pcols)
+   real(r8)                      :: emis_SO2_S(pcols)
+   real(r8)                      :: sour_SO2_S(pcols)
+   real(r8)                      :: sink_SO2_S(pcols)
+   real(r8)                      :: chloss_SO2_S(pcols)
+   real(r8)                      :: chlossg_SO2_S(pcols)
+   real(r8)                      :: emis_SULFATE(pcols)
+   real(r8)                      :: emis_SULFATE_S(pcols)
+   real(r8)                      :: sour_SULFATE(pcols)
+   real(r8)                      :: sour_SULFATE_S(pcols)
+   real(r8)                      :: emis_BC(pcols)
+   real(r8)                      :: emis_OM(pcols)
+   real(r8)                      :: sour_OM(pcols)
+
+   ! Zero all local variables
+   tot_dms_lost_as_S(:) = 0._r8
+   msa_prod_from_dms_as_S(:) = 0._r8
+   SO2_formed_from_DMS_as_S(:) = 0._r8
+   chloss_DMS_S(:) = 0._r8
+   chlossg_DMS_S(:) = 0._r8
+   emis_SO2(:) = 0._r8
+   emis_SO2_S(:) = 0._r8
+   sour_SO2_S(:) = 0._r8
+   sink_SO2_S(:) = 0._r8
+   chloss_SO2_S(:) = 0._r8
+   chlossg_SO2_S(:) = 0._r8
+   emis_SULFATE(:) = 0._r8
+   emis_SULFATE_S(:) = 0._r8
+   emis_BC(:) = 0._r8
+   emis_OM(:) = 0._r8
+   sour_OM(:) = 0._r8
+
+   ! calculate summations that is used across tracer species
+   ! SO2_formed_from_DMS_as_S = tot_dms_lost_as_S - msa_prod_from_dms_as_S
+   !     tot_dms_lost_as_S = - GS_DMS * sulfurMassFraction(l_dms)
+   !     msa_prod_from_dms_as_S = sulfurMassFraction_MSA * (
+   !         GS_SOA_LV + GS_SOA_SV - ( -1.0 ( 0.05*SOAyield_isoprene*GS_isoprene + 0.15*SOAyield_monoterp*GS_monoterp ) )
+   !     )
+   !         NOTE: The 0.005 and 0.15 are tuning factors - i.e. "magic numbers". Per 2024-04.08 these are in sync with the
+   !         chem_mech document (NorESM/components/cam/src/chemistry/pp_trop_mam_oslo/chem_mech.doc) line 109-111
+   !         (monoterp = 0.15) and line 112-114 (isoprene = 0.005).
+   tot_dms_lost_as_S(:ncol) = - GS_DMS(:ncol,lchnk) * sulfurMassFraction(l_dms)
+   msa_prod_from_dms_as_S(:ncol) = sulfurMassFraction_MSA * (                          &
+      GS_SOA(:ncol, lchnk) -                                                           &
+      (-1.0_r8 * ( 0.005_r8*SOAyield_isoprene*GS_isoprene(:ncol, lchnk) +              &
+                   0.15_r8*SOAyield_monoterp*GS_monoterp(:ncol, lchnk) ) )             &
+   )
+
+   SO2_formed_from_DMS_as_S(:ncol) = tot_dms_lost_as_S(:ncol) - msa_prod_from_dms_as_S(:ncol)
+
+   ! -----------------------------------------------------------------------
+   ! DMS summation fields
+   !     chloss_DMS
+   !     chlossg_DMS
+   ! -----------------------------------------------------------------------
+   chloss_DMS_S(:ncol) = -1.0_r8 * tot_dms_lost_as_S(:ncol)
+   chlossg_DMS_S(:ncol) = -1.0_r8 * msa_prod_from_dms_as_S(:ncol)
+
+   ! -----------------------------------------------------------------------
+   ! SO2 summation fields
+   !     emis_SO2
+   !     emis_SO2_S
+   !     sour_SO2 *
+   !     sour_SO2_S
+   !     wet_SO2
+   !     wet_SO2_S
+   !     sink_SO2 *
+   !     sink_SO2_S
+   !     chloss_SO2
+   !     chlossg_SO2
+   !     * not implemented yet
+   ! -----------------------------------------------------------------------
+
+   ! emis_SO2
+   if ( masterproc ) write(iulog,*) 'chemistry: attempting to access CMXF value for SO2 at index l_so2', l_so2
+   emis_SO2(:ncol) = SFSO2(:ncol, lchnk) + CMXF_fields(:ncol, l_so2, lchnk)
+   emis_SO2_S(:ncol) = ( SFSO2(:ncol, lchnk) + CMXF_fields(:ncol, l_so2, lchnk) ) * sulfurMassFraction(l_so2)
+   ! sour_SO2
+   sour_SO2_S(:ncol) = emis_SO2_S(:ncol) + SO2_formed_from_DMS_as_S(:ncol)
+   ! sink SO2
+   sink_SO2_S(:ncol) = ( ( - WD_A_SO2_NEU(:ncol, lchnk)     - &
+        DF_SO2(:ncol, lchnk)                                + &
+        AQ_SO2(:ncol, lchnk)                                + &
+        GS_SO2(:ncol, lchnk)                                - &
+        CMXF_fields(:ncol, l_so2, lchnk)                      &
+      ) * sulfurMassFraction(l_so2)                           &
+   ) - SO2_formed_from_DMS_as_S(:ncol)
+   ! chemical loss SO2
+   chlossg_SO2_S(:ncol) = (GS_SO2(:ncol, lchnk) - CMXF_fields(:ncol, l_so2, lchnk)) * sulfurMassFraction(l_so2)    - &
+      SO2_formed_from_DMS_as_S(:ncol)
+   chloss_SO2_S(:ncol) = chlossg_SO2_S(:ncol) + ( AQ_SO2(:ncol, lchnk) * sulfurMassFraction(l_so2) )
+
+   ! -----------------------------------------------------------------------
+   ! SULFATE summation fields
+   !     emis_SULFATE
+   !     emis_SULFATE_S
+   !     sour_SULFATE
+   !     sour_SULFATE_S
+   ! -----------------------------------------------------------------------
+
+   ! emis_SULFATE
+   if ( masterproc ) write(iulog,*) 'chemistry: attempting to access CMXF value for SULFATE at index l_so4_pr', l_so4_pr
+   emis_SULFATE(:ncol) = SFSULFATE(:ncol, lchnk) + CMXF_fields(:ncol,l_so4_pr,lchnk)
+   ! emis_SULFATE_S, sulfur mass only
+   emis_SULFATE_S(:ncol) = ( SFSULFATE(:ncol, lchnk) + CMXF_fields(:ncol,l_so4_pr,lchnk) ) * sulfurMassFraction(l_so4_pr)
+   ! sour_SULFATE
+   sour_SULFATE(:ncol) = emis_SULFATE(:ncol)             + &
+                           GS_H2SO4(:ncol, lchnk)        + &
+                           AQ_H2SO4(:ncol, lchnk)        + &
+                           AQ_SO4_A2_OCW(:ncol, lchnk)
+   ! sour_SULFATE_S, sulfur mass only
+   sour_SULFATE_S(:ncol) = emis_SULFATE_S(:ncol)         + &
+                           ( ( GS_H2SO4(:ncol, lchnk) + AQ_H2SO4(:ncol, lchnk) ) * sulfurMassFraction(l_h2so4) ) + &
+                           ( AQ_SO4_A2_OCW(:ncol, lchnk) * sulfurMassFraction(l_so4_a2) )
+
+   ! -----------------------------------------------------------------------
+   ! BC summation fields
+   !     emis_BC
+   ! -----------------------------------------------------------------------
+   ! emis_BC
+   if ( masterproc ) write(iulog,*) 'chemistry: attempting to access CMXF value for BC at index l_bc_ax', l_bc_ax, &
+      'l_bc_n', l_bc_n, 'l_bc_ni', l_bc_ni
+
+   !emis_BC(:ncol) = SFBC(:ncol, lchnk) + BC_CMXF(:ncol, lchnk)
+   emis_BC(:ncol) = SFBC(:ncol, lchnk)                   + &
+                     CMXF_fields(:ncol, l_bc_ax, lchnk)  + &
+                     CMXF_fields(:ncol, l_bc_n, lchnk)   + &
+                     CMXF_fields(:ncol, l_bc_ni, lchnk)
+
+   ! -----------------------------------------------------------------------
+   ! OM summation fields
+   !     emis_OM
+   !     sour_OM
+   ! -----------------------------------------------------------------------
+   ! emis_OM
+   if ( masterproc ) write(iulog,*) 'chemistry: attempting to access CMXF value for OM at index l_om_ni', l_om_ni
+   emis_OM(:ncol) = SFOM(:ncol, lchnk) + CMXF_fields(:ncol,l_om_ni,lchnk)
+   ! sour_OM
+   sour_OM(:ncol) = emis_OM(:ncol) + GS_SOA(:ncol,lchnk)
+
+   ! -----------------------------------------------------------------------
+   ! outfld calls
+   ! -----------------------------------------------------------------------
+   ! DMS outfld calls
+   call outfld('chloss_DMS_S', chloss_DMS_S(:), ncol, lchnk)
+   call outfld('chlossg_DMS_S', chlossg_DMS_S(:), ncol, lchnk)
+   ! SO2 outfld calls
+   call outfld('emis_SO2', emis_SO2(:), ncol, lchnk)
+   call outfld('emis_SO2_S', emis_SO2_S(:), ncol, lchnk)
+   call outfld('sour_SO2_S', sour_SO2_S(:), ncol, lchnk)
+   call outfld('sink_SO2_S', sink_SO2_S(:), ncol, lchnk)
+   call outfld('chloss_SO2_S', chloss_SO2_S(:), ncol, lchnk)
+   call outfld('chlossg_SO2_S', chlossg_SO2_S(:), ncol, lchnk)
+   ! SULFATE outfld calls
+   call outfld('emis_SULFATE', emis_SULFATE(:), ncol, lchnk)
+   call outfld('emis_SULFATE_S', emis_SULFATE_S(:), ncol, lchnk)
+   call outfld('sour_SULFATE', sour_SULFATE(:), ncol, lchnk)
+   call outfld('sour_SULFATE_S', sour_SULFATE_S(:), ncol, lchnk)
+   ! BC outfld calls
+   call outfld('emis_BC', emis_BC(:), ncol, lchnk)
+   ! OM outfld calls
+   call outfld('emis_OM', emis_OM(:), ncol, lchnk)
+   call outfld('sour_OM', sour_OM(:), ncol, lchnk)
+   ! tmp field outfld
+   call outfld('tot_dms_lost_as_S', tot_dms_lost_as_S(:), ncol, lchnk)
+   call outfld('msa_prod_from_dms_as_S', msa_prod_from_dms_as_S(:), ncol, lchnk)
+   call outfld('SO2_formed_from_DMS_as_S', SO2_formed_from_DMS_as_S(:), ncol, lchnk)
+
+end subroutine summation_fields_writeout
 
 end module chemistry

--- a/src_cam/chemistry.F90
+++ b/src_cam/chemistry.F90
@@ -1812,7 +1812,6 @@ subroutine summation_fields_writeout(lchnk, ncol)
    ! -----------------------------------------------------------------------
 
    ! emis_SO2
-   if ( masterproc ) write(iulog,*) 'chemistry: attempting to access CMXF value for SO2 at index l_so2', l_so2
    emis_SO2(:ncol) = SFSO2(:ncol, lchnk) + CMXF_fields(:ncol, l_so2, lchnk)
    emis_SO2_S(:ncol) = ( SFSO2(:ncol, lchnk) + CMXF_fields(:ncol, l_so2, lchnk) ) * sulfurMassFraction(l_so2)
    ! sour_SO2
@@ -1839,7 +1838,6 @@ subroutine summation_fields_writeout(lchnk, ncol)
    ! -----------------------------------------------------------------------
 
    ! emis_SULFATE
-   if ( masterproc ) write(iulog,*) 'chemistry: attempting to access CMXF value for SULFATE at index l_so4_pr', l_so4_pr
    emis_SULFATE(:ncol) = SFSULFATE(:ncol, lchnk) + CMXF_fields(:ncol,l_so4_pr,lchnk)
    ! emis_SULFATE_S, sulfur mass only
    emis_SULFATE_S(:ncol) = ( SFSULFATE(:ncol, lchnk) + CMXF_fields(:ncol,l_so4_pr,lchnk) ) * sulfurMassFraction(l_so4_pr)
@@ -1858,10 +1856,6 @@ subroutine summation_fields_writeout(lchnk, ncol)
    !     emis_BC
    ! -----------------------------------------------------------------------
    ! emis_BC
-   if ( masterproc ) write(iulog,*) 'chemistry: attempting to access CMXF value for BC at index l_bc_ax', l_bc_ax, &
-      'l_bc_n', l_bc_n, 'l_bc_ni', l_bc_ni
-
-   !emis_BC(:ncol) = SFBC(:ncol, lchnk) + BC_CMXF(:ncol, lchnk)
    emis_BC(:ncol) = SFBC(:ncol, lchnk)                   + &
                      CMXF_fields(:ncol, l_bc_ax, lchnk)  + &
                      CMXF_fields(:ncol, l_bc_n, lchnk)   + &
@@ -1873,7 +1867,6 @@ subroutine summation_fields_writeout(lchnk, ncol)
    !     sour_OM
    ! -----------------------------------------------------------------------
    ! emis_OM
-   if ( masterproc ) write(iulog,*) 'chemistry: attempting to access CMXF value for OM at index l_om_ni', l_om_ni
    emis_OM(:ncol) = SFOM(:ncol, lchnk) + CMXF_fields(:ncol,l_om_ni,lchnk)
    ! sour_OM
    sour_OM(:ncol) = emis_OM(:ncol) + GS_SOA(:ncol,lchnk)

--- a/src_cam/chemistry.F90
+++ b/src_cam/chemistry.F90
@@ -869,7 +869,7 @@ end function chem_is_active
                call addfld('emis_'//trim(sflxnam(n)(3:)), horiz_only, 'A', 'kg/m2/s', &
                      trim(sflxnam(n)(3:))//' emissions')
                if ( n == l_dms ) then
-                  call addfld('emis_'//trim(sflxnam(n)(3:))//'_S', horiz_only, 'A', 'kg*S/m2/s', &
+                  call addfld('emis_'//trim(sflxnam(n)(3:))//'_S', horiz_only, 'A', 'kg/m2/s', &
                      trim(sflxnam(n)(3:))//' emissions, sulfur mass only')
                endif
 
@@ -1580,54 +1580,40 @@ end function chem_is_active
    ! Initialisation of fields, orderered as in DESCRIPTION
    ! -----------------------------------------------------------------------
    ! DMS
-   call addfld ('chloss_DMS_S', horiz_only, 'A',  'kg*S/m2/s',   &
+   call addfld ('chloss_DMS_S', horiz_only, 'A',  'kg/m2/s',             &
       'Chemical loss of DMS, sulfur mass only.')
-   call addfld ('chlossg_DMS_S', horiz_only, 'A',  'kg*S/m2/s',   &
+   call addfld ('chlossg_DMS_S', horiz_only, 'A',  'kg/m2/s',            &
       'Chemical loss of DMS as gas, sulfur mass only.')
    ! SO2
-   call addfld ('emis_SO2', horiz_only, 'A',  'kg/m2/s',   &
+   call addfld ('emis_SO2', horiz_only, 'A',  'kg/m2/s',                 &
       'SO2 emission.')
-   call addfld ('emis_SO2_S', horiz_only, 'A',  'kg*S/m2/s',   &
+   call addfld ('emis_SO2_S', horiz_only, 'A',  'kg/m2/s',               &
       'SO2 emission, sulfur mass only.')
-   call addfld ('sour_SO2_S', horiz_only, 'A',  'kg*S/m2/s',   &
+   call addfld ('sour_SO2_S', horiz_only, 'A',  'kg/m2/s',               &
       'SO2 source, sulfur mass only.')
-   call addfld ('sink_SO2_S', horiz_only, 'A',  'kg*S/m2/s',   &
+   call addfld ('sink_SO2_S', horiz_only, 'A',  'kg/m2/s',               &
       'SO2 sink, sulfur mass only.')
-   call addfld ('chloss_SO2_S', horiz_only, 'A',  'kg*S/m2/s',   &
+   call addfld ('chloss_SO2_S', horiz_only, 'A',  'kg/m2/s',             &
       'Chemical loss of SO2, sulfur mass only.')
-   call addfld ('chlossg_SO2_S', horiz_only, 'A',  'kg*S/m2/s',   &
+   call addfld ('chlossg_SO2_S', horiz_only, 'A',  'kg/m2/s',            &
       'Chemical loss of SO2 as gas, sulfur mass only.')
    ! SULFATE
-   call addfld ('emis_SULFATE', horiz_only, 'A',  'kg/m2/s',   &
+   call addfld ('emis_SULFATE', horiz_only, 'A',  'kg/m2/s',             &
       'SULFATE emission.')
-   call addfld ('emis_SULFATE_S', horiz_only, 'A',  'kg*S/m2/s',   &
+   call addfld ('emis_SULFATE_S', horiz_only, 'A',  'kg/m2/s',           &
       'SULFATE emission, sulfur mass only.')
-   call addfld ('sour_SULFATE', horiz_only, 'A',  'kg/m2/s',   &
+   call addfld ('sour_SULFATE', horiz_only, 'A',  'kg/m2/s',             &
       'SULFATE source.')
-   call addfld ('sour_SULFATE_S', horiz_only, 'A',  'kg*S/m2/s',   &
+   call addfld ('sour_SULFATE_S', horiz_only, 'A',  'kg/m2/s',           &
       'SULFATE source, sulfur mass only.')
    ! BC
-   call addfld ('emis_BC', horiz_only, 'A',  'kg/m2/s',   &
+   call addfld ('emis_BC', horiz_only, 'A',  'kg/m2/s',                  &
       'BC emission.')
    ! OM
-   call addfld ('emis_OM', horiz_only, 'A',  'kg/m2/s',   &
+   call addfld ('emis_OM', horiz_only, 'A',  'kg/m2/s',                  &
       'OM emission.')
-   call addfld ('sour_OM', horiz_only, 'A',  'kg/m2/s',   &
+   call addfld ('sour_OM', horiz_only, 'A',  'kg/m2/s',                  &
       'OM source.')
-
-   ! TEMPORARY FIELDS
-   call addfld ('tot_dms_lost_as_S', horiz_only, 'A',  'kg/m2/s',   &
-      'tmp field, REMOVE BFR PR.')
-   call addfld ('msa_prod_from_dms_as_S', horiz_only, 'A',  'kg/m2/s',   &
-   'tmp field, REMOVE BFR PR.')
-   call addfld ('SO2_formed_from_DMS_as_S', horiz_only, 'A',  'kg/m2/s',   &
-      'tmp field, REMOVE BFR PR.')
-
-   if ( history_aerosol_debug_output ) then
-      call add_default('tot_dms_lost_as_S', 1, ' ')
-      call add_default('SO2_formed_from_DMS_as_S', 1, ' ')
-      call add_default('msa_prod_from_dms_as_S', 1, ' ')
-   endif
 
    if ( history_aerosol_base ) then
       ! SO2
@@ -1771,20 +1757,15 @@ subroutine summation_fields_writeout(lchnk, ncol)
    sour_OM(:) = 0._r8
 
    ! calculate summations that is used across tracer species
-   ! SO2_formed_from_DMS_as_S = tot_dms_lost_as_S - msa_prod_from_dms_as_S
-   !     tot_dms_lost_as_S = - GS_DMS * sulfurMassFraction(l_dms)
-   !     msa_prod_from_dms_as_S = sulfurMassFraction_MSA * (
-   !         GS_SOA_LV + GS_SOA_SV - ( -1.0 ( 0.05*SOAyield_isoprene*GS_isoprene + 0.15*SOAyield_monoterp*GS_monoterp ) )
-   !     )
-   !         NOTE: The 0.005 and 0.15 are tuning factors - i.e. "magic numbers". Per 2024-04.08 these are in sync with the
-   !         chem_mech document (NorESM/components/cam/src/chemistry/pp_trop_mam_oslo/chem_mech.doc) line 109-111
-   !         (monoterp = 0.15) and line 112-114 (isoprene = 0.005).
+   ! NOTE: The 0.005 and 0.15 are tuning factors - i.e. "magic numbers".
+   ! Per 2024-04.08 these are in sync with the
+   !     chem_mech document (NorESM/components/cam/src/chemistry/pp_trop_mam_oslo/chem_mech.doc) line 109-111
+   !     (monoterp = 0.15) and line 112-114 (isoprene = 0.005).
    tot_dms_lost_as_S(:ncol) = - GS_DMS(:ncol,lchnk) * sulfurMassFraction(l_dms)
-   msa_prod_from_dms_as_S(:ncol) = sulfurMassFraction_MSA * (                          &
-      GS_SOA(:ncol, lchnk) -                                                           &
-      (-1.0_r8 * ( 0.005_r8*SOAyield_isoprene*GS_isoprene(:ncol, lchnk) +              &
-                   0.15_r8*SOAyield_monoterp*GS_monoterp(:ncol, lchnk) ) )             &
-   )
+   msa_prod_from_dms_as_S(:ncol) = sulfurMassFraction_MSA * (              &
+      GS_SOA(:ncol, lchnk) -                                               &
+      (-1.0_r8 * ( 0.005_r8*SOAyield_isoprene*GS_isoprene(:ncol, lchnk) +  &
+                   0.15_r8*SOAyield_monoterp*GS_monoterp(:ncol, lchnk) ) ) )
 
    SO2_formed_from_DMS_as_S(:ncol) = tot_dms_lost_as_S(:ncol) - msa_prod_from_dms_as_S(:ncol)
 
@@ -1894,10 +1875,6 @@ subroutine summation_fields_writeout(lchnk, ncol)
    ! OM outfld calls
    call outfld('emis_OM', emis_OM(:), ncol, lchnk)
    call outfld('sour_OM', sour_OM(:), ncol, lchnk)
-   ! tmp field outfld
-   call outfld('tot_dms_lost_as_S', tot_dms_lost_as_S(:), ncol, lchnk)
-   call outfld('msa_prod_from_dms_as_S', msa_prod_from_dms_as_S(:), ncol, lchnk)
-   call outfld('SO2_formed_from_DMS_as_S', SO2_formed_from_DMS_as_S(:), ncol, lchnk)
 
 end subroutine summation_fields_writeout
 

--- a/src_cam/mo_chm_diags.F90
+++ b/src_cam/mo_chm_diags.F90
@@ -13,6 +13,7 @@ module mo_chm_diags
   use mo_drydep,       only : has_drydep
   !
   ! OSLO_AERO begin
+  use cam_abortutils,  only : endrun
   use ppgrid,          only : pcols
   use physics_buffer,  only : pbuf_get_field, pbuf_get_index, physics_buffer_desc
   use oslo_aero_share, only : getCloudTracerIndexDirect, getCloudTracerName
@@ -60,7 +61,10 @@ module mo_chm_diags
   character(len=fieldname_len) :: depflx_name(gas_pcnst)
   character(len=fieldname_len) :: wetdep_name(gas_pcnst)
   character(len=fieldname_len) :: wtrate_name(gas_pcnst)
-  character(len=fieldname_len) :: wetdep_name_area(gas_pcnst) ! OSLO_AERO
+  ! OSLO_AERO begin
+  character(len=fieldname_len) :: wetdep_name_area(gas_pcnst)
+  real(r8), public, protected, allocatable   :: DF_SO2(:,:)
+  ! OSLO_AERO end
   real(r8), parameter :: N_molwgt = 14.00674_r8
   real(r8), parameter :: S_molwgt = 32.066_r8
 
@@ -77,6 +81,16 @@ contains
     use constituents, only : cnst_get_ind, cnst_longname
     use phys_control, only : phys_getopts
     use species_sums_diags, only : species_sums_init
+    ! OSLO_AERO begin
+    use string_utils,    only: int2str
+    use oslo_aero_share, only: getCloudTracerIndexDirect, getCloudTracerName, isAerosol
+    use oslo_aero_share, only: aerosol_type_name, N_AEROSOL_TYPES, AEROSOL_TYPE_SULFATE
+    use oslo_aero_share, only: l_so2, l_dms
+    use phys_control,    only: history_aerosol_base,        &
+                               history_aerosol_decomposed,  &
+                               history_gas
+    use ppgrid,          only: pcols, begchunk, endchunk
+    ! OSLO_AERO end
 
     integer :: j, k, m, n
     character(len=16) :: jname, spc_name, attr
@@ -115,8 +129,12 @@ contains
     logical :: history_chemspecies_srf ! output the chemistry constituents species in the surface layer
     logical :: history_dust
     integer :: bulkaero_species(20)
-    integer :: cloudTracerIndex          ! OSLO_AERO
-    character(len=20) :: cloudTracerName ! OSLO_AERO
+    ! OSLO_AERO begin
+    integer :: cloudTracerIndex
+    integer :: l_atype
+    integer :: astat
+    character(len=20) :: cloudTracerName
+    ! OSLO_AERO end
     !-----------------------------------------------------------------------
 
     call phys_getopts( history_aerosol_out = history_aerosol, &
@@ -125,6 +143,15 @@ contains
                        history_cesm_forcing_out = history_cesm_forcing, &
                        history_scwaccm_forcing_out = history_scwaccm_forcing, &
                        history_dust_out = history_dust )
+
+   ! OSLO_AERO begin
+   ! allocate module variables
+   allocate( DF_SO2(pcols, begchunk:endchunk), stat=astat )
+   if( astat/= 0 ) then
+      call endrun('chm_diags_inti: failed to allocate DF_SO2 array; error = '//int2str(astat))
+   end if
+   DF_SO2(:,:) = 0.0_r8
+   ! OSLO_AERO end
 
     id_bry     = get_spc_ndx( 'BRY' )
     id_cly     = get_spc_ndx( 'CLY' )
@@ -447,7 +474,7 @@ contains
        wetdep_name_area(m)='WD_A_'//trim(spc_name)
        call addfld( wetdep_name_area(m), horiz_only, 'A', 'kg/m2/s ', spc_name//' wet deposition' )
 
-       if(n.gt.0) then
+       if(n > 0) then
           if(.NOT. isAerosol(n))then
              if(history_chemistry)then
                 ! Needed for budget term of gases! Aerosols have their own budget terms
@@ -456,7 +483,7 @@ contains
           endif
        end if
 
-       if (n.gt.0) then
+       if (n > 0) then
           if ( any( aer_species == m ) .or. isAerosol(n) ) then
              call addfld( spc_name,   (/ 'lev' /), 'A', unit_basename//'/kg ', trim(attr)//' concentration')
              call addfld( trim(spc_name)//'_SRF', horiz_only, 'A', unit_basename//'/kg', trim(attr)//" in bottom layer")
@@ -510,74 +537,120 @@ contains
           if (m==id_cfc12 ) call add_default( spc_name, 1, ' ')
        endif
 
-       ! OSLO_AERO begin
-       call add_default( spc_name, 1, ' ' )
+      ! OSLO_AERO begin
+      ! Add the 3D consentrations
+      if ( n > 0 ) then
+         ! if history_aerosol_decomposed we add the aerosol species
+         if ( (any( aer_species == m ) .or. isAerosol(n)) ) then
+            if ( history_aerosol_decomposed ) then
+               call add_default( spc_name, 1, ' ' )
+            endif
+         ! if it is not an aerosol species it is a gas species and we then require the history_gas flag
+         else
+            if ( history_gas ) then
+               call add_default( spc_name, 1, ' ' )
+            endif
+         endif
+      elseif ( trim(spc_name) == 'H2O' ) then
+         if ( history_gas ) then
+            call add_default( spc_name, 1, ' ' )
+         endif
+      endif
 
-       ! output 3d-field of aersol tracer in cloud water
-       if (n > 0) then
-          cloudTracerIndex = getCloudTracerIndexDirect(n)
-          if(cloudTracerIndex > 0)then
-             cloudTracerName(1:len(CloudTracerName))=" "
-             cloudTracerName = getCloudTracerName(n)
-             call addfld( trim(cloudTracerName), (/'lev'/), 'A','kg/kg', &
-                  trim(cloudTracerName)//' in cloud water')
-             call add_default( trim(cloudTracerName), 1, ' ' )
+      if(n > 0) then
+         ! Add cloud tracers output fields for column burden and concentrations to output
+         cloudTracerIndex = getCloudTracerIndexDirect(n)
+         if ( cloudTracerIndex > 0 ) then
+            ! first the 3d fields,
+            cloudTracerName = getCloudTracerName(n)
+            call addfld( trim(cloudTracerName), (/'lev'/), 'A','kg/kg', &
+               trim(cloudTracerName)//' in cloud water')
+            if ( history_aerosol_decomposed ) then
+               call add_default( trim(cloudTracerName), 1, ' ' )
+            endif
 
-             !Add column burden of cloud tracers
-             call addfld('cb_'//trim(cloudTracerName),horiz_only, 'A', 'kg/m2', &
-                  'cb_'//trim(cloudTracerName)//' column in cloud water')
-             call add_default('cb_'//trim(cloudTracerName),1,' ')
-          endif
-          !..and column burden in clean air
-          call addfld('cb_'//trim(spc_name),horiz_only, 'A', 'kg/m2', &
-               'cb_'//trim(spc_name)//' in column')
-          call add_default('cb_'//trim(spc_name),1,' ' )
+            call addfld('cb_'//trim(cloudTracerName),horiz_only, 'A', 'kg/m2', &
+               'cb_'//trim(cloudTracerName)//' column in cloud water')
+            if ( history_aerosol_decomposed ) then
+               call add_default('cb_'//trim(cloudTracerName),1,' ')
+            endif
+         endif
 
-          if (history_aerosol) then
-             if (cloudTracerIndex > 0) then
-                !Output budget-terms for cloud borne aerosols
-                call add_default (trim(cloudTracerName)//'GVF'   , 1, ' ')
-                call add_default (trim(cloudTracerName)//'SFWET' , 1, ' ')
-                call add_default (trim(cloudTracerName)//'TBF'   , 1, ' ')
-                call add_default (trim(cloudTracerName)//'DDF'   , 1, ' ')
-                call add_default (trim(cloudTracerName)//'SFSBS' , 1, ' ')
-                call add_default (trim(cloudTracerName)//'SFSIC' , 1, ' ')
-                call add_default (trim(cloudTracerName)//'SFSBC' , 1, ' ')
-                call add_default (trim(cloudTracerName)//'SFSIS' , 1, ' ')
-             endif
-          endif
-       end if
-       ! OSLO_AERO end
+         ! Add the column burden in for interstitial aerosols to output
+         call addfld('cb_'//trim(spc_name),horiz_only, 'A', 'kg/m2', &
+            'cb_'//trim(spc_name)//' in column')
+
+         ! If the aerosol tracer is so2 or dms we add the column burden of the sulfur mass only as well to output
+         if ( n == l_so2 .or. n == l_dms ) then
+            call addfld(trim('cb_'//trim(spc_name)//'_S'), horiz_only, 'A', 'kg*S/m2', &
+               'cb_'//trim(spc_name)//' column, sulfur mass only')
+         endif
+
+         ! if the species is an aerosol we require history_aerosol_decomposed flag to output the column burden
+         if ( any( aer_species == m ) .or. isAerosol(n) ) then
+            if ( history_aerosol_decomposed ) then
+               call add_default('cb_'//trim(spc_name),1,' ' )
+            endif
+         ! else, if it is a gasphase the cb is included in the base so we require history_aerosol_base flag
+         else
+            if ( history_aerosol_base ) then
+               call add_default('cb_'//trim(spc_name), 1, ' ')
+               ! if it is so2 or dms we add the column burden of the sulfur
+               if ( n == l_so2 .or. n == l_dms ) then
+                  call add_default(trim('cb_'//trim(spc_name)//'_S'), 1, ' ')
+               endif
+            endif
+         endif
+
+         if (history_aerosol) then
+            if (cloudTracerIndex > 0) then
+               !Output budget-terms for cloud borne aerosols
+               call add_default (trim(cloudTracerName)//'GVF'   , 1, ' ')
+               call add_default (trim(cloudTracerName)//'SFWET' , 1, ' ')
+               call add_default (trim(cloudTracerName)//'TBF'   , 1, ' ')
+               call add_default (trim(cloudTracerName)//'DDF'   , 1, ' ')
+               call add_default (trim(cloudTracerName)//'SFSBS' , 1, ' ')
+               call add_default (trim(cloudTracerName)//'SFSIC' , 1, ' ')
+               call add_default (trim(cloudTracerName)//'SFSBC' , 1, ' ')
+               call add_default (trim(cloudTracerName)//'SFSIS' , 1, ' ')
+            endif
+         endif
+      end if
+      ! OSLO_AERO end
     enddo
 
     call addfld( 'MASS', (/ 'lev' /), 'A', 'kg', 'mass of grid box' )
     call addfld( 'AREA', horiz_only,  'A', 'm2', 'area of grid box' )
 
-    ! OSLO_AERO begin
-    do n=1,N_AEROSOL_TYPES
-       call addfld('cb_'//trim(aerosol_type_name(n)),horiz_only, 'A', 'kg/m2',&
-            'cb_'//trim(aerosol_type_name(n))//' column of aerosol type')
-       call add_default('cb_'//trim(aerosol_type_name(n)), 1, ' ')
+   ! OSLO_AERO begin
+   ! iterate over the compounded aerosol types
+   do l_atype=1,N_AEROSOL_TYPES
+      ! add the column burden of the compound aerosols to output
+      call addfld('cb_'//trim(aerosol_type_name(l_atype)),horiz_only, 'A', 'kg/m2',&
+         'cb_'//trim(aerosol_type_name(l_atype))//' column of aerosol type')
+      if ( l_atype == AEROSOL_TYPE_SULFATE ) then
+         call addfld('cb_'//trim(aerosol_type_name(l_atype))//'_S',horiz_only, 'A', 'kg*S/m2',&
+         'cb_'//trim(aerosol_type_name(l_atype))//' column of aerosol, sulfur mass only')
+      endif
+      ! we require history_aerosol_base flag
+      if ( history_aerosol_base ) then
+         call add_default('cb_'//trim(aerosol_type_name(l_atype)), 1, ' ')
 
-       call addfld('mmr_'//trim(aerosol_type_name(n)),(/'lev'/),'A','kg/kg' ,&
-            'mmr_'//trim(aerosol_type_name(n))//' mmr of aerosol type')
-       call add_default('mmr_'//trim(aerosol_type_name(n)), 1, ' ')
-    end do
-    ! OSLO_AERO end
+         ! if the aerosol type is sulfur we make a version of the column burden that is only the sulfur
+         if ( l_atype == AEROSOL_TYPE_SULFATE ) then
+            call add_default('cb_'//trim(aerosol_type_name(l_atype))//'_S', 1, ' ')
+         endif
+      endif
 
-    call addfld('sum_SO4'  , (/ 'lev' /), 'A', 'kg/kg ', 'sum of SO4 concentrations')
-    call addfld('sum_BC'   , (/ 'lev' /), 'A', 'kg/kg ', 'sum of BC concentrations')
-    call addfld('sum_OM'   , (/ 'lev' /), 'A', 'kg/kg ', 'sum of OM concentrations')
-    call addfld('sum_DST'  , (/ 'lev' /), 'A', 'kg/kg ', 'sum of DST concentrations')
-    call addfld('sum_SS'   , (/ 'lev' /), 'A', 'kg/kg ', 'sum of SS concentrations')
-    call addfld('sum_SOA'  , (/ 'lev' /), 'A', 'kg/kg ', 'sum of SOA concentrations')
-
-    call add_default('sum_SO4'  , 1, ' ')
-    call add_default('sum_BC'   , 1, ' ')
-    call add_default('sum_OM'   , 1, ' ')
-    call add_default('sum_DST'  , 1, ' ')
-    call add_default('sum_SS'   , 1, ' ')
-    call add_default('sum_SOA'  , 1, ' ')
+      ! add the mass mixing ratio of the compound aerosols to output
+      call addfld('mmr_'//trim(aerosol_type_name(l_atype)),(/'lev'/),'A','kg/kg' ,&
+         'mmr_'//trim(aerosol_type_name(l_atype))//' mmr of aerosol type')
+      ! we require history_aerosol_base flag
+      if ( history_aerosol_base ) then
+         call add_default('mmr_'//trim(aerosol_type_name(l_atype)), 1, ' ')
+      endif
+   end do
+   ! OSLO_AERO end
 
     call addfld( 'dry_deposition_NOy_as_N', horiz_only, 'I', 'kg/m2/s', 'NOy dry deposition flux ' )
     call addfld( 'DF_SOX', horiz_only, 'I', 'kg/m2/s', 'SOx dry deposition flux ' )
@@ -614,6 +687,15 @@ contains
     use phys_grid,          only : get_area_all_p
     use species_sums_diags, only : species_sums_output
     use constituents,       only : cnst_get_ind
+    ! OSLO_AERO begin
+    use ppgrid,         only : pcols
+    use physics_buffer, only : pbuf_get_field, pbuf_get_index
+    use physics_buffer, only : physics_buffer_desc
+    !
+    use oslo_aero_share,only : getCloudTracerIndexDirect, getCloudTracerName, aerosolType, isAerosol
+    use oslo_aero_share,only : aerosol_type_name, N_AEROSOL_TYPES, AEROSOL_TYPE_SULFATE, AEROSOL_TYPE_BC
+    use oslo_aero_share,only : sulfurMassFraction, l_so2, l_dms
+    ! OSLO_AERO end
 !
 ! CCMI
 !
@@ -647,12 +729,15 @@ contains
     ! OSLO_AERO begin
     real(r8), pointer :: cloudTracerField(:,:)
     integer           :: cloudTracerIndex
+    integer           :: l_atype
     character(len=20) :: cloudTracerName
     real(r8)          :: mass_tmp(pcols,pver)
     real(r8)          :: cb(pcols)
     real(r8)          :: cb_aerosol_type(pcols,N_AEROSOL_TYPES)         !column burden aerosol types
+    real(r8)          :: cb_SULFUR_S(pcols)                             !column burden for SULFATE in sulfur mass
     real(r8)          :: mmr_aerosol_type(pcols,pver,N_AEROSOL_TYPES)   !concentration aerosol types
     character(len=16) :: spc_name
+    integer           :: l_aero
     ! OSLO_AERO end
     integer     :: i, k, m, n
     real(r8)    :: wrk(ncol,pver)
@@ -666,13 +751,6 @@ contains
     real(r8), dimension(ncol)      :: df_noy, df_sox, df_nhx, do3chm_trp, do3chm_lms
     real(r8), dimension(ncol)      :: wd_noy, wd_nhx
     real(r8), dimension(ncol,pver) :: vmr_hox
-
-    real(r8) :: sum_so4(ncol,pver)
-    real(r8) :: sum_bc(ncol,pver)
-    real(r8) :: sum_om(ncol,pver)
-    real(r8) :: sum_dst(ncol,pver)
-    real(r8) :: sum_ss(ncol,pver)
-    real(r8) :: sum_soa(ncol,pver)
 
     real(r8) :: area(ncol), mass(ncol,pver)
     real(r8) :: wgt
@@ -712,10 +790,12 @@ contains
     call outfld( 'AREA', area(:ncol),   ncol, lchnk )
     call outfld( 'MASS', mass(:ncol,:), ncol, lchnk )
 
-    ! OSLO_AERO begin
-    cb_aerosol_type(:,:) = 0.0_r8
-    mmr_aerosol_type(:,:,:) = 0.0_r8
-    ! OSLO_AERO end
+   ! OSLO_AERO begin
+   DF_SO2(:ncol,lchnk) = 0.0_r8
+   cb_aerosol_type(:,:) = 0.0_r8
+   cb_SULFUR_S(:) = 0.0_r8
+   mmr_aerosol_type(:,:,:) = 0.0_r8
+   ! OSLO_AERO end
 
     do m = 1,gas_pcnst
 
@@ -803,7 +883,7 @@ contains
        spc_name = trim(solsym(m))
        call cnst_get_ind(spc_name, n, abort=.false.)
 
-       if (n.gt.0) then
+       if (n > 0) then
           if ( any( aer_species == m ) .or. isAerosol(n) ) then
              call outfld( solsym(m), mmr(:ncol,:,m), ncol ,lchnk )
              call outfld( trim(solsym(m))//'_SRF', mmr(:ncol,pver,m), ncol ,lchnk )
@@ -829,18 +909,43 @@ contains
              call outfld(trim('cb_'//trim(cloudTracerName)), cb(:ncol), ncol, lchnk)
           endif
 
+         ! Add the column burden of the cloud tracer to the aerosol type cb
+         if ( aerosolType(n) > 0 .and. cloudTracerIndex > 0 ) then
+            ! column burden in terms of aerosol type mass
+            cb_aerosol_type(:ncol,aerosolType(n)) = cb_aerosol_type(:ncol,aerosolType(n)) + cb(:ncol)
+
+            ! column burden in terms of sulfur mass for sulfate aerosol
+            if (aerosolType(n) == AEROSOL_TYPE_SULFATE) then
+               cb_SULFUR_S(:ncol) = cb_SULFUR_S(:ncol) + ( cb(:ncol) * sulfurMassFraction(n) )
+            endif
+         endif
+
           ! Treat column burden (normal tracer)
           mass_tmp(:ncol,:) = mmr(:ncol,:,m) * pdel(:ncol,:) * rgrav
           cb(:ncol) = sum(mass_tmp(:ncol,:),2)
           call outfld(trim('cb_'//trim(spc_name)), cb(:ncol), ncol, lchnk)
+         if ( n == l_so2 .or. n == l_dms ) then
+            call outfld(trim('cb_'//trim(spc_name)//'_S'), ( cb(:ncol) * sulfurMassFraction(n) ), ncol, lchnk)
+         endif
 
-          !Sum column burden per aerosol type
-          if (aerosolType(n) > 0) then
-             cb_aerosol_type(:ncol,aerosolType(n)) = cb_aerosol_type(:ncol,aerosolType(n)) + cb(:ncol)
-             !Total mass mixing ratio of aerosol type
-             mmr_aerosol_type(:ncol,:,aerosolType(n)) = mmr_aerosol_type(:ncol,:,aerosolType(n)) + mmr(:ncol,:,m)
-          endif
+         ! Add the column burden and mass mixing ratio of the interstitial tracers to the aerosol type cb and mmr
+         if (aerosolType(n) > 0) then
+            ! column burden in terms of aerosol type mass
+            cb_aerosol_type(:ncol,aerosolType(n)) = cb_aerosol_type(:ncol,aerosolType(n)) + cb(:ncol)
+            ! column burden in terms of sulfur mass for sulfate aerosol
+            if (aerosolType(n) == AEROSOL_TYPE_SULFATE) then
+               cb_SULFUR_S(:ncol) = cb_SULFUR_S(:ncol) + ( cb(:ncol) * sulfurMassFraction(n) )
+            endif
+
+            !Total mass mixing ratio of aerosol type
+            mmr_aerosol_type(:ncol,:,aerosolType(n)) = mmr_aerosol_type(:ncol,:,aerosolType(n)) + mmr(:ncol,:,m)
+         endif
        end if !Check if this is a chemistry tracer
+
+       call cnst_get_ind(trim(solsym(m)), l_aero, abort=.false.)
+       if ( l_aero == l_so2 ) then
+          DF_SO2(:ncol,lchnk) = DF_SO2(:ncol,lchnk) + depflx(:ncol,m)
+       endif
        ! OSLO_AERO end
 
        if (has_drydep(solsym(m))) then
@@ -911,55 +1016,16 @@ contains
     enddo ! end loop from m=1,gas_pcnst
 
 
-    ! Generate compund sum
-
-    ! SO4_NA, SO4_A1, SO4_A2    SO4_AC, SO4_PR
-    ! BC_N, BC_AX, BC_NI, BC_A, BC_AI ,BC_AC
-    ! OM_NI, OM_AI, OM_AC
-    ! DST_A2, DST_A3
-    ! SS_A1, SS_A2, SS_A3
-    ! SOA_NA, SOA_A1
-    ! H2SO4, SOA_LV,SOA_SV, monoterp, isoprene
-
-    sum_so4(:,:) = 0._r8
-    sum_bc(:,:) = 0._r8
-    sum_om(:,:) = 0._r8
-    sum_dst(:,:) = 0._r8
-    sum_ss(:,:) = 0._r8
-    sum_soa(:,:) = 0._r8
-
-    ! add all the nums in one variable for mam
-
-
-    do m = 1,gas_pcnst
-       spc_name = trim(solsym(m))
-       if (spc_name(1:4) == 'SO4_') then
-          sum_so4(:ncol,:) = sum_so4(:ncol,:) + mmr(:ncol,:,m)
-       else if (spc_name(1:3) == 'BC_') then
-          sum_bc(:ncol,:) = sum_bc(:ncol,:) + mmr(:ncol,:,m)
-       else if (spc_name(1:3) == 'OM_') then
-          sum_om(:ncol,:) = sum_om(:ncol,:) + mmr(:ncol,:,m)
-       else if (spc_name(1:4) == 'DST_') then
-          sum_dst(:ncol,:) = sum_dst(:ncol,:) + mmr(:ncol,:,m)
-       else if (spc_name(1:3) == 'SS_') then
-          sum_ss(:ncol,:) = sum_ss(:ncol,:) + mmr(:ncol,:,m)
-       else if (spc_name(1:4) == 'SOA_') then
-          sum_soa(:ncol,:) = sum_soa(:ncol,:) + mmr(:ncol,:,m)
-       end if
-    end do
-    call outfld( 'sum_SO4'   , sum_so4(:ncol,:)   , ncol ,lchnk )
-    call outfld( 'sum_BC'    , sum_bc(:ncol,:)    , ncol ,lchnk )
-    call outfld( 'sum_OM'    , sum_om(:ncol,:)    , ncol ,lchnk )
-    call outfld( 'sum_DST'   , sum_dst(:ncol,:)   , ncol ,lchnk )
-    call outfld( 'sum_SS'    , sum_ss(:ncol,:)    , ncol ,lchnk )
-    call outfld( 'sum_SOA'   , sum_soa(:ncol,:)   , ncol ,lchnk )
-
     ! OSLO_AERO begin
-    do n=1,N_AEROSOL_TYPES
-       call outfld("mmr_"//trim(aerosol_type_name(n)), mmr_aerosol_type(:ncol,:,n), ncol,lchnk)
-       call outfld("cb_"//trim(aerosol_type_name(n)) , cb_aerosol_type(:ncol,n)   , ncol,lchnk)
-    enddo
-    ! OSLO_AERO end
+    do l_atype=1,N_AEROSOL_TYPES
+      call outfld("mmr_"//trim(aerosol_type_name(l_atype)), mmr_aerosol_type(:ncol,:,l_atype), ncol,lchnk)
+      call outfld("cb_"//trim(aerosol_type_name(l_atype)), cb_aerosol_type(:ncol,l_atype), ncol,lchnk)
+
+      if ( l_atype == AEROSOL_TYPE_SULFATE ) then
+         call outfld("cb_"//trim(aerosol_type_name(l_atype))//'_S', cb_SULFUR_S(:ncol), ncol,lchnk)
+      endif
+   enddo
+   ! OSLO_AERO end
     call outfld( 'NOX',  vmr_nox  (:ncol,:), ncol, lchnk )
     call outfld( 'NOY',  vmr_noy  (:ncol,:), ncol, lchnk )
     call outfld( 'HOX',  vmr_hox  (:ncol,:), ncol, lchnk )
@@ -1098,11 +1164,9 @@ contains
     real(r8), intent(in)  :: het_rates(ncol,pver,max(1,gas_pcnst))
     real(r8), intent(in)  :: mmr(ncol,pver,gas_pcnst)
     real(r8), intent(in)  :: pdel(ncol,pver)
+    real(r8)              :: area(ncol) ! OSLO_AERO end
 
     real(r8), dimension(ncol) :: noy_wk, sox_wk, nhx_wk, wrk_wd
-    ! OSLO_AERO begin
-    real(r8), dimension(ncol) :: area
-    ! OSLO_AERO end
 
     integer :: m, k
     real(r8) :: wght(ncol)
@@ -1134,7 +1198,6 @@ contains
           call outfld( wetdep_name(m), wrk_wd(:ncol), ncol, lchnk )
           ! OSLO_AERO begin
           call outfld( wetdep_name_area(m), wrk_wd(:ncol)/area(:ncol)  ,ncol, lchnk )
-          ! OSLO_AERO end
           call outfld( wtrate_name(m), het_rates(:ncol,:,m), ncol, lchnk )
 
           if ( any(noy_species == m ) ) then

--- a/src_cam/mo_chm_diags.F90
+++ b/src_cam/mo_chm_diags.F90
@@ -538,7 +538,7 @@ contains
        endif
 
       ! OSLO_AERO begin
-      ! Add the 3D consentrations
+      ! Add the 3D concentrations
       if ( n > 0 ) then
          ! if history_aerosol_decomposed we add the aerosol species
          if ( (any( aer_species == m ) .or. isAerosol(n)) ) then
@@ -582,8 +582,8 @@ contains
 
          ! If the aerosol tracer is so2 or dms we add the column burden of the sulfur mass only as well to output
          if ( n == l_so2 .or. n == l_dms ) then
-            call addfld(trim('cb_'//trim(spc_name)//'_S'), horiz_only, 'A', 'kg*S/m2', &
-               'cb_'//trim(spc_name)//' column, sulfur mass only')
+            call addfld(trim('cb_'//trim(spc_name)//'_S'), horiz_only, 'A', 'kg/m2', &
+               'cb_'//trim(spc_name)//' column burden, sulfur mass only')
          endif
 
          ! if the species is an aerosol we require history_aerosol_decomposed flag to output the column burden
@@ -627,10 +627,10 @@ contains
    do l_atype=1,N_AEROSOL_TYPES
       ! add the column burden of the compound aerosols to output
       call addfld('cb_'//trim(aerosol_type_name(l_atype)),horiz_only, 'A', 'kg/m2',&
-         'cb_'//trim(aerosol_type_name(l_atype))//' column of aerosol type')
+         'cb_'//trim(aerosol_type_name(l_atype))//' column burden of aerosol type')
       if ( l_atype == AEROSOL_TYPE_SULFATE ) then
-         call addfld('cb_'//trim(aerosol_type_name(l_atype))//'_S',horiz_only, 'A', 'kg*S/m2',&
-         'cb_'//trim(aerosol_type_name(l_atype))//' column of aerosol, sulfur mass only')
+         call addfld('cb_'//trim(aerosol_type_name(l_atype))//'_S',horiz_only, 'A', 'kg/m2',&
+         'cb_'//trim(aerosol_type_name(l_atype))//' column burden of aerosol, sulfur mass only')
       endif
       ! we require history_aerosol_base flag
       if ( history_aerosol_base ) then

--- a/src_cam/mo_extfrc.F90
+++ b/src_cam/mo_extfrc.F90
@@ -1,0 +1,437 @@
+module mo_extfrc
+  !---------------------------------------------------------------
+  ! 	... insitu forcing module
+  !---------------------------------------------------------------
+
+  use shr_kind_mod,  only : r8 => shr_kind_r8
+  use ppgrid,        only : pver, pverp
+  use chem_mods,     only : extcnt, extfrc_lst, frc_from_dataset, adv_mass
+  use spmd_utils,    only : masterproc
+  use cam_abortutils,only : endrun
+  use cam_history,   only : addfld, outfld, add_default, horiz_only
+  use cam_history_support,only : max_fieldname_len
+  use cam_logfile,   only : iulog
+  use tracer_data,   only : trfld,trfile
+  use mo_constants,  only : avogadro
+  use ioFileMod,     only : getfil
+
+  implicit none
+
+  type :: forcing
+     integer           :: frc_ndx
+     real(r8)          :: scalefactor
+     character(len=265):: filename
+     character(len=16) :: species
+     integer                   :: nsectors
+     character(len=32),pointer :: sectors(:)
+     type(trfld), pointer      :: fields(:)
+     type(trfile)              :: file
+  end type forcing
+
+  private
+  public  :: extfrc_inti
+  public  :: extfrc_set
+  public  :: extfrc_timestep_init
+
+  save
+
+  integer, parameter :: time_span = 1
+
+  character(len=256) ::   filename
+
+  type(forcing), allocatable  :: forcings(:)
+  integer :: n_frc_files = 0
+
+contains
+
+  subroutine extfrc_inti( extfrc_specifier, extfrc_type_in, extfrc_cycle_yr, extfrc_fixed_ymd, extfrc_fixed_tod)
+
+    !-----------------------------------------------------------------------
+    ! 	... initialize the surface forcings
+    !-----------------------------------------------------------------------
+    use cam_pio_utils, only : cam_pio_openfile, cam_pio_closefile
+    use pio,           only : pio_inquire, pio_inq_varndims, pio_inq_dimid
+    use pio,           only : pio_inq_varname, pio_nowrite, file_desc_t
+    use pio,           only : pio_get_att, PIO_NOERR, PIO_GLOBAL
+    use pio,           only : pio_seterrorhandling, PIO_BCAST_ERROR,PIO_INTERNAL_ERROR
+    use mo_chem_utls,  only : get_extfrc_ndx
+    use chem_mods,     only : frc_from_dataset
+    use tracer_data,   only : trcdata_init
+    use phys_control,  only : phys_getopts
+    use string_utils,  only : GLC
+    use m_MergeSorts,  only : IndexSort
+
+    implicit none
+
+    !-----------------------------------------------------------------------
+    ! 	... dummy arguments
+    !-----------------------------------------------------------------------
+    character(len=*), dimension(:), intent(in) :: extfrc_specifier
+    character(len=*), intent(in) :: extfrc_type_in
+    integer  , intent(in)        :: extfrc_cycle_yr
+    integer  , intent(in)        :: extfrc_fixed_ymd
+    integer  , intent(in)        :: extfrc_fixed_tod
+
+    !-----------------------------------------------------------------------
+    ! 	... local variables
+    !-----------------------------------------------------------------------
+    integer :: astat
+    integer :: j, l, m, n, i,mm                          ! Indices
+    character(len=16)  :: spc_name
+    character(len=256) :: frc_fnames(size(extfrc_specifier))
+    real(r8)           :: frc_scalefactor(size(extfrc_specifier))
+    character(len=16)  :: frc_species(size(extfrc_specifier))
+    integer            :: frc_indexes(size(extfrc_specifier))
+    integer            :: indx(size(extfrc_specifier))
+
+    integer ::  vid, ndims, nvars, isec, ierr, num_dims_xfrc, dimid
+    logical, allocatable :: is_sector(:)
+    type(file_desc_t) :: ncid
+    character(len=32)  :: varname
+    logical :: unstructured
+
+    character(len=1), parameter :: filelist = ''
+    character(len=1), parameter :: datapath = ''
+    logical         , parameter :: rmv_file = .false.
+    logical  :: history_aerosol
+    logical  :: history_chemistry
+    logical  :: history_cesm_forcing
+
+    character(len=32) :: extfrc_type = ' '
+    character(len=80) :: file_interp_type = ' '
+    character(len=256) :: tmp_string = ' '
+    character(len=32) :: xchr = ' '
+    real(r8) :: xdbl
+    character(len=256) :: locfn
+
+    !-----------------------------------------------------------------------
+
+    call phys_getopts( &
+         history_aerosol_out = history_aerosol, &
+         history_chemistry_out = history_chemistry, &
+         history_cesm_forcing_out = history_cesm_forcing )
+
+    !-----------------------------------------------------------------------
+    ! 	... species has insitu forcing ?
+    !-----------------------------------------------------------------------
+
+    !write(iulog,*) 'Species with insitu forcings'
+    mm = 0
+    indx(:) = 0
+
+    count_emis: do n=1,size(extfrc_specifier)
+
+       if ( len_trim(extfrc_specifier(n) ) == 0 ) then
+          exit count_emis
+       endif
+
+       i = scan(extfrc_specifier(n),'->')
+       spc_name = trim(adjustl(extfrc_specifier(n)(:i-1)))
+
+       ! need to parse out scalefactor ...
+       tmp_string = adjustl(extfrc_specifier(n)(i+2:))
+       j = scan( tmp_string, '*' )
+       if (j>0) then
+          xchr = tmp_string(1:j-1) ! get the multipler (left of the '*')
+          read( xchr, * ) xdbl   ! convert the string to a real
+          tmp_string = adjustl(tmp_string(j+1:)) ! get the filepath name (right of the '*')
+       else
+          xdbl = 1._r8
+       endif
+       filename = trim(tmp_string)
+
+       m = get_extfrc_ndx( spc_name )
+
+       if ( m < 1 ) then
+          call endrun('extfrc_inti: '//trim(spc_name)// ' does not have an external source')
+       endif
+
+       if ( .not. frc_from_dataset(m) ) then
+          call endrun('extfrc_inti: '//trim(spc_name)//' cannot have external forcing from additional dataset')
+       endif
+
+       mm = mm+1
+       frc_species(mm) = spc_name
+       frc_fnames(mm) = filename
+       frc_indexes(mm) = m
+       frc_scalefactor(mm) = xdbl
+
+       indx(n)=n
+
+    enddo count_emis
+
+    n_frc_files = mm
+
+    if( n_frc_files < 1 ) then
+       if (masterproc) write(iulog,*) 'There are no species with insitu forcings'
+       return
+    end if
+
+    if (masterproc) write(iulog,*) ' '
+
+    !-----------------------------------------------------------------------
+    ! 	... allocate forcings type array
+    !-----------------------------------------------------------------------
+    allocate( forcings(n_frc_files), stat=astat )
+    if( astat/= 0 ) then
+       write(iulog,*) 'extfrc_inti: failed to allocate forcings array; error = ',astat
+       call endrun('extfrc_inti: failed to allocate forcings array')
+    end if
+
+    !-----------------------------------------------------------------------
+    ! Sort the input files so that the emissions sources are summed in the
+    ! same order regardless of the order of the input files in the namelist
+    !-----------------------------------------------------------------------
+    if (n_frc_files > 0) then
+       call IndexSort(n_frc_files, indx, frc_fnames)
+    end if
+
+    !-----------------------------------------------------------------------
+    ! 	... setup the forcing type array
+    !-----------------------------------------------------------------------
+    do m=1,n_frc_files
+       forcings(m)%frc_ndx     = frc_indexes(indx(m))
+       forcings(m)%species     = frc_species(indx(m))
+       forcings(m)%filename    = frc_fnames(indx(m))
+       forcings(m)%scalefactor = frc_scalefactor(indx(m))
+    enddo
+
+    do n= 1,extcnt
+       if (frc_from_dataset(n)) then
+          spc_name = extfrc_lst(n)
+          call addfld( trim(spc_name)//'_XFRC', (/ 'lev' /), 'A',  'molec/cm3/s', &
+               'external forcing for '//trim(spc_name) )
+          call addfld( trim(spc_name)//'_CLXF', horiz_only,  'A',  'molec/cm2/s', &
+               'vertically intergrated external forcing for '//trim(spc_name) )
+          call addfld( trim(spc_name)//'_CMXF', horiz_only,  'A',  'kg/m2/s', &
+               'vertically intergrated external forcing for '//trim(spc_name) )
+          if ( history_aerosol .or. history_chemistry ) then
+             call add_default( trim(spc_name)//'_CLXF', 1, ' ' )
+             call add_default( trim(spc_name)//'_CMXF', 1, ' ' )
+          endif
+          if ( history_cesm_forcing .and. spc_name == 'NO2' ) then
+             call add_default( trim(spc_name)//'_CLXF', 1, ' ' )
+             call add_default( trim(spc_name)//'_CMXF', 1, ' ' )
+          endif
+       endif
+    enddo
+
+    if (masterproc) then
+       !-----------------------------------------------------------------------
+       ! 	... diagnostics
+       !-----------------------------------------------------------------------
+       write(iulog,*) ' '
+       write(iulog,*) 'extfrc_inti: diagnostics'
+       write(iulog,*) ' '
+       write(iulog,*) 'extfrc timing specs'
+       write(iulog,*) 'type = ',extfrc_type
+       if( extfrc_type == 'FIXED' ) then
+          write(iulog,*) ' fixed date = ', extfrc_fixed_ymd
+          write(iulog,*) ' fixed time = ', extfrc_fixed_tod
+       else if( extfrc_type == 'CYCLICAL' ) then
+          write(iulog,*) ' cycle year = ',extfrc_cycle_yr
+       end if
+       write(iulog,*) ' '
+       write(iulog,*) 'there are ',n_frc_files,' species with external forcing files'
+       do m = 1,n_frc_files
+          write(iulog,*) ' '
+          write(iulog,*) 'forcing type ',m
+          write(iulog,*) 'species = ',trim(forcings(m)%species)
+          write(iulog,*) 'frc ndx = ',forcings(m)%frc_ndx
+          write(iulog,*) 'filename= ',trim(forcings(m)%filename)
+       end do
+       write(iulog,*) ' '
+    endif
+
+    !-----------------------------------------------------------------------
+    ! read emis files to determine number of sectors
+    !-----------------------------------------------------------------------
+    frcing_loop: do m = 1, n_frc_files
+
+       forcings(m)%nsectors = 0
+
+       if (masterproc) then
+          write(iulog,'(a,i3,a)') 'extfrc_inti m: ',m,' init file : '//trim(forcings(m)%filename)
+       endif
+
+       call getfil (forcings(m)%filename, locfn, 0)
+       call cam_pio_openfile ( ncid, trim(locfn), PIO_NOWRITE)
+       ierr = pio_inquire (ncid, nVariables=nvars)
+
+       call pio_seterrorhandling(ncid, PIO_BCAST_ERROR)
+       ierr = pio_inq_dimid( ncid, 'ncol', dimid )
+       unstructured = ierr==PIO_NOERR
+       call pio_seterrorhandling(ncid, PIO_INTERNAL_ERROR)
+
+       allocate(is_sector(nvars))
+       is_sector(:) = .false.
+
+       do vid = 1,nvars
+
+          ierr = pio_inq_varndims (ncid, vid, ndims)
+          if (unstructured) then
+             num_dims_xfrc = 3
+          else
+             num_dims_xfrc = 4
+          endif
+
+          if( ndims < num_dims_xfrc ) then
+             cycle
+          elseif( ndims > num_dims_xfrc ) then
+             ierr = pio_inq_varname (ncid, vid, varname)
+             write(iulog,*) 'extfrc_inti: Skipping variable ', trim(varname),', ndims = ',ndims, &
+                  ' , species=',trim(forcings(m)%species)
+             cycle
+          end if
+
+          forcings(m)%nsectors = forcings(m)%nsectors+1
+          is_sector(vid)=.true.
+
+       enddo
+
+       allocate( forcings(m)%sectors(forcings(m)%nsectors), stat=astat )
+       if( astat/= 0 ) then
+         write(iulog,*) 'extfrc_inti: failed to allocate forcings(m)%sectors array; error = ',astat
+         call endrun
+       end if
+
+       isec = 1
+       do vid = 1,nvars
+          if( is_sector(vid) ) then
+             ierr = pio_inq_varname(ncid, vid, forcings(m)%sectors(isec))
+             isec = isec+1
+          endif
+       enddo
+       deallocate(is_sector)
+
+       ! Global attribute 'input_method' overrides the ext_frc_type namelist setting on
+       ! a file-by-file basis.  If the ext_frc file does not contain the 'input_method'
+       ! attribute then the ext_frc_type namelist setting is used.
+       call pio_seterrorhandling(ncid, PIO_BCAST_ERROR)
+       ierr = pio_get_att(ncid, PIO_GLOBAL, 'input_method', file_interp_type)
+       call pio_seterrorhandling(ncid, PIO_INTERNAL_ERROR)
+       if ( ierr == PIO_NOERR) then
+          l = GLC(file_interp_type)
+          extfrc_type(1:l) = file_interp_type(1:l)
+          extfrc_type(l+1:) = ' '
+       else
+          extfrc_type = trim(extfrc_type_in)
+       endif
+
+       call cam_pio_closefile (ncid)
+
+       allocate(forcings(m)%file%in_pbuf(size(forcings(m)%sectors)))
+       forcings(m)%file%in_pbuf(:) = .false.
+       call trcdata_init( forcings(m)%sectors, &
+                          forcings(m)%filename, filelist, datapath, &
+                          forcings(m)%fields,  &
+                          forcings(m)%file, &
+                          rmv_file, extfrc_cycle_yr, extfrc_fixed_ymd, extfrc_fixed_tod, trim(extfrc_type) )
+
+    enddo frcing_loop
+
+
+  end subroutine extfrc_inti
+
+  subroutine extfrc_timestep_init( pbuf2d, state )
+    !-----------------------------------------------------------------------
+    !       ... check serial case for time span
+    !-----------------------------------------------------------------------
+
+    use physics_types,only : physics_state
+    use ppgrid,       only : begchunk, endchunk
+    use tracer_data,  only : advance_trcdata
+    use physics_buffer, only : physics_buffer_desc
+
+    implicit none
+
+    type(physics_state), intent(in):: state(begchunk:endchunk)
+    type(physics_buffer_desc), pointer :: pbuf2d(:,:)
+
+    !-----------------------------------------------------------------------
+    !       ... local variables
+    !-----------------------------------------------------------------------
+    integer :: m
+
+    do m = 1,n_frc_files
+       call advance_trcdata( forcings(m)%fields, forcings(m)%file, state, pbuf2d  )
+    end do
+
+  end subroutine extfrc_timestep_init
+
+  subroutine extfrc_set( lchnk, zint, frcing, ncol )
+
+    !--------------------------------------------------------
+    !	... form the external forcing
+    !--------------------------------------------------------
+    use mo_chem_utls,  only : get_spc_ndx
+
+    implicit none
+
+    !--------------------------------------------------------
+    !	... dummy arguments
+    !--------------------------------------------------------
+    integer,  intent(in)    :: ncol                  ! columns in chunk
+    integer,  intent(in)    :: lchnk                 ! chunk index
+    real(r8), intent(in)    :: zint(ncol, pverp)                  ! interface geopot above surface (km)
+    real(r8), intent(inout) :: frcing(ncol,pver,extcnt)   ! insitu forcings (molec/cm^3/s)
+
+    !--------------------------------------------------------
+    !	... local variables
+    !--------------------------------------------------------
+    integer  ::  m, n
+    character(len=max_fieldname_len) :: xfcname
+    real(r8) :: frcing_col(1:ncol), frcing_col_kg(1:ncol)
+    integer  :: k, isec
+    real(r8),parameter :: km_to_cm = 1.e5_r8
+    real(r8),parameter :: cm2_to_m2 = 1.e4_r8
+    real(r8),parameter :: kg_to_g = 1.e-3_r8
+    real(r8) :: molec_to_kg
+    integer  :: spc_ndx
+
+    if( n_frc_files < 1 .or. extcnt < 1 ) then
+       return
+    end if
+
+    frcing(:,:,:) = 0._r8
+
+    !--------------------------------------------------------
+    !	... set non-zero forcings
+    !--------------------------------------------------------
+    file_loop : do m = 1,n_frc_files
+
+       n = forcings(m)%frc_ndx
+
+       do isec = 1,forcings(m)%nsectors
+          frcing(:ncol,:,n) = frcing(:ncol,:,n) + forcings(m)%scalefactor*forcings(m)%fields(isec)%data(:ncol,:,lchnk)
+       enddo
+
+    enddo file_loop
+
+    frc_loop : do n = 1,extcnt
+       if (frc_from_dataset(n)) then
+
+          xfcname = trim(extfrc_lst(n))//'_XFRC'
+          call outfld( xfcname, frcing(:ncol,:,n), ncol, lchnk )
+
+          spc_ndx = get_spc_ndx( extfrc_lst(n) )
+          molec_to_kg = adv_mass( spc_ndx ) / avogadro *cm2_to_m2 * kg_to_g
+
+          frcing_col(:ncol) = 0._r8
+          frcing_col_kg(:ncol) = 0._r8
+          do k = 1,pver
+             frcing_col(:ncol) = frcing_col(:ncol) + frcing(:ncol,k,n)*(zint(:ncol,k)-zint(:ncol,k+1))*km_to_cm
+             frcing_col_kg(:ncol) = frcing_col_kg(:ncol) + frcing(:ncol,k,n)*(zint(:ncol,k)-zint(:ncol,k+1))*km_to_cm*molec_to_kg
+          enddo
+
+          xfcname = trim(extfrc_lst(n))//'_CLXF'
+          call outfld( xfcname, frcing_col(:ncol), ncol, lchnk )
+          xfcname = trim(extfrc_lst(n))//'_CMXF'
+          call outfld( xfcname, frcing_col_kg(:ncol), ncol, lchnk )
+       endif
+    end do frc_loop
+
+  end subroutine extfrc_set
+
+
+end module mo_extfrc

--- a/src_cam/mo_extfrc.F90
+++ b/src_cam/mo_extfrc.F90
@@ -14,6 +14,10 @@ module mo_extfrc
   use tracer_data,   only : trfld,trfile
   use mo_constants,  only : avogadro
   use ioFileMod,     only : getfil
+  ! OSLO_AERO begin
+  use constituents,  only : pcnst
+  use ppgrid,        only : pcols, begchunk, endchunk
+  ! OSLO_AERO end
 
   implicit none
 
@@ -41,6 +45,14 @@ module mo_extfrc
 
   type(forcing), allocatable  :: forcings(:)
   integer :: n_frc_files = 0
+  ! OSLO_AERO begin
+  ! CMXF summations used for emission fields summed in oslo_aero_share.F90-summation_fields_writeout()
+  ! BC_CMXF = BC_AX_XMCF + BC_NI_CMXF + BC_N_CMXF, we use l_bc_ax, l_bc_ni, l_bc_n for logic
+  ! OM_NI_CMXF = OM_NI_CMXF, we use l_om_ni for logic
+  ! SO2_CMXF = SO2_CMXF, we use l_so2 for logic
+  ! SO4_PR_CMXF = SO4_PR_CMXF, we use l_so4_pr for logic
+  real(r8), public, protected, allocatable   :: CMXF_fields(:,:,:)
+  ! OSLO_AERO end
 
 contains
 
@@ -60,6 +72,10 @@ contains
     use phys_control,  only : phys_getopts
     use string_utils,  only : GLC
     use m_MergeSorts,  only : IndexSort
+    ! OSLO_AERO begin
+    use phys_control,  only : history_aerosol_decomposed
+    use string_utils,  only : int2str
+    ! OSLO_AERO end
 
     implicit none
 
@@ -178,6 +194,17 @@ contains
        call endrun('extfrc_inti: failed to allocate forcings array')
     end if
 
+   ! OSLO_AERO begin
+   !-----------------------------------------------------------------------
+   ! 	... allocate  array for CMXF data transfer
+   !-----------------------------------------------------------------------
+   allocate( CMXF_fields(pcols, pcnst, begchunk:endchunk), stat=astat )
+   if( astat/= 0 ) then
+      call endrun('extfrc_inti: failed to allocate CMXF_fields array; error = '//int2str(astat))
+   end if
+   CMXF_fields(:,:,:) = 0.0_r8
+   ! OSLO_AERO end
+
     !-----------------------------------------------------------------------
     ! Sort the input files so that the emissions sources are summed in the
     ! same order regardless of the order of the input files in the namelist
@@ -205,7 +232,7 @@ contains
                'vertically intergrated external forcing for '//trim(spc_name) )
           call addfld( trim(spc_name)//'_CMXF', horiz_only,  'A',  'kg/m2/s', &
                'vertically intergrated external forcing for '//trim(spc_name) )
-          if ( history_aerosol .or. history_chemistry ) then
+          if ( history_aerosol .or. history_chemistry .or. history_aerosol_decomposed) then
              call add_default( trim(spc_name)//'_CLXF', 1, ' ' )
              call add_default( trim(spc_name)//'_CMXF', 1, ' ' )
           endif
@@ -364,7 +391,10 @@ contains
     !--------------------------------------------------------
     !	... form the external forcing
     !--------------------------------------------------------
-    use mo_chem_utls,  only : get_spc_ndx
+    use mo_chem_utls,      only : get_spc_ndx
+    ! OSLO_AERO begin
+    use constituents,      only : cnst_get_ind
+    use oslo_aero_share,   only : l_bc_ax, l_bc_ni, l_bc_n, l_om_ni, l_so2, l_so4_pr
 
     implicit none
 
@@ -388,12 +418,14 @@ contains
     real(r8),parameter :: kg_to_g = 1.e-3_r8
     real(r8) :: molec_to_kg
     integer  :: spc_ndx
+    integer  :: l_aero     ! OSLO_AERO
 
     if( n_frc_files < 1 .or. extcnt < 1 ) then
        return
     end if
 
     frcing(:,:,:) = 0._r8
+    CMXF_fields(:ncol,:,lchnk) = 0.0_r8 ! OSLO_AERO
 
     !--------------------------------------------------------
     !	... set non-zero forcings
@@ -423,6 +455,23 @@ contains
              frcing_col(:ncol) = frcing_col(:ncol) + frcing(:ncol,k,n)*(zint(:ncol,k)-zint(:ncol,k+1))*km_to_cm
              frcing_col_kg(:ncol) = frcing_col_kg(:ncol) + frcing(:ncol,k,n)*(zint(:ncol,k)-zint(:ncol,k+1))*km_to_cm*molec_to_kg
           enddo
+
+         !OSLO_AERO begin
+         ! get the index of the forcing index that coresponds to the l_spc system
+         call cnst_get_ind(trim(extfrc_lst(n)), l_aero, abort=.false.)
+         if ( l_aero == l_bc_ax .or. l_aero == l_bc_ni .or. l_aero == l_bc_n .or. &
+            l_aero == l_om_ni .or. l_aero == l_so2 .or. l_aero == l_so4_pr ) then
+            if ( masterproc ) then
+               write(iulog,*) 'extfrc_set: adding forcing for ',trim(extfrc_lst(n)), &
+                  'l_aero = ',l_aero,', l_bc_ax = ',l_bc_ax, &
+                  ', l_bc_ni = ',l_bc_ni,', l_bc_n = ', l_bc_n, &
+                  ', l_om_ni = ',l_om_ni, &
+                  ', l_so2 = ',l_so2,', l_so4_pr = ',l_so4_pr
+            end if
+            ! add the forcing to the CMXF_fields array
+            CMXF_fields(:ncol,l_aero,lchnk) = CMXF_fields(:ncol,l_aero,lchnk) + frcing_col_kg(:ncol)
+         end if
+         !OSLO_AERO end
 
           xfcname = trim(extfrc_lst(n))//'_CLXF'
           call outfld( xfcname, frcing_col(:ncol), ncol, lchnk )

--- a/src_cam/mo_extfrc.F90
+++ b/src_cam/mo_extfrc.F90
@@ -461,13 +461,6 @@ contains
          call cnst_get_ind(trim(extfrc_lst(n)), l_aero, abort=.false.)
          if ( l_aero == l_bc_ax .or. l_aero == l_bc_ni .or. l_aero == l_bc_n .or. &
             l_aero == l_om_ni .or. l_aero == l_so2 .or. l_aero == l_so4_pr ) then
-            if ( masterproc ) then
-               write(iulog,*) 'extfrc_set: adding forcing for ',trim(extfrc_lst(n)), &
-                  'l_aero = ',l_aero,', l_bc_ax = ',l_bc_ax, &
-                  ', l_bc_ni = ',l_bc_ni,', l_bc_n = ', l_bc_n, &
-                  ', l_om_ni = ',l_om_ni, &
-                  ', l_so2 = ',l_so2,', l_so4_pr = ',l_so4_pr
-            end if
             ! add the forcing to the CMXF_fields array
             CMXF_fields(:ncol,l_aero,lchnk) = CMXF_fields(:ncol,l_aero,lchnk) + frcing_col_kg(:ncol)
          end if

--- a/src_cam/mo_gas_phase_chemdr.F90
+++ b/src_cam/mo_gas_phase_chemdr.F90
@@ -8,6 +8,7 @@ module mo_gas_phase_chemdr
   use chem_mods,        only : rxt_tag_cnt, rxt_tag_lst, rxt_tag_map, extcnt, num_rnts
   use ppgrid,           only : pcols, pver
   use phys_control,     only : phys_getopts
+  use phys_control,     only : history_aerosol_forcing ! OSLO_AERO
   use carma_flags_mod,  only : carma_hetchem_feedback
   use chem_prod_loss_diags, only: chem_prod_loss_diags_init, chem_prod_loss_diags_out
 
@@ -222,12 +223,14 @@ contains
     call addfld ('HO2_aft   ',  (/ 'lev' /), 'A','unit', 'HO2 invariants after adding diurnal variations'           )
     call addfld ('NO3_aft   ',  (/ 'lev' /), 'A','unit', 'NO3 invariants after adding diurnal variations'           )
 
-    call add_default ('OH_bef       ', 1, ' ')
-    call add_default ('HO2_bef      ', 1, ' ')
-    call add_default ('NO3_bef      ', 1, ' ')
-    call add_default ('OH_aft       ', 1, ' ')
-    call add_default ('HO2_aft      ', 1, ' ')
-    call add_default ('NO3_aft      ', 1, ' ')
+    if ( history_aerosol_forcing ) then
+      call add_default ('OH_bef       ', 1, ' ')
+      call add_default ('HO2_bef      ', 1, ' ')
+      call add_default ('NO3_bef      ', 1, ' ')
+      call add_default ('OH_aft       ', 1, ' ')
+      call add_default ('HO2_aft      ', 1, ' ')
+      call add_default ('NO3_aft      ', 1, ' ')
+    endif
     ! OSLO_AERO end
 
     if (het1_ndx>0) then

--- a/src_cam/mo_neu_wetdep.F90
+++ b/src_cam/mo_neu_wetdep.F90
@@ -25,8 +25,6 @@ module mo_neu_wetdep
   public :: neu_wetdep_init
   public :: neu_wetdep_tend
 !
-  save
-!
   integer, allocatable, dimension(:) :: mapping_to_heff,mapping_to_mmr
   real(r8),allocatable, dimension(:) :: mol_weight
   logical ,allocatable, dimension(:) :: ice_uptake
@@ -264,7 +262,7 @@ subroutine neu_wetdep_tend(lchnk,ncol,mmr,pmid,pdel,zint,tfld,delt,   &
   use ppgrid,           only : pcols, pver
   use phys_grid,        only : get_area_all_p, get_rlat_all_p
   use shr_const_mod,    only : SHR_CONST_REARTH,SHR_CONST_G
-  use cam_history,      only : outfld
+  use cam_history,      only : outfld, hist_fld_active
   use shr_const_mod,    only : pi => shr_const_pi
   ! OSLO_AERO begin
   use oslo_aero_share,  only : sulfurMassFraction
@@ -273,9 +271,7 @@ subroutine neu_wetdep_tend(lchnk,ncol,mmr,pmid,pdel,zint,tfld,delt,   &
   use constituents,     only : cnst_get_ind
   use mo_tracname,      only : solsym
   ! OSLO_AERO end
-!
-  implicit none
-!
+
   integer,        intent(in)    :: lchnk,ncol
   real(r8),       intent(in)    :: mmr(pcols,pver,pcnst)    ! mass mixing ratio (kg/kg)
   real(r8),       intent(in)    :: pmid(pcols,pver)         ! midpoint pressures (Pa)
@@ -324,6 +320,7 @@ subroutine neu_wetdep_tend(lchnk,ncol,mmr,pmid,pdel,zint,tfld,delt,   &
   real(r8)            :: wrk_wd(pcols)
   integer             :: l_aero
   real(r8), pointer   :: wd_a_h2so4(:)
+  logical,            :: computed_wrd_wd
   ! OSLO_AERO end
 !
 ! from cam/src/physics/cam/stratiform.F90
@@ -526,21 +523,26 @@ subroutine neu_wetdep_tend(lchnk,ncol,mmr,pmid,pdel,zint,tfld,delt,   &
   ! OSLO_AERO begin
   !This is output normally in mo_chm_diags, but if neu wetdep, we have to output it here!
   do m=1,gas_wetdep_cnt
-    wrk_wd(:ncol) = 0.0_r8
-    do k=1,pver
+    if ((l_aero == l_so2) .or. (l_aero == l_h2so4) .or.                    &
+         hist_fld_active('WD_A_'//trim(gas_wetdep_list(m)))) then
+      wrk_wd(:ncol) = 0.0_r8
+      do k=1,pver
         !Note sign: tendency is negative, so this becomes a positive flux!
         wrk_wd(:ncol) = wrk_wd(:ncol) - wd_tend(1:ncol,k,mapping_to_mmr(m))*pdel(:ncol,k)*rgrav !kg/m2/sec
-    end do
+      end do
+      computed_wrd_wd = .true.
+   else
+     computed_wrd_wd = .false.
+    end if
 
     ! get the index of the gas species that coresponds to the l_spcies system
     call cnst_get_ind(trim(gas_wetdep_list(m)), l_aero, abort=.false.)
 
-    call outfld('WD_A_'//trim(gas_wetdep_list(m)),wrk_wd(:ncol),ncol,lchnk)
+    if (computed_wrd_wd) then
+      call outfld('WD_A_'//trim(gas_wetdep_list(m)),wrk_wd(:ncol),ncol,lchnk)
+    end if
 
-    if ( l_aero == l_so2 ) then
-
-      if ( masterproc ) write(iulog,*) 'OSLO_AERO, mo_neu_wetdep, line 546: l_aero = l_so2, outputting wet_SO2 and wet_SO2_S', &
-        'gas_wetdep_list(m) = ', trim(gas_wetdep_list(m))
+    if ((l_aero == l_so2) .and. computed_wrd_wd) then
 
       call outfld('wet_SO2', wrk_wd(:ncol), ncol, lchnk)
       call outfld('wet_SO2_S', ( wrk_wd(:ncol) * sulfurMassFraction(l_so2) ), ncol, lchnk)
@@ -550,25 +552,17 @@ subroutine neu_wetdep_tend(lchnk,ncol,mmr,pmid,pdel,zint,tfld,delt,   &
 
     ! Save the WD_A field to the wd_a_h2so4 pointer if l_aero == l_h2so4
     ! this field is passed to the pbuf
-    if (l_aero == l_h2so4) then
-
-      if ( masterproc ) write(iulog,*) 'OSLO_AERO, mo_neu_wetdep, line 559: l_aero = l_h2so4, outputting wd_a_h2so4', &
-        ' to the pbuf gas_wetdep_list(m) = ', trim(gas_wetdep_list(m))
+    if ((l_aero == l_h2so4) .and. computed_wrd_wd) then
 
       idx_wd_a_h2so4 = pbuf_get_index('WD_A_H2SO4')
 
-      if ( masterproc ) write(iulog,*) 'OSLO_AERO, mo_neu_wetdep, line 564: idx_wd_a_h2so4 = ', idx_wd_a_h2so4
       call pbuf_get_field(pbuf, idx_wd_a_h2so4, wd_a_h2so4)
-      if ( masterproc ) write(iulog,*) 'OSLO_AERO, mo_neu_wetdep, line 567: pbuf_get_field for wd_a_h2so4 done', &
-        ' idx_wd_a_h2so4 = ', idx_wd_a_h2so4, ' wd_a_h2so4 size = ', size(wd_a_h2so4)
 
       wd_a_h2so4(:ncol) = wrk_wd(:ncol)
-      if ( masterproc ) write(iulog,*) 'OSLO_AERO, mo_neu_wetdep, line 569: write wrk_wd to wd_a_h2so4(:ncol)'
-    end if
 
+    end if
   end do
   ! OSLO_AERO end
-
 
   if ( do_diag ) then
     call outfld('QT_RAIN_HNO3', qt_rain, ncol, lchnk )
@@ -591,7 +585,6 @@ end subroutine neu_wetdep_tend
       RLS,CLWC,CIWC,CFR,TEM,EVAPRATE,GAREA,HSTAR,TCMASS,TCKAQB, &
       TCNION, qt_rain, qt_rime, qt_wash, qt_evap)
 !
-      implicit none
 
 !-----------------------------------------------------------------------
 !---p-conde 5.4 (2007)   -----called from main-----
@@ -1650,7 +1643,6 @@ upper_level : &
 !---------------------------------------------------------------------
       subroutine DISGAS (CLWX,CFX,MOLMASS,HSTAR,TM,PR,QM,QT,QTDIS)
 !---------------------------------------------------------------------
-      implicit none
       real(r8), intent(in) :: CLWX,CFX    !cloud water,cloud fraction
       real(r8), intent(in) :: MOLMASS     !molecular mass of tracer
       real(r8), intent(in) :: HSTAR       !Henry's Law coeffs A*exp(-B/T)
@@ -1699,7 +1691,6 @@ upper_level : &
 !---
 !---Does NOT now use RMC (moist conv rain) but could, assuming 30% coverage
 !-----------------------------------------------------------------------
-      implicit none
       real(r8), intent(in) :: RRAIN       !new rain formation in box (kg/s)
       real(r8), intent(in) :: DTSCAV      !time step (s)
       real(r8), intent(in) :: CLWX,CFX !cloud water and cloud fraction
@@ -1741,7 +1732,6 @@ upper_level : &
 !---ALSO the possible formation of other soluble species from, eg, CH2O, H2O2
 !---   can be considered with enhanced values of KHA.
 !-----------------------------------------------------------------------
-      implicit none
       real(r8), intent(in)  :: RWASH   ! precip leaving bottom of box (kg/s)
       real(r8), intent(in)  :: BOXF   ! fraction of box with washout
       real(r8), intent(in)  :: DTSCAV  ! time step (s)
@@ -1796,7 +1786,6 @@ upper_level : &
 !-----------------------------------------------------------------------
       use shr_spfn_mod, only: shr_spfn_gamma
 
-      implicit none
       real(r8), intent(in)  :: CWATER
       real(r8), intent(in)  :: RRATE
 

--- a/src_cam/mo_neu_wetdep.F90
+++ b/src_cam/mo_neu_wetdep.F90
@@ -320,7 +320,7 @@ subroutine neu_wetdep_tend(lchnk,ncol,mmr,pmid,pdel,zint,tfld,delt,   &
   real(r8)            :: wrk_wd(pcols)
   integer             :: l_aero
   real(r8), pointer   :: wd_a_h2so4(:)
-  logical,            :: computed_wrd_wd
+  logical             :: computed_wrk_wd
   ! OSLO_AERO end
 !
 ! from cam/src/physics/cam/stratiform.F90
@@ -334,7 +334,7 @@ subroutine neu_wetdep_tend(lchnk,ncol,mmr,pmid,pdel,zint,tfld,delt,   &
 !
 ! reset output variables
 !
-   wd_tend_int = 0._r8
+   wd_tend_int(:,:) = 0._r8
    WD_A_SO2_NEU(:ncol,lchnk) = 0._r8 ! OSLO_AERO
 !
 ! get area (in radians square)
@@ -523,6 +523,9 @@ subroutine neu_wetdep_tend(lchnk,ncol,mmr,pmid,pdel,zint,tfld,delt,   &
   ! OSLO_AERO begin
   !This is output normally in mo_chm_diags, but if neu wetdep, we have to output it here!
   do m=1,gas_wetdep_cnt
+    ! get the index of the gas species that coresponds to the l_species system
+    call cnst_get_ind(trim(gas_wetdep_list(m)), l_aero, abort=.false.)
+
     if ((l_aero == l_so2) .or. (l_aero == l_h2so4) .or.                    &
          hist_fld_active('WD_A_'//trim(gas_wetdep_list(m)))) then
       wrk_wd(:ncol) = 0.0_r8
@@ -530,19 +533,19 @@ subroutine neu_wetdep_tend(lchnk,ncol,mmr,pmid,pdel,zint,tfld,delt,   &
         !Note sign: tendency is negative, so this becomes a positive flux!
         wrk_wd(:ncol) = wrk_wd(:ncol) - wd_tend(1:ncol,k,mapping_to_mmr(m))*pdel(:ncol,k)*rgrav !kg/m2/sec
       end do
-      computed_wrd_wd = .true.
+      computed_wrk_wd = .true.
    else
-     computed_wrd_wd = .false.
+     computed_wrk_wd = .false.
     end if
 
-    ! get the index of the gas species that coresponds to the l_spcies system
-    call cnst_get_ind(trim(gas_wetdep_list(m)), l_aero, abort=.false.)
-
-    if (computed_wrd_wd) then
+    if (computed_wrk_wd) then
       call outfld('WD_A_'//trim(gas_wetdep_list(m)),wrk_wd(:ncol),ncol,lchnk)
     end if
 
-    if ((l_aero == l_so2) .and. computed_wrd_wd) then
+    if (l_aero == l_so2) then
+      if (.not. computed_wrk_wd) then
+        call endrun('neu_wetdep_tend: Internal ERROR for l_so2, wrk_wd')
+      end if
 
       call outfld('wet_SO2', wrk_wd(:ncol), ncol, lchnk)
       call outfld('wet_SO2_S', ( wrk_wd(:ncol) * sulfurMassFraction(l_so2) ), ncol, lchnk)
@@ -552,7 +555,10 @@ subroutine neu_wetdep_tend(lchnk,ncol,mmr,pmid,pdel,zint,tfld,delt,   &
 
     ! Save the WD_A field to the wd_a_h2so4 pointer if l_aero == l_h2so4
     ! this field is passed to the pbuf
-    if ((l_aero == l_h2so4) .and. computed_wrd_wd) then
+    if (l_aero == l_h2so4) then
+       if (.not. computed_wrk_wd) then
+        call endrun('neu_wetdep_tend: Internal ERROR for l_h2so4, wrk_wd')
+      end if
 
       idx_wd_a_h2so4 = pbuf_get_index('WD_A_H2SO4')
 

--- a/src_cam/mo_neu_wetdep.F90
+++ b/src_cam/mo_neu_wetdep.F90
@@ -34,6 +34,10 @@ module mo_neu_wetdep
   integer                     :: so4_ndx,so4s_ndx ! geos-chem
   logical                     :: debug   = .false.
   integer                     :: hno3_ndx = 0
+  ! OSLO_AERO begin
+  real(r8), public, protected, allocatable   :: WD_A_SO2_NEU(:,:)
+  integer                                    :: idx_wd_a_h2so4 = -1
+  ! OSLO_AERO end
 !
 ! diagnostics
 !
@@ -57,11 +61,19 @@ subroutine neu_wetdep_init
   use constituents, only : cnst_get_ind,cnst_mw
   use cam_history,  only : addfld, add_default, horiz_only
   use phys_control, only : phys_getopts, cam_chempkg_is
+  ! OSLO_AERO begin
+  use string_utils, only : int2str
+  use ppgrid,       only : pcols, begchunk, endchunk
+  use phys_control, only : history_aerosol_base
+  ! OSLO_AERO end
 !
   integer :: m,l
   character*20 :: test_name
 
   logical :: history_chemistry
+  ! OSLO_AERO begin
+  integer :: astat
+  ! OSLO_AERO end
 
   call phys_getopts(history_chemistry_out=history_chemistry)
 
@@ -73,6 +85,14 @@ subroutine neu_wetdep_init
   allocate( mapping_to_mmr(gas_wetdep_cnt) )
   allocate( ice_uptake(gas_wetdep_cnt) )
   allocate( mol_weight(gas_wetdep_cnt) )
+
+  ! OSLO_AERO begin
+  allocate( WD_A_SO2_NEU(pcols, begchunk:endchunk), stat=astat )
+  if( astat/= 0 ) then
+    call endrun('neu_wetdep_init: failed to allocate WD_A_SO2 array; error = '//int2str(astat))
+  end if
+  WD_A_SO2_NEU(:,:) = 0.0_r8
+  ! OSLO_AERO end
 
 !
 ! find mapping to heff table
@@ -207,6 +227,17 @@ subroutine neu_wetdep_init
     end if
   end do
 !
+! OSLO_AERO begin
+  call addfld ('wet_SO2', horiz_only, 'A',  'kg/m2/s',   &
+    'SO2 wet deposition flux at surface.')
+  call addfld ('wet_SO2_S', horiz_only, 'A',  'kg*S/m2/s',   &
+    'SO2 wet deposition flux at surface, sulfur mass only.')
+
+  if ( history_aerosol_base ) then
+      call add_default( 'wet_SO2', 1, ' ' )
+      call add_default( 'wet_SO2_S', 1, ' ' )
+  end if
+! OSLO_AERO end
   if ( do_diag ) then
     call addfld     ('QT_RAIN_HNO3',(/ 'lev' /), 'A','mol/mol/s','wet removal Neu scheme rain tendency')
     call addfld     ('QT_RIME_HNO3',(/ 'lev' /), 'A','mol/mol/s','wet removal Neu scheme rain tendency')
@@ -225,13 +256,20 @@ subroutine neu_wetdep_init
 end subroutine neu_wetdep_init
 !
 subroutine neu_wetdep_tend(lchnk,ncol,mmr,pmid,pdel,zint,tfld,delt, &
-     prain, nevapr, cld, cmfdqr, wd_tend, wd_tend_int)
+     prain, nevapr, cld, cmfdqr, wd_tend, wd_tend_int )
 !
   use ppgrid,           only : pcols, pver
   use phys_grid,        only : get_area_all_p, get_rlat_all_p
   use shr_const_mod,    only : SHR_CONST_REARTH,SHR_CONST_G
   use cam_history,      only : outfld
   use shr_const_mod,    only : pi => shr_const_pi
+  ! OSLO_AERO begin
+  use oslo_aero_share,  only : sulfurMassFraction
+  use oslo_aero_share,  only : l_so2, l_h2so4
+  !use physics_buffer,   only : physics_buffer_desc, pbuf_get_field, pbuf_get_index
+  use constituents,     only : cnst_get_ind
+  use mo_tracname,      only : solsym
+  ! OSLO_AERO end
 !
   implicit none
 !
@@ -249,6 +287,9 @@ subroutine neu_wetdep_tend(lchnk,ncol,mmr,pmid,pdel,zint,tfld,delt, &
   real(r8),       intent(in)    :: cmfdqr(ncol, pver)
   real(r8),       intent(inout) :: wd_tend(pcols,pver,pcnst)
   real(r8),       intent(inout) :: wd_tend_int(pcols,pcnst)
+  ! OSLO_AERO begin
+  !type(physics_buffer_desc),  pointer :: pbuf(:)
+  ! OSLO_AERO end
 !
 ! local arrays and variables
 !
@@ -275,9 +316,12 @@ subroutine neu_wetdep_tend(lchnk,ncol,mmr,pmid,pdel,zint,tfld,delt, &
   real(r8)                  :: e298, dhr
   real(r8), dimension(ncol) :: dk1s,dk2s,wrk
   real(r8) :: lats(pcols)
-  real(r8) :: wrk_wd(pcols)   ! OSLO_AERO
-  logical  :: history_aerosol ! OSLO_AERO
   real(r8), parameter :: rad2deg = 180._r8/pi
+  ! OSLO_AERO begin
+  real(r8)            :: wrk_wd(pcols)
+  integer             :: l_aero
+  real(r8), pointer   :: wd_a_h2so4(:)
+  ! OSLO_AERO end
 !
 ! from cam/src/physics/cam/stratiform.F90
 !
@@ -291,6 +335,7 @@ subroutine neu_wetdep_tend(lchnk,ncol,mmr,pmid,pdel,zint,tfld,delt, &
 ! reset output variables
 !
    wd_tend_int = 0._r8
+   WD_A_SO2_NEU(:ncol,lchnk) = 0._r8 ! OSLO_AERO
 !
 ! get area (in radians square)
 !
@@ -477,17 +522,37 @@ subroutine neu_wetdep_tend(lchnk,ncol,mmr,pmid,pdel,zint,tfld,delt, &
 !
   ! OSLO_AERO begin
   !This is output normally in mo_chm_diags, but if neu wetdep, we have to output it here!
-  call phys_getopts( history_aerosol_out = history_aerosol)
-  if (history_aerosol) then
-     do m=1,gas_wetdep_cnt
-        wrk_wd(:ncol) = 0.0_r8
-        do k=1,pver
-           !Note sign: tendency is negative, so this becomes a positive flux!
-           wrk_wd(:ncol) = wrk_wd(:ncol) - wd_tend(1:ncol,k,mapping_to_mmr(m))*pdel(:ncol,k)*rgrav !kg/m2/sec
-        end do
-        call outfld('WD_A_'//trim(gas_wetdep_list(m)),wrk_wd(:ncol),ncol,lchnk)
-     end do
-  end if
+  do m=1,gas_wetdep_cnt
+    wrk_wd(:ncol) = 0.0_r8
+    do k=1,pver
+        !Note sign: tendency is negative, so this becomes a positive flux!
+        wrk_wd(:ncol) = wrk_wd(:ncol) - wd_tend(1:ncol,k,mapping_to_mmr(m))*pdel(:ncol,k)*rgrav !kg/m2/sec
+    end do
+
+    ! get the index of the gas species that coresponds to the l_spcies system
+    call cnst_get_ind(trim(gas_wetdep_list(m)), l_aero, abort=.false.)
+
+    call outfld('WD_A_'//trim(gas_wetdep_list(m)),wrk_wd(:ncol),ncol,lchnk)
+
+    if ( l_aero == l_so2 ) then
+
+      call outfld('wet_SO2', wrk_wd(:ncol), ncol, lchnk)
+      call outfld('wet_SO2_S', ( wrk_wd(:ncol) * sulfurMassFraction(l_so2) ), ncol, lchnk)
+
+      WD_A_SO2_NEU(:ncol,lchnk) = WD_A_SO2_NEU(:ncol,lchnk) + wrk_wd(:ncol)
+    endif
+
+    ! Save the WD_A field to the wd_a_h2so4 pointer if l_aero == l_h2so4
+    ! this field is passed to the pbuf
+    !if (l_aero == l_h2so4) then
+!
+    !  idx_wd_a_h2so4 = pbuf_get_index('WD_A_H2SO4')
+!
+    !  call pbuf_get_field(pbuf, idx_wd_a_h2so4, wd_a_h2so4)
+    !  wd_a_h2so4(:ncol) = wrk_wd(:ncol)
+    !end if
+
+  end do
   ! OSLO_AERO end
 
 

--- a/src_cam/mo_neu_wetdep.F90
+++ b/src_cam/mo_neu_wetdep.F90
@@ -238,6 +238,7 @@ subroutine neu_wetdep_init
       call add_default( 'wet_SO2_S', 1, ' ' )
   end if
 ! OSLO_AERO end
+
   if ( do_diag ) then
     call addfld     ('QT_RAIN_HNO3',(/ 'lev' /), 'A','mol/mol/s','wet removal Neu scheme rain tendency')
     call addfld     ('QT_RIME_HNO3',(/ 'lev' /), 'A','mol/mol/s','wet removal Neu scheme rain tendency')
@@ -255,8 +256,10 @@ subroutine neu_wetdep_init
 !
 end subroutine neu_wetdep_init
 !
-subroutine neu_wetdep_tend(lchnk,ncol,mmr,pmid,pdel,zint,tfld,delt, &
-     prain, nevapr, cld, cmfdqr, wd_tend, wd_tend_int )
+subroutine neu_wetdep_tend(lchnk,ncol,mmr,pmid,pdel,zint,tfld,delt,   &
+     prain, nevapr, cld, cmfdqr, wd_tend, wd_tend_int,                &
+     pbuf                                                             & ! OSLO_AERO
+     )
 !
   use ppgrid,           only : pcols, pver
   use phys_grid,        only : get_area_all_p, get_rlat_all_p
@@ -266,7 +269,7 @@ subroutine neu_wetdep_tend(lchnk,ncol,mmr,pmid,pdel,zint,tfld,delt, &
   ! OSLO_AERO begin
   use oslo_aero_share,  only : sulfurMassFraction
   use oslo_aero_share,  only : l_so2, l_h2so4
-  !use physics_buffer,   only : physics_buffer_desc, pbuf_get_field, pbuf_get_index
+  use physics_buffer,   only : physics_buffer_desc, pbuf_get_field, pbuf_get_index
   use constituents,     only : cnst_get_ind
   use mo_tracname,      only : solsym
   ! OSLO_AERO end
@@ -288,7 +291,7 @@ subroutine neu_wetdep_tend(lchnk,ncol,mmr,pmid,pdel,zint,tfld,delt, &
   real(r8),       intent(inout) :: wd_tend(pcols,pver,pcnst)
   real(r8),       intent(inout) :: wd_tend_int(pcols,pcnst)
   ! OSLO_AERO begin
-  !type(physics_buffer_desc),  pointer :: pbuf(:)
+  type(physics_buffer_desc),  pointer :: pbuf(:)
   ! OSLO_AERO end
 !
 ! local arrays and variables
@@ -536,6 +539,9 @@ subroutine neu_wetdep_tend(lchnk,ncol,mmr,pmid,pdel,zint,tfld,delt, &
 
     if ( l_aero == l_so2 ) then
 
+      if ( masterproc ) write(iulog,*) 'OSLO_AERO, mo_neu_wetdep, line 546: l_aero = l_so2, outputting wet_SO2 and wet_SO2_S', &
+        'gas_wetdep_list(m) = ', trim(gas_wetdep_list(m))
+
       call outfld('wet_SO2', wrk_wd(:ncol), ncol, lchnk)
       call outfld('wet_SO2_S', ( wrk_wd(:ncol) * sulfurMassFraction(l_so2) ), ncol, lchnk)
 
@@ -544,13 +550,21 @@ subroutine neu_wetdep_tend(lchnk,ncol,mmr,pmid,pdel,zint,tfld,delt, &
 
     ! Save the WD_A field to the wd_a_h2so4 pointer if l_aero == l_h2so4
     ! this field is passed to the pbuf
-    !if (l_aero == l_h2so4) then
-!
-    !  idx_wd_a_h2so4 = pbuf_get_index('WD_A_H2SO4')
-!
-    !  call pbuf_get_field(pbuf, idx_wd_a_h2so4, wd_a_h2so4)
-    !  wd_a_h2so4(:ncol) = wrk_wd(:ncol)
-    !end if
+    if (l_aero == l_h2so4) then
+
+      if ( masterproc ) write(iulog,*) 'OSLO_AERO, mo_neu_wetdep, line 559: l_aero = l_h2so4, outputting wd_a_h2so4', &
+        ' to the pbuf gas_wetdep_list(m) = ', trim(gas_wetdep_list(m))
+
+      idx_wd_a_h2so4 = pbuf_get_index('WD_A_H2SO4')
+
+      if ( masterproc ) write(iulog,*) 'OSLO_AERO, mo_neu_wetdep, line 564: idx_wd_a_h2so4 = ', idx_wd_a_h2so4
+      call pbuf_get_field(pbuf, idx_wd_a_h2so4, wd_a_h2so4)
+      if ( masterproc ) write(iulog,*) 'OSLO_AERO, mo_neu_wetdep, line 567: pbuf_get_field for wd_a_h2so4 done', &
+        ' idx_wd_a_h2so4 = ', idx_wd_a_h2so4, ' wd_a_h2so4 size = ', size(wd_a_h2so4)
+
+      wd_a_h2so4(:ncol) = wrk_wd(:ncol)
+      if ( masterproc ) write(iulog,*) 'OSLO_AERO, mo_neu_wetdep, line 569: write wrk_wd to wd_a_h2so4(:ncol)'
+    end if
 
   end do
   ! OSLO_AERO end

--- a/src_cam/physpkg.F90
+++ b/src_cam/physpkg.F90
@@ -1408,7 +1408,6 @@ contains
     use microp_aero,        only: microp_aero_run
     ! OSLO_AERO begin
     use oslo_aero_microp,   only: oslo_aero_microp_run
-    use oslo_aero_share
     ! OSLO_AERO end
     use clubb_intr,         only: clubb_tend_cam, clubb_emissions_cam
     use subcol,             only: subcol_gen, subcol_ptend_avg
@@ -2499,6 +2498,14 @@ contains
 
     call clybry_fam_set( ncol, lchnk, map2chm, state%q, pbuf )
 
+    ! output these here -- after updates by chem_timestep_tend or export_fields within the current time step
+    if (associated(cam_out%nhx_nitrogen_flx)) then
+       call outfld('a2x_NHXDEP', cam_out%nhx_nitrogen_flx, pcols, lchnk)
+    end if
+    if (associated(cam_out%noy_nitrogen_flx)) then
+       call outfld('a2x_NOYDEP', cam_out%noy_nitrogen_flx, pcols, lchnk)
+    end if
+
   end subroutine tphysac
 
   subroutine tphysbc (ztodt, state,  &
@@ -2941,14 +2948,6 @@ contains
     call t_startf('diag_export')
     call diag_export(cam_out)
     call t_stopf('diag_export')
-
-    ! output these here -- after updates by chem_timestep_tend or export_fields within the current time step
-    if (associated(cam_out%nhx_nitrogen_flx)) then
-       call outfld('a2x_NHXDEP', cam_out%nhx_nitrogen_flx, pcols, lchnk)
-    end if
-    if (associated(cam_out%noy_nitrogen_flx)) then
-       call outfld('a2x_NOYDEP', cam_out%noy_nitrogen_flx, pcols, lchnk)
-    end if
 
   end subroutine tphysbc
 


### PR DESCRIPTION
Summary: Control all output from CAM-Oslo

Contributors: Johannes Fjeldså

Reviewers: Steve Goldhaber

Purpose of changes: Contain output from CAM-Oslo that is always outputted to be namelist options. In additition implement summation fields to allow for aerosol budget calculations and less posprocessing of often-reviewed aerosol output.

Github PR URL: https://github.com/NorESMhub/OSLO_AERO/pull/60

Changes made to build system: 'None'

Changes made to the namelist: 'None'

Changes to the defaults for the boundary datasets: 'None'

Substantial timing or memory changes: 'None'

Usage of new history flags to contain output that is always outputted from OsloAero. In addition multiple new fields are calculated at runtime. Similar work as done for noresm2.3, see https://github.com/NorESMhub/OSLO_AERO/pull/51. Build's on smaller changes done to the namelist system of CAM, see PR https://github.com/NorESMhub/CAM/pull/232.

To test changes:
```
git clone git@github.com:NorESMhub/NorESM.git
cd NorESM
git checkout noresm3_0_beta01
./bin/git-fleximod update

cd components/cam
git remote add johannesfjeldsaa git@github.com:Johannesfjeldsaa/CAM.git
git fetch johannesfjeldsaa
git checkout johannesfjeldsaa/cam_output_control_noresm3_beta01

cd src/chemistry/oslo_aero
git remote add johannesfjeldsaa git@github.com:Johannesfjeldsaa/OSLO_AERO.git
git fetch johannesfjeldsaa
git checkout johannesfjeldsaa/reduced_output_noresm3_from_scratch
```
and then create whatever test case wanted.

I have done control calculations between the in-model and out-of model fields which can be seen on nird:
/nird/datalake/NS9560K/noresm3/cases/n1850.ne16pg3_tn14.beta01.budget_calculation.20250714/documentation_of_work/lookatoutput.ipynb 
Also a budget has been done which is found in:
/nird/datalake/NS9560K/noresm3/cases/n1850.ne16pg3_tn14.beta01.budget_calculation.20250714/documentation_of_work/aerosol_budget_noresm3.out
NOTE however that the budgets are perhaps a bit to unclosed. This is probably because I was unable to calculate the change in global load from restart files (since needed variable live on different grids. If one where to regrid the restart files this could be done). As a result the change in load is calculated based on h0a.0122-12 - h0a.0122-01 which are monthly averages and probably not the most representative numbers. 

Issues addressed by this PR: https://github.com/NorESMhub/CAM/issues/195 