### PR TITLE
oslo_aero_3_0a008: Updates from cam6_4_112: Fix minor bugs in cloud chemistry

### DIFF
--- a/src/aero_model.F90
+++ b/src/aero_model.F90
@@ -631,8 +631,8 @@ contains
     dvmrcwdt_sv1 = vmrcw
 
     ! aqueous chemistry ...
-    call setsox( state, ncol, lchnk, loffset, delt, pmid, pdel, tfld, mbar, cwat, &
-         cldfr, cldnum, airdens, invariants, vmrcw, vmr, xphlwc, &
+    call setsox( state, pbuf, ncol, lchnk, loffset, delt, pmid, pdel, tfld, mbar, &
+         cwat, cldfr, cldnum, invariants, vmrcw, vmr, xphlwc, &
          aqso4, aqh2so4, aqso4_h2o2, aqso4_o3)
 
     call outfld( 'AQSO4_H2O2', aqso4_h2o2(:ncol), ncol, lchnk)

--- a/src/oslo_aero_sox_cldaero.F90
+++ b/src/oslo_aero_sox_cldaero.F90
@@ -290,11 +290,16 @@ contains
 
     ! Update the mixing ratios
     do ilev = 1,pver
-       qcw(:,ilev,id_so4_1a) =  MAX( qcw(:,ilev,id_so4_1a), small_value )
-       qin(:,ilev,id_so2) =  MAX( qin(:,ilev,id_so2), small_value )
+       qcw(:,ilev,id_so4_1a) = MAX( qcw(:,ilev,id_so4_1a),   small_value )
+       qin(:,ilev,id_so2) =    MAX( qin(:,ilev,id_so2),      small_value )
+       qin(:,ilev,id_h2o2)  =     MAX( qin(:,ilev,id_h2o2),  small_value )
+       qin(:,ilev,id_h2so4) =     MAX( qin(:,ilev,id_h2so4), small_value )
+       if ( id_msa > 0 ) then
+          qin(:,ilev,id_msa) =    MAX( qin(:,ilev,id_msa),   small_value )
+       end if
        if ( id_nh3 > 0 ) then
-          qin(:,ilev,id_nh3) =  MAX( qin(:,ilev,id_nh3), small_value )
-       endif
+          qin(:,ilev,id_nh3) = MAX( qin(:,ilev,id_nh3),      small_value )
+       end if
     end do
 
     ! diagnostics

--- a/src_cam/mo_setsox.F90
+++ b/src_cam/mo_setsox.F90
@@ -21,6 +21,9 @@ module mo_setsox
 
   logical :: cloud_borne = .false.
 
+  ! Indices for species in the shared array of Henry's Law constant parameters
+  integer :: heff_id_hno3, heff_id_so2, heff_id_nh3, heff_id_co2, heff_id_h2o2, heff_id_o3
+
 contains
 
 !-----------------------------------------------------------------------
@@ -43,7 +46,6 @@ contains
     ! OSLO_AERO begin
     modal_aerosols = .true.
     ! OSLO_AERO end
-
     cloud_borne = modal_aerosols .or. carma_do_cloudborne
 
     !-----------------------------------------------------------------
@@ -112,6 +114,19 @@ contains
        has_sox = has_sox .and. (id_so4>0) .and. (id_nh3>0)
     endif
 
+    ! Lookup Effective Henry's Law Constant parameters from the common
+    ! data file read in the shared code.
+    heff_id_hno3 = get_heff_index( 'HNO3' )
+    heff_id_so2  = get_heff_index( 'SO2'  )
+    heff_id_nh3  = get_heff_index( 'NH3'  )
+    heff_id_co2  = get_heff_index( 'CO2'  )
+    heff_id_h2o2 = get_heff_index( 'H2O2' )
+    heff_id_o3   = get_heff_index( 'OX'   )
+
+    has_sox = has_sox .and. (heff_id_hno3 > 0) .and. (heff_id_so2 > 0) &
+               .and. (heff_id_nh3 > 0) .and. (heff_id_co2 > 0) &
+               .and. (heff_id_h2o2 > 0) .and. (heff_id_o3 > 0)
+
     if (masterproc) then
        write(iulog,*) 'sox_inti: has_sox = ',has_sox
     endif
@@ -119,7 +134,7 @@ contains
     if( has_sox ) then
        if (masterproc) then
           write(iulog,*) '-----------------------------------------'
-          write(iulog,*) 'mo_setsox will do sox aerosols'
+          write(iulog,*) ' mo_setsox will do sox aerosols'
           write(iulog,*) '-----------------------------------------'
        endif
     else
@@ -138,6 +153,7 @@ contains
 !-----------------------------------------------------------------------
 !-----------------------------------------------------------------------
   subroutine setsox( state, &
+       pbuf,   &
        ncol,   &
        lchnk,  &
        loffset,&
@@ -149,7 +165,6 @@ contains
        lwc,    &
        cldfrc, &
        cldnum, &
-       xhnm,   &
        invariants, &
        qcw,    &
        qin,    &
@@ -176,22 +191,35 @@ contains
     !           (b) PARTIONING
     !           (c) REACTION rates
     !           (d) PREDICTION
+    !
+    ! NOTE: This routine assumes an Ideal Gas.
     !-----------------------------------------------------------------------
     !
-    use ppgrid,       only : pcols, pver
-    use chem_mods,    only : gas_pcnst, nfs
-    use chem_mods,    only : adv_mass
-    use physconst,    only : mwdry, gravit
-    use mo_constants, only : pi
+    use physconst,             only : AVOGADRO_KMOL => avogad,             &
+                                      BOLTZMANN => boltz,                  &
+                                      GAS_CONSTANT_KMOL => r_universal,    &
+                                      MOLECULAR_WEIGHT_CO2_G_MOL => mwco2, &
+                                      MOLECULAR_WEIGHT_DRY_AIR_G_MOL => mwdry
+    use ppgrid,                only : pcols, pver
+    use chem_mods,             only : gas_pcnst, nfs
+    use chem_mods,             only : adv_mass
+    use physconst,             only : mwdry, gravit
+    use mo_constants,          only : pi
     ! OSLO_AERO begin
-    use oslo_aero_sox_cldaero, only : sox_cldaero_update, sox_cldaero_create_obj, sox_cldaero_destroy_obj
+    use oslo_aero_sox_cldaero, only : sox_cldaero_update
+    use oslo_aero_sox_cldaero, only : sox_cldaero_create_obj, sox_cldaero_destroy_obj
     use oslo_aero_sox_cldaero, only : cldaero_conc_t
     ! OSLO_AERO end
+    use shr_drydep_mod,        only : dheff
+    use physics_buffer,        only : physics_buffer_desc
+    use rad_constituents,      only : rad_cnst_get_gas
+
     !
     !-----------------------------------------------------------------------
     !      ... Dummy arguments
     !-----------------------------------------------------------------------
-    type(physics_state), intent(in) :: state             ! Physics state variables
+    type(physics_state),                intent(in)    :: state   ! Physics state variables
+    type(physics_buffer_desc), pointer, intent(inout) :: pbuf(:) ! Physics buffer
     integer,          intent(in)    :: ncol              ! num of columns in chunk
     integer,          intent(in)    :: lchnk             ! chunk id
     integer,          intent(in)    :: loffset           ! offset of chem tracers in the advected tracers array
@@ -203,7 +231,6 @@ contains
     real(r8), target, intent(in)    :: lwc(:,:)          ! cloud liquid water content (kg/kg)
     real(r8), target, intent(in)    :: cldfrc(:,:)       ! cloud fraction
     real(r8),         intent(in)    :: cldnum(:,:)       ! droplet number concentration (#/kg)
-    real(r8),         intent(in)    :: xhnm(:,:)         ! total atms density ( /cm**3)
     real(r8),         intent(in)    :: invariants(:,:,:)
     real(r8), target, intent(inout) :: qcw(:,:,:)        ! cloud-borne aerosol (vmr)
     real(r8),         intent(inout) :: qin(:,:,:)        ! transported species ( vmr )
@@ -217,7 +244,6 @@ contains
     real(r8),         intent(out), optional :: aqso4_h2o2_3d(:, :)  ! 3D SO4 aqueous phase chemistry due to H2O2 (kg/m2)
     real(r8),         intent(out), optional :: aqso4_o3_3d(:, :)    ! 3D SO4 aqueous phase chemistry due to O3 (kg/m2)
 
-
     !-----------------------------------------------------------------------
     !      ... Local variables
     !
@@ -225,7 +251,16 @@ contains
     !-----------------------------------------------------------------------
     integer,  parameter :: itermax = 20
     real(r8), parameter :: ph0 = 5.0_r8  ! INITIAL PH VALUES
-    real(r8), parameter :: const0 = 1.e3_r8/6.023e23_r8
+    real(r8), parameter :: PASCAL_TO_ATM = 1.0_r8 / 101325.0_r8 ! atm Pa-1
+    real(r8), parameter :: M3_TO_L = 1.0e3_r8                   ! L m-3
+    real(r8), parameter :: M3_TO_CM3 = 1.0e6_r8                 ! cm3 m-3
+    real(r8), parameter :: G_TO_KG = 1.0e-3_r8                  ! kg g-1
+    real(r8), parameter :: KMOL_TO_MOL = 1.0e3_r8               ! mol kmol-1
+    real(r8), parameter :: SMALL_NUMBER = 1.0e-30_r8
+    real(r8), parameter :: AVOGADRO = AVOGADRO_KMOL / KMOL_TO_MOL ! molecule mol-1
+    real(r8), parameter :: const0 = 1.e3_r8/AVOGADRO
+    real(r8)            :: MOLECULAR_WEIGHT_DRY_AIR ! kg mol-1
+    real(r8), parameter :: MOLECULAR_WEIGHT_CO2 = MOLECULAR_WEIGHT_CO2_G_MOL * G_TO_KG ! kg mol-1
     real(r8), parameter :: xa0 = 11._r8
     real(r8), parameter :: xb0 = -.1_r8
     real(r8), parameter :: xa1 = 1.053_r8
@@ -235,25 +270,27 @@ contains
     real(r8), parameter :: xa3 = .816e-32_r8
     real(r8), parameter :: xb3 = .259_r8
 
-    real(r8), parameter :: kh0 = 9.e3_r8            ! HO2(g)          -> Ho2(a)
-    real(r8), parameter :: kh1 = 2.05e-5_r8         ! HO2(a)          -> H+ + O2-
-    real(r8), parameter :: kh2 = 8.6e5_r8           ! HO2(a) + ho2(a) -> h2o2(a) + o2
-    real(r8), parameter :: kh3 = 1.e8_r8            ! HO2(a) + o2-    -> h2o2(a) + o2
-    real(r8), parameter :: Ra = 8314._r8/101325._r8 ! universal constant   (atm)/(M-K)
-    real(r8), parameter :: xkw = 1.e-14_r8          ! water acidity
+    real(r8), parameter :: kh0 = 690.0_r8          ! HO2(g)          -> Ho2(a)        Reference: JPL 19-5
+    real(r8), parameter :: kh1 = 1.6e-5_r8         ! HO2(a)          -> H+ + O2-      Reference: JPL 19-5
+    real(r8), parameter :: kh2 = 8.3e5_r8          ! HO2(a) + ho2(a) -> h2o2(a) + o2  Reference: JPL; Bielski et al. 1985
+    real(r8), parameter :: kh3 = 9.7e7_r8          ! HO2(a) + o2-    -> h2o2(a) + o2  Reference: JPL; Bielski et al. 1985
+    real(r8), parameter :: Ra = GAS_CONSTANT_KMOL / KMOL_TO_MOL * M3_TO_L * PASCAL_TO_ATM ! universal constant   (atm)/(M-K)
 
     !
     real(r8) :: xdelso4hp(ncol,pver)
+    real(r8) :: xhnm(ncol,pver) ! air number density (molecules cm-3)
 
     integer  :: k, i, iter, file
     real(r8) :: wrk, delta
     real(r8) :: xph0, aden, xk, xe, x2
-    real(r8) :: tz, xl, px, qz, pz, es, qs, patm
+    real(r8) :: tz, xl, px, qz, es, qs, patm
     real(r8) :: Eso2, Eso4, Ehno3, Eco2, Eh2o, Enh3
-    real(r8) :: so2g, h2o2g, co2g, o3g
+    real(r8) :: so2g, h2o2g, o3g
     real(r8) :: hno3a, nh3a, so2a, h2o2a, co2a, o3a
     real(r8) :: rah2o2, rao3, pso4, ccc
     real(r8) :: cnh3, chno3, com, com1, com2, xra
+    real(r8) :: f_hso3 ! fraction of aqueous S(IV) that's HSO3-
+    real(r8) :: f_so3  ! fraction of aqueous S(IV) that's SO3=
 
     real(r8) :: hno3g(ncol,pver), nh3g(ncol,pver)
     !
@@ -268,7 +305,7 @@ contains
     real(r8) :: r2h2o2 ! prod(h2o2) by ho2 in mix/s
 
     real(r8), dimension(ncol,pver)  ::             &
-         xhno3, xh2o2, xso2, xso4, xno3, &
+         xhno3, xh2o2, xso2, xso4, xno3, xco2, &
          xnh3, xnh4, xo3,         &
          cfact, &
          xph, xho2,         &
@@ -279,7 +316,7 @@ contains
          henh3,  &            ! henry law const for nh3
          heo3              !!,   &            ! henry law const for o3
 
-    real(r8) :: patm_x
+    real(r8), pointer :: co2_mass_mixing_ratio(:,:) ! kg kg-1
 
     real(r8), dimension(ncol)  :: work1
     logical :: converged
@@ -292,11 +329,14 @@ contains
     real(r8) :: fact1_hno3, fact2_hno3, fact3_hno3
     real(r8) :: fact1_so2, fact2_so2, fact3_so2, fact4_so2
     real(r8) :: fact1_nh3, fact2_nh3, fact3_nh3
+    real(r8) :: fact1_co2, fact2_co2, fact3_co2, fact4_co2
     real(r8) :: tmp_hp, tmp_hso3, tmp_hco3, tmp_nh4, tmp_no3
     real(r8) :: tmp_oh, tmp_so3, tmp_so4
     real(r8) :: tmp_neg, tmp_pos
     real(r8) :: yph, yph_lo, yph_hi
     real(r8) :: ynetpos, ynetpos_lo, ynetpos_hi
+
+    MOLECULAR_WEIGHT_DRY_AIR = MOLECULAR_WEIGHT_DRY_AIR_G_MOL * G_TO_KG  ! kg mol-1
 
     !-----------------------------------------------------------------
     !       ... NOTE: The press array is in pascals and must be
@@ -308,12 +348,16 @@ contains
     !      ... Initial values
     !           The values of so2, so4 are after (1) SLT, and CHEM
     !-----------------------------------------------------------------
+    xhnm(:ncol,:) = press(:ncol,:) / (tfld(:ncol,:) * M3_TO_CM3 * BOLTZMANN)  ! air number density (molecules cm-3)
+
+    call rad_cnst_get_gas(0, 'CO2', state, pbuf, co2_mass_mixing_ratio)
+
     xph0 = 10._r8**(-ph0)                      ! initial PH value
 
     do k = 1,pver
        cfact(:,k) = xhnm(:,k)     &          ! /cm3(a)
             * 1.e6_r8             &          ! /m3(a)
-            * 1.38e-23_r8/287._r8 &          ! Kg(a)/m3(a)
+            * BOLTZMANN/287._r8   &          ! Kg(a)/m3(a)
             * 1.e-3_r8                       ! Kg(a)/L(a)
     end do
 
@@ -328,6 +372,9 @@ contains
 
     do k = 1,pver
        xph(:,k) = xph0                                ! initial PH value
+
+       xco2(:ncol,k) = co2_mass_mixing_ratio(:ncol,k) &
+                   * (MOLECULAR_WEIGHT_DRY_AIR / MOLECULAR_WEIGHT_CO2)  ! mixing ratio
 
        if ( inv_so2 ) then
           xso2 (:,k) = invariants(:,k,id_so2)/xhnm(:,k)  ! mixing ratio
@@ -403,10 +450,9 @@ contains
              !-----------------------------------------------------------------
 
              !-----------------------------------------------------------------
-             pz = .01_r8*press(i,k)       !! pressure in mb
              tz = tfld(i,k)
-             patm = pz/1013._r8
-             xam  = press(i,k)/(1.38e-23_r8*tz)  !air density /M3
+             patm = press(i,k) * PASCAL_TO_ATM ! atm
+             xam  = press(i,k)/(BOLTZMANN*tz)  ! air density /M3
 
              !-----------------------------------------------------------------
              !        ... hno3
@@ -425,8 +471,8 @@ contains
              !          = xk*xe*patm*xhno3/(1 + xk*ra*tz*xl*(1 + xe/hplus)
              !          = ( fact1_hno3    )/(1 + fact2_hno3 *(1 + fact3_hno3/hplus)
              !    [hno3-] = ehno3/hplus
-             xk = 2.1e5_r8 *EXP( 8700._r8*work1(i) )
-             xe = 15.4_r8
+             xk = dheff(1,heff_id_hno3) * exp( dheff(2,heff_id_hno3) * work1(i) )
+             xe = dheff(3,heff_id_hno3) * exp( dheff(4,heff_id_hno3) * work1(i) )
              fact1_hno3 = xk*xe*patm*xhno3(i,k)
              fact2_hno3 = xk*ra*tz*xl
              fact3_hno3 = xe
@@ -448,9 +494,9 @@ contains
              !          = xk*xe*patm*xso2/(1 + xk*ra*tz*xl*(1 + (xe/hplus)*(1 + x2/hplus))
              !          = ( fact1_so2    )/(1 + fact2_so2 *(1 + (fact3_so2/hplus)*(1 + fact4_so2/hplus)
              !    [hso3-] + 2*[so3--] = (eso2/hplus)*(1 + 2*x2/hplus)
-             xk = 1.23_r8  *EXP( 3120._r8*work1(i) )
-             xe = 1.7e-2_r8*EXP( 2090._r8*work1(i) )
-             x2 = 6.0e-8_r8*EXP( 1120._r8*work1(i) )
+             xk = dheff(1,heff_id_so2) * exp( dheff(2,heff_id_so2) * work1(i) )
+             xe = dheff(3,heff_id_so2) * exp( dheff(4,heff_id_so2) * work1(i) )
+             x2 = dheff(5,heff_id_so2) * exp( dheff(6,heff_id_so2) * work1(i) )
              fact1_so2 = xk*xe*patm*xso2(i,k)
              fact2_so2 = xk*ra*tz*xl
              fact3_so2 = xe
@@ -473,25 +519,38 @@ contains
              !          = ((xk*xe*patm/xkw)*xnh34)/(1 + xk*ra*tz*xl*(1 + xe*hplus/xkw)
              !          = ( fact1_nh3            )/(1 + fact2_nh3  *(1 + fact3_nh3*hplus)
              !    [nh4+] = enh3*hplus
-             xk = 58._r8   *EXP( 4085._r8*work1(i) )
-             xe = 1.7e-5_r8*EXP( -4325._r8*work1(i) )
-
-             fact1_nh3 = (xk*xe*patm/xkw)*(xnh3(i,k)+xnh4(i,k))
+             ! NOTE: Algorithm modified to follow that used in wet deposition.
+             !       This essentially replaces xkw (1.0e-14) with a temperature
+             !       dependent value for the water dissociation constant, x2.
+             xk = dheff(1,heff_id_nh3) * exp( dheff(2,heff_id_nh3) * work1(i) )
+             xe = dheff(3,heff_id_nh3) * exp( dheff(4,heff_id_nh3) * work1(i) )
+             x2 = dheff(5,heff_id_nh3) * exp( dheff(6,heff_id_nh3) * work1(i) )
+             fact1_nh3 = (xk*xe*patm/x2)*(xnh3(i,k)+xnh4(i,k))
              fact2_nh3 = xk*ra*tz*xl
-             fact3_nh3 = xe/xkw
+             fact3_nh3 = xe/x2
 
              !-----------------------------------------------------------------
              !        ... h2o effects
+             ! NOTE: Algorithm modified to follow that used in wet deposition.
+             !       This essentially replaces xkw (1.0e-14) with a temperature
+             !       dependent value for the water dissociation constant, x2
+             !       (calculated above with NH4 Heff terms).
              !-----------------------------------------------------------------
-             Eh2o = xkw
+             Eh2o = x2
 
              !-----------------------------------------------------------------
              !        ... co2 effects
+             ! NOTE: Algorithm modified to follow that used in wet deposition.
+             !       This now applies the same algorithm for diprotic acids used
+             !       for SO2.
              !-----------------------------------------------------------------
-             co2g = 330.e-6_r8                            !330 ppm = 330.e-6 atm
-             xk = 3.1e-2_r8*EXP( 2423._r8*work1(i) )
-             xe = 4.3e-7_r8*EXP(-913._r8 *work1(i) )
-             Eco2 = xk*xe*co2g  *patm
+             xk = dheff(1,heff_id_co2) * exp( dheff(2,heff_id_co2) * work1(i) )
+             xe = dheff(3,heff_id_co2) * exp( dheff(4,heff_id_co2) * work1(i) )
+             x2 = dheff(5,heff_id_co2) * exp( dheff(6,heff_id_co2) * work1(i) )
+             fact1_co2 = xk*xe*patm*xco2(i,k)
+             fact2_co2 = xk*ra*tz*xl
+             fact3_co2 = xe
+             fact4_co2 = x2
 
              !-----------------------------------------------------------------
              !         ... so4 effect
@@ -549,6 +608,12 @@ contains
                 !          ... nh3
                 !-----------------------------------------------------------------
                 Enh3 = fact1_nh3/(1.0_r8 + fact2_nh3*(1.0_r8 + fact3_nh3*xph(i,k)))
+
+                !-----------------------------------------------------------------
+                !          ... co2
+                !-----------------------------------------------------------------
+                Eco2 = fact1_co2/(1.0_r8 + fact2_co2*(1.0_r8 + (fact3_co2/xph(i,k)) &
+                     *(1.0_r8 +  fact4_co2/xph(i,k))))
 
                 tmp_nh4  = Enh3 * xph(i,k)
                 tmp_hso3 = Eso2 / xph(i,k)
@@ -642,44 +707,50 @@ contains
 
           xl = cldconc%xlwc(i,k)
 
-          patm = press(i,k)/101300._r8        ! press is in pascal
-          xam  = press(i,k)/(1.38e-23_r8*tz)  ! air density /M3
+          patm = press(i,k) * PASCAL_TO_ATM   ! atm
+          xam  = press(i,k)/(BOLTZMANN*tz)    ! air density /M3
 
           !-----------------------------------------------------------------------
           !        ... hno3
           !-----------------------------------------------------------------------
-          xk = 2.1e5_r8 *EXP( 8700._r8*work1(i) )
-          xe = 15.4_r8
+          xk = dheff(1,heff_id_hno3) * exp( dheff(2,heff_id_hno3) * work1(i) )
+          xe = dheff(3,heff_id_hno3) * exp( dheff(4,heff_id_hno3) * work1(i) )
           hehno3(i,k)  = xk*(1._r8 + xe/xph(i,k))
 
           !-----------------------------------------------------------------
           !        ... h2o2
           !-----------------------------------------------------------------
-          xk = 7.4e4_r8   *EXP( 6621._r8*work1(i) )
-          xe = 2.2e-12_r8 *EXP(-3730._r8*work1(i) )
+          xk = dheff(1,heff_id_h2o2) * exp( dheff(2,heff_id_h2o2) * work1(i) )
+          xe = dheff(3,heff_id_h2o2) * exp( dheff(4,heff_id_h2o2) * work1(i) )
           heh2o2(i,k)  = xk*(1._r8 + xe/xph(i,k))
 
           !-----------------------------------------------------------------
           !         ... so2
           !-----------------------------------------------------------------
-          xk = 1.23_r8  *EXP( 3120._r8*work1(i) )
-          xe = 1.7e-2_r8*EXP( 2090._r8*work1(i) )
-          x2 = 6.0e-8_r8*EXP( 1120._r8*work1(i) )
+          xk = dheff(1,heff_id_so2) * exp( dheff(2,heff_id_so2) * work1(i) )
+          xe = dheff(3,heff_id_so2) * exp( dheff(4,heff_id_so2) * work1(i) )
+          x2 = dheff(5,heff_id_so2) * exp( dheff(6,heff_id_so2) * work1(i) )
 
           wrk = xe/xph(i,k)
           heso2(i,k)  = xk*(1._r8 + wrk*(1._r8 + x2/xph(i,k)))
 
+          ! Calculate fraction of total aqueous S(IV) that is HSO3- and SO3=
+          wrk = xe/(xph(i,k)*xph(i,k) + xe*xph(i,k) + xe*x2)
+          f_hso3 = wrk*xph(i,k) ! [HSO3-]/[S(IV)]
+          f_so3  = wrk*x2       !  [SO3=]/[S(IV)]
+
           !-----------------------------------------------------------------
           !          ... nh3
           !-----------------------------------------------------------------
-          xk = 58._r8   *EXP( 4085._r8*work1(i) )
-          xe = 1.7e-5_r8*EXP(-4325._r8*work1(i) )
-          henh3(i,k)  = xk*(1._r8 + xe*xph(i,k)/xkw)
+          xk = dheff(1,heff_id_nh3) * exp( dheff(2,heff_id_nh3) * work1(i) )
+          xe = dheff(3,heff_id_nh3) * exp( dheff(4,heff_id_nh3) * work1(i) )
+          x2 = dheff(5,heff_id_nh3) * exp( dheff(6,heff_id_nh3) * work1(i) )
+          henh3(i,k)  = xk*(1._r8 + xe*xph(i,k)/x2)
 
           !-----------------------------------------------------------------
           !        ... o3
           !-----------------------------------------------------------------
-          xk = 1.15e-2_r8 *EXP( 2560._r8*work1(i) )
+          xk = dheff(1,heff_id_o3) * exp( dheff(2,heff_id_o3) * work1(i) )
           heo3(i,k) = xk
 
           !------------------------------------------------------------------------
@@ -688,21 +759,13 @@ contains
           !------------------------------------------------------------------------
           kh4 = (kh2 + kh3*kh1/xph(i,k)) / ((1._r8 + kh1/xph(i,k))**2)
           ho2s = kh0*xho2(i,k)*patm*(1._r8 + kh1/xph(i,k))  ! ho2s = ho2(a)+o2-
-          r1h2o2 = kh4*ho2s*ho2s                         ! prod(h2o2) in mole/L(w)/s
+          r1h2o2 = kh4*ho2s*ho2s                            ! prod(h2o2) in mole/L(w)/s
+          r2h2o2 = r1h2o2 * xl  & ! (mole(h2o2)/L(w)/s) * (L(w)/L(a))
+                  / xam         & ! / (molecule(a)/m3(a))
+                  * AVOGADRO    & ! * (molecule(a)/mole(a))
+                  * M3_TO_L       ! * (L(a)/m3(a)) = mole(h2o2)/mole(a)/s
 
-          if ( cloud_borne ) then
-             r2h2o2 = r1h2o2*xl        &    ! mole/L(w)/s   * L(w)/fm3(a) = mole/fm3(a)/s
-                  / const0*1.e+6_r8  &    ! correct a bug here ????
-                  / xam
-          else
-             r2h2o2 = r1h2o2*xl  &          ! mole/L(w)/s   * L(w)/fm3(a) = mole/fm3(a)/s
-                  * const0     &          ! mole/fm3(a)/s * 1.e-3       = mole/cm3(a)/s
-                  / xam                   ! /cm3(a)/s    / air-den     = mix-ratio/s
-          endif
-
-          if ( .not. cloud_borne) then    ! this seems to be specific to aerosols that are not cloud borne
-             xh2o2(i,k) = xh2o2(i,k) + r2h2o2*dtime         ! updated h2o2 by het production
-          endif
+          xh2o2(i,k) = xh2o2(i,k) + r2h2o2*dtime ! updated h2o2 by het production
 
           !-----------------------------------------------
           !       ... Partioning
@@ -750,15 +813,19 @@ contains
 
           !------------------------------------------------------------------------
           !       ... S(IV) (HSO3) + H2O2
+          ! Reference: Seinfeld and Pandis textbook (chapter 6);
+          !            original source: Hoffmann and Calvert (1985)
           !------------------------------------------------------------------------
-          rah2o2 = 8.e4_r8 * EXP( -3650._r8*work1(i) )  &
-               / (.1_r8 + xph(i,k))
+          rah2o2 = 7.45e7_r8 * EXP( -4430.0_r8*work1(i) ) * xph(i,k) &
+                   / (1.0_r8 + 13.0_r8*xph(i,k)) * f_hso3
 
           !------------------------------------------------------------------------
           !        ... S(IV)+ O3
+          ! Reference: Seinfeld and Pandis textbook (chapter 6);
+          !            original source: Hoffmann and Calvert (1985)
           !------------------------------------------------------------------------
-          rao3   = 4.39e11_r8 * EXP(-4131._r8/tz)  &
-               + 2.56e3_r8  * EXP(-996._r8 /tz) /xph(i,k)
+          rao3   =   3.75e5_r8 * EXP(-5530.0_r8*work1(i)) * f_hso3 &
+                   + 1.59e9_r8 * EXP(-5280.0_r8*work1(i)) * f_so3
 
           !-----------------------------------------------------------------
           !       ... Prediction after aqueous phase
@@ -779,87 +846,38 @@ contains
 
           IF (XL .ge. 1.e-8_r8) THEN    !! WHEN CLOUD IS PRESENTED
 
-             if (cloud_borne) then
-                patm_x = patm
-             else
-                patm_x = 1._r8
-             endif
-
-             if (cloud_borne) then
-
-                pso4 = rah2o2 * 7.4e4_r8*EXP(6621._r8*work1(i)) * h2o2g * patm_x &
-                     * 1.23_r8 *EXP(3120._r8*work1(i)) * so2g * patm_x
-             else
-                pso4 = rah2o2 * heh2o2(i,k) * h2o2g * patm_x  &
-                     * heso2(i,k)  * so2g  * patm_x    ! [M/s]
-
-             endif
+             pso4 = rah2o2 * heh2o2(i,k) * h2o2g * patm  &
+                    * heso2(i,k)  * so2g  * patm  ! [M/s]
 
              pso4 = pso4 & ! [M/s] = [mole/L(w)/s]
                   * xl & ! [mole/L(a)/s]
                   / const0 & ! [/L(a)/s]
                   / xhnm(i,k)
 
+             ! estimate the net production of so4, without exceeding reactant concentrations
+             xso4_init(i,k) = xso4(i,k)
+             ccc            = max(min(pso4*dtime, min(xh2o2(i,k) - SMALL_NUMBER, xso2(i,k) - SMALL_NUMBER)), 0.0_r8)
+             xso4(i,k)      = xso4(i,k) + ccc
+             xh2o2(i,k)     = xh2o2(i,k) - ccc
+             xso2(i,k)      = xso2(i,k)  - ccc
+             xdelso4hp(i,k) = ccc
 
-             ccc = pso4*dtime
-             ccc = max(ccc, 1.e-30_r8)
-
-             xso4_init(i,k)=xso4(i,k)
-
-             IF (xh2o2(i,k) .gt. xso2(i,k)) THEN
-                if (ccc .gt. xso2(i,k)) then
-                   xso4(i,k)=xso4(i,k)+xso2(i,k)
-                   if (cloud_borne) then
-                      xh2o2(i,k)=xh2o2(i,k)-xso2(i,k)
-                      xso2(i,k)=1.e-20_r8
-                   else       ! ???? bug ????
-                      xso2(i,k)=1.e-20_r8
-                      xh2o2(i,k)=xh2o2(i,k)-xso2(i,k)
-                   endif
-                else
-                   xso4(i,k)  = xso4(i,k)  + ccc
-                   xh2o2(i,k) = xh2o2(i,k) - ccc
-                   xso2(i,k)  = xso2(i,k)  - ccc
-                end if
-
-             ELSE
-                if (ccc  .gt. xh2o2(i,k)) then
-                   xso4(i,k)=xso4(i,k)+xh2o2(i,k)
-                   xso2(i,k)=xso2(i,k)-xh2o2(i,k)
-                   xh2o2(i,k)=1.e-20_r8
-                else
-                   xso4(i,k)  = xso4(i,k)  + ccc
-                   xh2o2(i,k) = xh2o2(i,k) - ccc
-                   xso2(i,k)  = xso2(i,k)  - ccc
-                end if
-             END IF
-
-             if (cloud_borne) then
-                xdelso4hp(i,k)  =  xso4(i,k) - xso4_init(i,k)
-             endif
              !...........................
              !       S(IV) + O3 = S(VI)
              !...........................
 
-             pso4 = rao3 * heo3(i,k)*o3g*patm_x * heso2(i,k)*so2g*patm_x  ! [M/s]
+             pso4 = rao3 * heo3(i,k)*o3g*patm * heso2(i,k)*so2g*patm  ! [M/s]
 
              pso4 = pso4        &                                ! [M/s] =  [mole/L(w)/s]
                   * xl          &                                ! [mole/L(a)/s]
                   / const0      &                                ! [/L(a)/s]
                   / xhnm(i,k)                                    ! [mixing ratio/s]
 
-             ccc = pso4*dtime
-             ccc = max(ccc, 1.e-30_r8)
-
-             xso4_init(i,k)=xso4(i,k)
-
-             if (ccc .gt. xso2(i,k)) then
-                xso4(i,k) = xso4(i,k) + xso2(i,k)
-                xso2(i,k) = 1.e-20_r8
-             else
-                xso4(i,k) = xso4(i,k) + ccc
-                xso2(i,k) = xso2(i,k) - ccc
-             end if
+             ! estimate the net production of so4, without exceeding reactant concentrations
+             xso4_init(i,k) = xso4(i,k)
+             ccc            = max(min(pso4*dtime, xso2(i,k) - SMALL_NUMBER), 0.0_r8)
+             xso4(i,k)      = xso4(i,k) + ccc
+             xso2(i,k)      = xso2(i,k) - ccc
 
           END IF !! WHEN CLOUD IS PRESENTED
 
@@ -883,5 +901,20 @@ contains
     call sox_cldaero_destroy_obj(cldconc)
 
   end subroutine setsox
+
+   !-----------------------------------------------------------------
+   !       ... looks up Effective Henry's Law Constant parameters
+   !-----------------------------------------------------------------
+   pure integer function get_heff_index(species_name) result(index)
+      use shr_drydep_mod, only: species_name_table
+
+      character(len=*), intent(in) :: species_name
+
+      do index = 1, size(species_name_table)
+         if (trim(adjustl(species_name)) == &
+             trim(adjustl(species_name_table(index)))) return
+      end do
+      index = -1
+   end function get_heff_index
 
 end module mo_setsox

--- a/src_cam/physpkg.F90
+++ b/src_cam/physpkg.F90
@@ -1941,8 +1941,6 @@ contains
        !  . Aerosol wet chemistry determines scavenging fractions, and transformations
        !  . Then do convective transport of all trace species except qv,ql,qi.
        !  . We needed to do the scavenging first to determine the interstitial fraction.
-       !  . When UNICON is used as unified convection, we should still perform
-       !    wet scavenging but not 'convect_deep_tend2'.
        ! -------------------------------------------------------------------------------
 
        call t_startf('aerosol_wet_processes')

--- a/src_cam/radiation.F90
+++ b/src_cam/radiation.F90
@@ -162,6 +162,9 @@ real(r8) :: rad_uniform_angle = -99._r8
 ! PIO descriptors (for restarts)
 type(var_desc_t) :: cospcnt_desc
 type(var_desc_t) :: nextsw_cday_desc
+
+! set by cloud_rad_props_init
+real(kind=r8) :: tiny
 !===============================================================================
 contains
 !===============================================================================
@@ -397,7 +400,8 @@ subroutine radiation_init(pbuf2d)
    call rad_data_init(pbuf2d) ! initialize output fields for offline driver
    call radsw_init()
    call radlw_init()
-   call cloud_rad_props_init()
+   ! Read ice and liquid optics files
+   call cloud_rad_props_init(tiny)
 
    cld_idx      = pbuf_get_index('CLD')
    cldfsnow_idx = pbuf_get_index('CLDFSNOW',errcode=err)
@@ -954,7 +958,8 @@ subroutine radiation_tend( &
 
    if (use_rad_uniform_angle) then
       do i = 1, ncol
-         coszrs(i) = shr_orb_cosz(calday, clat(i), clon(i), delta, dt_avg, uniform_angle=rad_uniform_angle)
+         coszrs(i) = shr_orb_cosz(calday, clat(i), clon(i), delta, dt_avg, &
+              uniform_angle=rad_uniform_angle)
       end do
    else
       do i = 1, ncol
@@ -1494,7 +1499,7 @@ subroutine radiation_tend( &
 
    ! Compute net radiative heating tendency
    call radheat_tend(state, pbuf,  ptend, qrl, qrs, fsns, &
-                     fsnt, flns, flnt, cam_in%asdir, net_flx)
+                     fsnt, flns, flnt, cam_in%asdir, coszrs, net_flx)
 
    if (write_output) then
       ! Compute heating rate for dtheta/dt

--- a/src_cam/vertical_diffusion.F90
+++ b/src_cam/vertical_diffusion.F90
@@ -115,10 +115,6 @@ integer              :: ixnumice, ixnumliq
 
 integer              :: pblh_idx, tpert_idx, qpert_idx
 
-! pbuf fields for unicon
-integer              :: qtl_flx_idx  = -1            ! for use in cloud macrophysics when UNICON is on
-integer              :: qti_flx_idx  = -1            ! for use in cloud macrophysics when UNICON is on
-
 ! pbuf fields for tms
 integer              :: ksrftms_idx  = -1
 integer              :: tautmsx_idx  = -1
@@ -238,11 +234,6 @@ subroutine vd_register()
 
   call pbuf_add_field('tpert', 'global', dtype_r8, (/pcols/),           tpert_idx)
   call pbuf_add_field('qpert', 'global', dtype_r8, (/pcols/),           qpert_idx)
-
-  if (trim(shallow_scheme) == 'UNICON') then
-     call pbuf_add_field('qtl_flx',  'global', dtype_r8, (/pcols, pverp/), qtl_flx_idx)
-     call pbuf_add_field('qti_flx',  'global', dtype_r8, (/pcols, pverp/), qti_flx_idx)
-  end if
 
   ! diag_TKE fields
   if (eddy_scheme == 'diag_TKE') then
@@ -652,10 +643,6 @@ subroutine vertical_diffusion_init(pbuf2d)
      ! Initialization of pbuf fields tke, kvh, kvm are done in phys_inidat
      call pbuf_set_field(pbuf2d, tauresx_idx,  0.0_r8)
      call pbuf_set_field(pbuf2d, tauresy_idx,  0.0_r8)
-     if (trim(shallow_scheme) == 'UNICON') then
-        call pbuf_set_field(pbuf2d, qtl_flx_idx,  0.0_r8)
-        call pbuf_set_field(pbuf2d, qti_flx_idx,  0.0_r8)
-     end if
   end if
 end subroutine vertical_diffusion_init
 
@@ -757,9 +744,6 @@ subroutine vertical_diffusion_tend( &
 
   real(r8) :: dtk(pcols,pver)                                     ! T tendency from KE dissipation
   real(r8), pointer   :: tke(:,:)                                 ! Turbulent kinetic energy [ m2/s2 ]
-
-  real(r8), pointer   :: qtl_flx(:,:)                             ! overbar(w'qtl') where qtl = qv + ql
-  real(r8), pointer   :: qti_flx(:,:)                             ! overbar(w'qti') where qti = qv + qi
 
   real(r8) :: cgs(pcols,pverp)                                    ! Counter-gradient star  [ cg/flux ]
   real(r8) :: cgh(pcols,pverp)                                    ! Counter-gradient term for heat
@@ -1306,28 +1290,6 @@ subroutine vertical_diffusion_tend( &
      qtflx_cg(:ncol,pverp) = 0._r8
      uflx_cg(:ncol,pverp)  = 0._r8
      vflx_cg(:ncol,pverp)  = 0._r8
-
-     if (trim(shallow_scheme) == 'UNICON') then
-        call pbuf_get_field(pbuf, qtl_flx_idx,  qtl_flx)
-        call pbuf_get_field(pbuf, qti_flx_idx,  qti_flx)
-        qtl_flx(:ncol,1) = 0._r8
-        qti_flx(:ncol,1) = 0._r8
-        do k = 2, pver
-           do i = 1, ncol
-              ! For use in the cloud macrophysics
-              ! Note that density is not added here. Also, only consider local transport term.
-              qtl_flx(i,k) = - kvh(i,k)*(q_tmp(i,k-1,1)-q_tmp(i,k,1)+q_tmp(i,k-1,ixcldliq)-q_tmp(i,k,ixcldliq))/&
-                   (state%zm(i,k-1)-state%zm(i,k))
-              qti_flx(i,k) = - kvh(i,k)*(q_tmp(i,k-1,1)-q_tmp(i,k,1)+q_tmp(i,k-1,ixcldice)-q_tmp(i,k,ixcldice))/&
-                   (state%zm(i,k-1)-state%zm(i,k))
-           end do
-        end do
-        do i = 1, ncol
-           rhoair = state%pint(i,pverp)/(rair*((slv(i,pver)-gravit*state%zi(i,pverp))/cpair))
-           qtl_flx(i,pverp) = cam_in%cflx(i,1)/rhoair
-           qti_flx(i,pverp) = cam_in%cflx(i,1)/rhoair
-        end do
-     end if
 
   end if
 


### PR DESCRIPTION
Some updates from the RRTMGP work that affect all versions
Changes due to removing UNICON

Addresses NorESMhub/CAM#241
Original issue: ESCOMP/CAM#1345

See [comparison with recent NorESM beta03 experiment](https://ns2345k.web.sigma2.no/datalake/diagnostics/ADF/goldy/n1850.ne16_tn14.noresm3_0_beta03_rafsipmasstonum.20251023_1_10_vs_n1850.ne16_tn14.noresm3_0_beta03_rafsipmasstonum.20250930_1_10/website/index.html)