### PR TITLE
oslo_aero_3_0a007: Resolve pcols / ncol conflict

### DIFF
--- a/src/oslo_aero_coag.F90
+++ b/src/oslo_aero_coag.F90
@@ -13,6 +13,7 @@ module oslo_aero_coag
   use mo_constants,   only: pi
   use physconst,      only: rair, gravit
   use cam_history,    only: addfld, add_default, fieldname_len, horiz_only, outfld
+  use spmd_utils,     only: masterproc
   use cam_logfile,    only: iulog
   !
   use oslo_aero_share, only: nmodes, max_tracers_per_mode
@@ -288,8 +289,11 @@ contains
     else
        tableindexcloud=nsiz
     end if
-    write(iulog,*) 'Assumed droplet size and table bin number for cloud  &
-         coagulation ',rcoagdroplet, ' nbin ',tableindexcloud,'binmid',rBinMidPoint(tableindexcloud)
+    if (masterproc) then
+       write(iulog,*) 'Assumed droplet size and table bin number for ',       &
+            'cloud  & coagulation ', rcoagdroplet, ' nbin ', tableindexcloud, &
+            'binmid', rBinMidPoint(tableindexcloud)
+    end if
 
     do iCoagulatingMode = 1, numberOfCoagulatingModes
        modeIndexCoagulator = coagulatingMode(iCoagulatingMode) !Index of the coagulating mode

--- a/src/oslo_aero_depos.F90
+++ b/src/oslo_aero_depos.F90
@@ -564,9 +564,9 @@ contains
             ! accumulate the deposition flux for the aerosol type
             ! All will have a version without weighted sum, that is ...DDF
             ! sulfate will have a version with weighted sum, that is ...SDDF
-            sflx_DDF_arosol_type(:, aerosolType(itrac)) = sflx_DDF_arosol_type(:, aerosolType(itrac)) + sflx(:ncol)
+            sflx_DDF_arosol_type(:ncol, aerosolType(itrac)) = sflx_DDF_arosol_type(:ncol, aerosolType(itrac)) + sflx(:ncol)
             if ( aerosolType(itrac) ==  AEROSOL_TYPE_SULFATE ) then
-               sflx_DDF_SULFATE_S(:) = sflx_DDF_SULFATE_S(:) + ( sflx(:ncol) * sulfurMassFraction(itrac) )
+               sflx_DDF_SULFATE_S(:ncol) = sflx_DDF_SULFATE_S(:ncol) + ( sflx(:ncol) * sulfurMassFraction(itrac) )
             endif
 
           enddo   ! lspec = 0, nspec_amode(imode)+1
@@ -717,9 +717,6 @@ contains
           ! sol_factic is strictly a tuning factor
           !
           if (lphase == 1) then   ! interstial aerosol
-             !hygro_sum_old(:,:) = 0.0_r8
-             !hygro_sum_del(:,:) = 0.0_r8
-             !call modal_aero_bcscavcoef_get( m, ncol, isprx, dgncur_awet, scavcoefnv(:,:,1), scavcoefnv(:,:,2) )
 
              scavcoefnv(:,:,1) = 0.1_r8  !Used by MAM for number concentration
 
@@ -945,9 +942,9 @@ contains
 
             ! accumulate the deposition flux for the aerosol type, aerosol mass
             ! if it is sulfate we accumulate in sflx_SFWET_SULFATE_S in addition
-            sflx_SFWET_arosol_type(:, aerosolType(itrac)) = sflx_SFWET_arosol_type(:, aerosolType(itrac)) + sflx(:ncol)
+            sflx_SFWET_arosol_type(:ncol, aerosolType(itrac)) = sflx_SFWET_arosol_type(:ncol, aerosolType(itrac)) + sflx(:ncol)
             if ( aerosolType(itrac) == AEROSOL_TYPE_SULFATE ) then
-               sflx_SFWET_SULFATE_S(:) = sflx_SFWET_SULFATE_S(:) + ( sflx(:ncol) * sulfurMassFraction(itrac) )
+               sflx_SFWET_SULFATE_S(:ncol) = sflx_SFWET_SULFATE_S(:ncol) + ( sflx(:ncol) * sulfurMassFraction(itrac) )
             endif
 
           enddo   ! lspec = 0, nspec_amode(imode)+1

--- a/src/oslo_aero_logn_tables.F90
+++ b/src/oslo_aero_logn_tables.F90
@@ -254,7 +254,9 @@ contains
        enddo
     enddo
 
-    write(iulog,*)'nlog mode 5-10 ok'
+    if (masterproc) then
+       write(iulog,*)'nlog mode 5-10 ok'
+    end if
 
     do ifil=20,29
        close (ifil)

--- a/src/oslo_aero_ndrop.F90
+++ b/src/oslo_aero_ndrop.F90
@@ -420,7 +420,7 @@ contains
 
     real(r8), allocatable :: coltend(:,:)       ! column tendency for diagnostic output
     real(r8), allocatable :: coltend_cw(:,:)    ! column tendency
-    real(r8)              :: ccn(pcols,pverp,psat) ! number conc of aerosols activated at supersat
+    real(r8)              :: ccn(pcols,pver,psat) ! number conc of aerosols activated at supersat
 
     !for gas species turbulent mixing
     real(r8), pointer     :: rgas(:, :, :)
@@ -597,6 +597,13 @@ contains
        end do
        zs(pver) = zs(pver-1)
 
+       do ilev = 1, pver
+          do imode = 1, ntot_amode
+             nact(ilev,imode) = 0._r8
+             mact(ilev,imode) = 0._r8
+          end do
+       end do
+
        ! load number nucleated into qcld on cloud boundaries
        do ilev = top_lev, pver
 
@@ -605,11 +612,6 @@ contains
           srcn(ilev)  = 0._r8
           cs(icol,ilev)  = pmid(icol,ilev)/(rair*temp(icol,ilev))        ! air density (kg/m3)
           dz(icol,ilev)  = 1._r8/(cs(icol,ilev)*gravit*rpdel(icol,ilev)) ! layer thickness in m
-
-          do imode = 1, ntot_amode
-             nact(ilev,imode) = 0._r8
-             mact(ilev,imode) = 0._r8
-          end do
 
           zn(ilev) = gravit*rpdel(icol,ilev)
 
@@ -743,6 +745,8 @@ contains
        do imode = 1, nmodes ! Number of modes
           !Get number concentration of this mode
           mm = mam_idx(imode,0)
+          raercol(1:top_lev-1,mm,nsav) = 0.0_r8
+          raercol_cw(1:top_lev-1,mm,nsav) = 0.0_r8
           do ilev= top_lev,pver
              raercol(ilev,mm,nsav) = numberConcentration(icol,ilev,imode)/cs(icol,ilev) !#/kg air
              !In oslo model, number concentrations are diagnostics, so

--- a/src/oslo_aero_ndrop.F90
+++ b/src/oslo_aero_ndrop.F90
@@ -1464,7 +1464,7 @@ contains
    call ccncalc_oslo(state, pbuf, cs, hasAerosol, numberConcentration, volumeConcentration, &
       hygroscopicity, lnSigma, ccn)
    do isat = 1, psat
-      call outfld(ccn_name(isat), ccn(:,:,isat), pcols, lchnk)
+      call outfld(ccn_name(isat), ccn(:ncol,:,isat), ncol, lchnk)
    enddo
 
     tendencyCounted(:)=.FALSE.


### PR DESCRIPTION
Fix mismatch where some arrays in an equation used `:` as the first dimension while others used `:ncol`. This fails when `ncol` /= `pcols` which happens when there is an unfilled chunk on any task.

Addresses NorESMhub/CAM#233