### PR TITLE
oslo_aero_2_3a4: Corrections for constituents not found

### DIFF
--- a/src/oslo_aero_share.F90
+++ b/src/oslo_aero_share.F90
@@ -378,8 +378,20 @@ contains
       ! gas phase species
       call cnst_get_ind('SO2'    ,l_so2,   abort=.true.) !sulfur dioxide
       call cnst_get_ind('DMS'    ,l_dms,   abort=.true.) !dimethyl sulfide
-      call cnst_get_ind('monoterp'  ,l_monoterp, abort=.true.) !monoterpenes
-      call cnst_get_ind('isoprene'  ,l_isoprene, abort=.true.) !isoprene
+      call cnst_get_ind('monoterp'  ,l_monoterp, abort=.false.) !monoterpenes
+      if (l_monoterp < 0) then
+         call cnst_get_ind('MTERP'  ,l_monoterp, abort=.false.) !monoterpenes
+         if (l_monoterp < 0) then
+            call endrun("Neither 'monoterp' or 'MTERP' found in constituents")
+         end if
+      end if
+      call cnst_get_ind('isoprene'  ,l_isoprene, abort=.false.) !isoprene
+      if (l_isoprene < 0) then
+         call cnst_get_ind('ISOP'  ,l_isoprene, abort=.true.) !isoprene
+         if (l_isoprene < 0) then
+            call endrun("Neither 'isoprene' or 'ISOP' found in constituents")
+         end if
+      end if
 
       ! Register the tracers in modes
       call registerTracersInMode()

--- a/src_cam/mo_extfrc.F90
+++ b/src_cam/mo_extfrc.F90
@@ -370,9 +370,10 @@ contains
     !--------------------------------------------------------
     !	... form the external forcing
     !--------------------------------------------------------
-    use mo_chem_utls,  only : get_spc_ndx
+    use mo_chem_utls,    only : get_spc_ndx
     ! OSLO_AERO begin
     use constituents,    only : cnst_get_ind
+    use oslo_aero_share, only : l_bc_ax, l_bc_ni, l_bc_n, l_om_ni, l_so2, l_so4_pr
     ! OSLO_AERO end
 
     implicit none
@@ -442,10 +443,11 @@ contains
           !OSLO_AERO begin
           ! get the index of the forcing index that coresponds to the l_spc system
           call cnst_get_ind(trim(extfrc_lst(n)), l_aero, abort=.false.)
-          if (l_aero < 1) then
-             call endrun("extfrc_set: No constituent, '"//trim(extfrc_lst(n))//"'")
+          if ( l_aero == l_bc_ax .or. l_aero == l_bc_ni .or. l_aero == l_bc_n .or. &
+               l_aero == l_om_ni .or. l_aero == l_so2 .or. l_aero == l_so4_pr ) then
+             ! add the forcing to the CMXF_fields array
+             CMXF_fields(:ncol,l_aero,lchnk) = CMXF_fields(:ncol,l_aero,lchnk) + frcing_col_kg(:ncol)
           end if
-          CMXF_fields(:ncol,l_aero,lchnk) = CMXF_fields(:ncol,l_aero,lchnk) + frcing_col_kg(:ncol)
           !OSLO_AERO end
 
           xfcname = trim(extfrc_lst(n))//'_CLXF'

--- a/src_cam/mo_extfrc.F90
+++ b/src_cam/mo_extfrc.F90
@@ -442,6 +442,9 @@ contains
           !OSLO_AERO begin
           ! get the index of the forcing index that coresponds to the l_spc system
           call cnst_get_ind(trim(extfrc_lst(n)), l_aero, abort=.false.)
+          if (l_aero < 1) then
+             call endrun("extfrc_set: No constituent, '"//trim(extfrc_lst(n))//"'")
+          end if
           CMXF_fields(:ncol,l_aero,lchnk) = CMXF_fields(:ncol,l_aero,lchnk) + frcing_col_kg(:ncol)
           !OSLO_AERO end
 


### PR DESCRIPTION
In some runs `cnst_get_ind` was failing due to looking for a constituent not in the array.

In `extfrc_set`, not every constituent listed in `extfrc_set` is present in all runs. This PR includes changes to only look for fields needed to perform the requested update (lines 445 - 450).

In oslo_aero_share, changes were made to accept either 'monoterp' or 'MTERP' for the monoterpene constituent name and also to accept either 'isoprene' or 'ISOP' for the isoprene constituent name.