### PR TITLE
Add in processing of prescribed volcanic emissions

### DIFF
--- a/src_cam/prescribed_volcaero.F90
+++ b/src_cam/prescribed_volcaero.F90
@@ -1,11 +1,12 @@
 module prescribed_volcaero
 
-   use shr_kind_mod,     only : r8 => shr_kind_r8, cs => shr_kind_cs
-   use cam_abortutils,   only : endrun
-   use spmd_utils,       only : mpicom, mstrid=>masterprocid, masterproc
-   use spmd_utils,       only : mpi_logical, mpi_real8, mpi_character, mpi_integer, mpi_success
-   use tracer_data,      only : trfld, trfile
-   use cam_logfile,      only : iulog
+   use shr_kind_mod,     only: r8 => shr_kind_r8, cs => shr_kind_cs
+   use cam_abortutils,   only: endrun
+   use spmd_utils,       only: mpicom, mstrid=>masterprocid, masterproc
+   use spmd_utils,       only: mpi_logical, mpi_real8, mpi_character, mpi_integer, mpi_success
+   use tracer_data,      only: trfld, trfile
+   use cam_logfile,      only: iulog
+   use string_utils,     only: int2str
 
    implicit none
    private
@@ -142,21 +143,18 @@ contains
       ! Local variables
       integer :: idx
       integer :: band
-      character(len=3) :: c3
       !---------------------------------------------------
 
       if (has_prescribed_volcaero) then
          do band=1,solar_bands
-            write(c3,'(i3)') band
-            call pbuf_add_field('ext_sun'   //trim(adjustl(c3)),'physpkg',dtype_r8,(/pcols,pver/),idx)
-            call pbuf_add_field('omega_sun' //trim(adjustl(c3)),'physpkg',dtype_r8,(/pcols,pver/),idx)
-            call pbuf_add_field('g_sun'     //trim(adjustl(c3)),'physpkg',dtype_r8,(/pcols,pver/),idx)
+            call pbuf_add_field('ext_sun'  //trim(int2str(band)),'physpkg',dtype_r8,(/pcols,pver/),idx)
+            call pbuf_add_field('omega_sun'//trim(int2str(band)),'physpkg',dtype_r8,(/pcols,pver/),idx)
+            call pbuf_add_field('g_sun'    //trim(int2str(band)),'physpkg',dtype_r8,(/pcols,pver/),idx)
          enddo
          do band=1,terrestrial_bands
-            write(c3,'(i3)') band
-            call pbuf_add_field('ext_earth'   //trim(adjustl(c3)),'physpkg',dtype_r8,(/pcols,pver/),idx)
-            call pbuf_add_field('omega_earth' //trim(adjustl(c3)),'physpkg',dtype_r8,(/pcols,pver/),idx)
-            call pbuf_add_field('g_earth'     //trim(adjustl(c3)),'physpkg',dtype_r8,(/pcols,pver/),idx)
+            call pbuf_add_field('ext_earth'  //trim(int2str(band)),'physpkg',dtype_r8,(/pcols,pver/),idx)
+            call pbuf_add_field('omega_earth'//trim(int2str(band)),'physpkg',dtype_r8,(/pcols,pver/),idx)
+            call pbuf_add_field('g_earth'    //trim(int2str(band)),'physpkg',dtype_r8,(/pcols,pver/),idx)
          enddo
       endif
 
@@ -170,7 +168,6 @@ contains
 
       ! Local variables
       integer           :: band
-      character(len=3)  :: c3
       character(len=32) :: specifier(3*(solar_bands+terrestrial_bands))
       !---------------------------------------------------
 
@@ -180,22 +177,23 @@ contains
          endif
 
          do band=1,solar_bands
-            write(c3,'(i3)') band
-            specifier(band*3-2) = 'ext_sun'   //trim(adjustl(c3))//':'//'ext_sun'//trim(adjustl(c3))
-            specifier(band*3-1) = 'omega_sun' //trim(adjustl(c3))//':'//'omega_sun'//trim(adjustl(c3))
-            specifier(band*3-0) = 'g_sun'     //trim(adjustl(c3))//':'//'g_sun'//trim(adjustl(c3))
-            call addfld('ext_sun'   //trim(adjustl(c3)),(/ 'lev' /), 'I', '1/km', 'Extinction coefficient of solar bands' )
-            call addfld('omega_sun' //trim(adjustl(c3)),(/ 'lev' /), 'I', '1'   , 'Single scattering albedo of solar bands' )
-            call addfld('g_sun'     //trim(adjustl(c3)),(/ 'lev' /), 'I', '1'   , 'Asymmetry factor of solar bands' )
+            specifier(band*3-2) = 'ext_sun'  //trim(int2str(band))//':'//'ext_sun'//trim(int2str(band))
+            specifier(band*3-1) = 'omega_sun'//trim(int2str(band))//':'//'omega_sun'//trim(int2str(band))
+            specifier(band*3-0) = 'g_sun'    //trim(int2str(band))//':'//'g_sun'//trim(int2str(band))
+            call addfld('ext_sun'  //trim(int2str(band)),(/ 'lev' /), 'I', '1/km', 'Extinction coefficient of solar bands' )
+            call addfld('omega_sun'//trim(int2str(band)),(/ 'lev' /), 'I', '1'   , 'Single scattering albedo of solar bands' )
+            call addfld('g_sun'    //trim(int2str(band)),(/ 'lev' /), 'I', '1'   , 'Asymmetry factor of solar bands' )
          enddo
          do band=1,terrestrial_bands
-            write(c3,'(i3)') band
-            specifier((solar_bands+band)*3-2) = 'ext_earth'   //trim(adjustl(c3))//':'//'ext_earth'//trim(adjustl(c3))
-            specifier((solar_bands+band)*3-1) = 'omega_earth' //trim(adjustl(c3))//':'//'omega_earth'//trim(adjustl(c3))
-            specifier((solar_bands+band)*3-0) = 'g_earth'     //trim(adjustl(c3))//':'//'g_earth'//trim(adjustl(c3))
-            call addfld('ext_earth'   //trim(adjustl(c3)),(/ 'lev' /), 'I', '1/km', 'Extinction coefficient of terrestrial bands' )
-            call addfld('omega_earth' //trim(adjustl(c3)),(/ 'lev' /), 'I', '1'   , 'Single scattering albedo of terrestrial bands' )
-            call addfld('g_earth'     //trim(adjustl(c3)),(/ 'lev' /), 'I', '1'   , 'Asymmetry factor of terrestrial bands' )
+            specifier((solar_bands+band)*3-2) = 'ext_earth'  //trim(int2str(band))//':'//'ext_earth'//trim(int2str(band))
+            specifier((solar_bands+band)*3-1) = 'omega_earth'//trim(int2str(band))//':'//'omega_earth'//trim(int2str(band))
+            specifier((solar_bands+band)*3-0) = 'g_earth'    //trim(int2str(band))//':'//'g_earth'//trim(int2str(band))
+            call addfld('ext_earth'  //trim(int2str(band)),(/ 'lev' /), 'I', '1/km', &
+                 'Extinction coefficient of terrestrial bands')
+            call addfld('omega_earth'//trim(int2str(band)),(/ 'lev' /), 'I', '1'   , &
+                 'Single scattering albedo of terrestrial bands')
+            call addfld('g_earth'    //trim(int2str(band)),(/ 'lev' /), 'I', '1'   , &
+                 'Asymmetry factor of terrestrial bands')
          enddo
 
          allocate(file%in_pbuf(size(specifier)))
@@ -224,7 +222,6 @@ contains
       integer           :: c,ncol,i,k
       integer           :: band
       real(r8), pointer :: data(:,:)
-      character(len=3)  :: c3
       integer           :: tropLev(pcols)
       type(physics_buffer_desc), pointer :: pbuf_chnk(:)
       !---------------------------------------------------
@@ -240,52 +237,50 @@ contains
             call tropopause_find_cam(pstate=state(c), tropLev=tropLev)
             ncol = state(c)%ncol
             do band=1,solar_bands
-               write(c3,'(i3)') band
                call pbuf_get_field(pbuf_chnk, fields(band*3-2)%pbuf_ndx, data)
                do i = 1,ncol
                   do k = 1,pver
                      if ( k >= tropLev(i) ) data(i,k) = 0._r8
                   enddo
                enddo
-               call outfld('ext_sun'//trim(adjustl(c3)),data(:,:), pcols, state(c)%lchnk)
+               call outfld('ext_sun'//trim(int2str(band)),data(:,:), pcols, state(c)%lchnk)
                call pbuf_get_field(pbuf_chnk, fields(band*3-1)%pbuf_ndx, data)
                do i = 1,ncol
                   do k = 1,pver
                      if ( k >= tropLev(i) ) data(i,k) = 0.999_r8
                   enddo
                enddo
-               call outfld('omega_sun'//trim(adjustl(c3)),data(:,:), pcols, state(c)%lchnk)
+               call outfld('omega_sun'//trim(int2str(band)),data(:,:), pcols, state(c)%lchnk)
                call pbuf_get_field(pbuf_chnk, fields(band*3-0)%pbuf_ndx, data)
                do i = 1,ncol
                   do k = 1,pver
                      if ( k >= tropLev(i) ) data(i,k) = 0.5_r8
                   enddo
                enddo
-               call outfld('g_sun'//trim(adjustl(c3)),data(:,:), pcols, state(c)%lchnk)
+               call outfld('g_sun'//trim(int2str(band)),data(:,:), pcols, state(c)%lchnk)
             enddo
             do band=1,terrestrial_bands
-               write(c3,'(i3)') band
                call pbuf_get_field(pbuf_chnk, fields((solar_bands+band)*3-2)%pbuf_ndx, data)
                do i = 1,ncol
                   do k = 1,pver
                      if ( k >= tropLev(i) ) data(i,k) = 0._r8
                   enddo
                enddo
-               call outfld('ext_earth'//trim(adjustl(c3)),data(:,:), pcols, state(c)%lchnk)
+               call outfld('ext_earth'//trim(int2str(band)),data(:,:), pcols, state(c)%lchnk)
                call pbuf_get_field(pbuf_chnk, fields((solar_bands+band)*3-1)%pbuf_ndx, data)
                do i = 1,ncol
                   do k = 1,pver
                      if ( k >= tropLev(i) ) data(i,k) = 0.999_r8
                   enddo
                enddo
-               call outfld('omega_earth'//trim(adjustl(c3)),data(:,:), pcols, state(c)%lchnk)
+               call outfld('omega_earth'//trim(int2str(band)),data(:,:), pcols, state(c)%lchnk)
                call pbuf_get_field(pbuf_chnk, fields((solar_bands+band)*3-0)%pbuf_ndx, data)
                do i = 1,ncol
                   do k = 1,pver
                      if ( k >= tropLev(i) ) data(i,k) = 0.5_r8
                   enddo
                enddo
-               call outfld('g_earth'//trim(adjustl(c3)),data(:,:), pcols, state(c)%lchnk)
+               call outfld('g_earth'//trim(int2str(band)),data(:,:), pcols, state(c)%lchnk)
             enddo
          enddo
       endif

--- a/src_cam/radiation.F90
+++ b/src_cam/radiation.F90
@@ -42,8 +42,9 @@ use cam_abortutils,      only: endrun
 use error_messages,      only: handle_err
 use perf_mod,            only: t_startf, t_stopf
 use cam_logfile,         only: iulog
+use string_utils,        only: int2str
 ! OSLO_AERO begin
-use prescribed_volcaero,      only: has_prescribed_volcaero
+use prescribed_volcaero,      only: has_prescribed_volcaero, solar_bands, terrestrial_bands
 use oslo_aero_optical_params, only: oslo_aero_optical_params_calc
 use oslo_aero_share,          only: nmodes_oslo=>nmodes
 use oslo_aero_control,        only: use_aerocom
@@ -52,7 +53,6 @@ use oslo_aero_aerocom,        only: dod440, dod550, dod870, abs550, abs550alt
 
 implicit none
 private
-save
 
 public :: &
    radiation_readnl,         &! read namelist variables
@@ -782,6 +782,7 @@ subroutine radiation_tend( &
    ! OSLO_AERO begin
    integer                  :: band
    logical                  :: idrf
+   integer                  :: volc_idx
    ! OSLO_AERO end
    type(rad_out_t), pointer :: rd  ! allow rd_out to be optional by allocating a local object
                                    ! if the argument is not present
@@ -816,6 +817,9 @@ subroutine radiation_tend( &
    real(r8), pointer :: fsnt(:)  ! Net column abs solar flux at model top
    real(r8), pointer :: flns(:)  ! Srf longwave cooling (up-down) flux
    real(r8), pointer :: flnt(:)  ! Net outgoing lw flux at model top
+   ! OSLO_AERO begin
+   real(r8), pointer :: volcopt(:,:)  ! Read in stratospheric volcano SW optical parameter
+   ! OSLO_AERO end
 
    real(r8), pointer, dimension(:,:,:) :: su => NULL()  ! shortwave spectral flux up
    real(r8), pointer, dimension(:,:,:) :: sd => NULL()  ! shortwave spectral flux down
@@ -1247,23 +1251,48 @@ subroutine radiation_tend( &
       call t_stopf('cldoptics')
 
       ! Solar radiation computation
-
       if (dosw) then
 
          ! OSLO_AERO begin
          qdirind(:ncol,:,:) = state%q(:ncol,:,:)
 
          ! Volcanic optics for solar (SW) bands
-         do band=1,nswbands
-            volc_ext_sun(1:ncol,1:pver,band)=0.0_r8
-            volc_omega_sun(1:ncol,1:pver,band)=0.999_r8
-            volc_g_sun(1:ncol,1:pver,band)=0.5_r8
-         enddo
+         do band = 1, nswbands
+            volc_ext_sun(:ncol, :pver, band) = 0.0_r8
+            volc_omega_sun(:ncol, :pver, band) = 0.999_r8
+            volc_g_sun(:ncol, :pver, band) = 0.5_r8
+         end do
+         if (has_prescribed_volcaero) then
+            do band = 1, solar_bands
+               volc_idx = pbuf_get_index('ext_sun'//int2str(band))
+               call pbuf_get_field(pbuf, volc_idx, volcopt, start=(/1,1,itim_old/), kount=(/pcols,pver,1/))
+               volc_ext_sun(:ncol, :pver, band) = volcopt(:ncol, :pver)
+               volc_idx = pbuf_get_index('omega_sun'//int2str(band))
+               call pbuf_get_field(pbuf, volc_idx, volcopt, start=(/1,1,itim_old/), kount=(/pcols,pver,1/))
+               volc_omega_sun(:ncol, :pver, band) = volcopt(:ncol, :pver)
+               volc_idx = pbuf_get_index('g_sun'//int2str(band))
+               call pbuf_get_field(pbuf, volc_idx, volcopt, start=(/1,1,itim_old/), kount=(/pcols,pver,1/))
+               volc_g_sun(:ncol, :pver, band) = volcopt(:ncol, :pver)
+            end do
+         end if
+
          !  Volcanic optics for terrestrial (LW) bands
-         do band=1,nlwbands
-            volc_ext_earth(1:ncol,1:pver,band) = 0.0_r8
-            volc_omega_earth(1:ncol,1:pver,band) = 0.999_r8
-         enddo
+         do band = 1, nlwbands
+            volc_ext_earth(:ncol, :pver, band) = 0.0_r8
+            volc_omega_earth(:ncol, :pver, band) = 0.999_r8
+         end do
+         !  Volcanic optics for terrestrial (LW) bands (g is not used here)
+         if (has_prescribed_volcaero) then
+            do band = 1, terrestrial_bands
+               volc_idx = pbuf_get_index('ext_earth'//int2str(band))
+               call pbuf_get_field(pbuf, volc_idx, volcopt, start=(/1,1,itim_old/), kount=(/pcols,pver,1/))
+               volc_ext_earth(:ncol, :pver, band) = volcopt(:ncol, :pver)
+
+               volc_idx = pbuf_get_index('omega_earth'//int2str(band))
+               call pbuf_get_field(pbuf, volc_idx, volcopt, start=(/1,1,itim_old/), kount=(/pcols,pver,1/))
+               volc_omega_earth(:ncol, :pver, band) = volcopt(:ncol, :pver)
+            end do
+         end if
 
          ! No aerocom variables passed for now
          ! dod440, dod550, dod870, abs550, abs550alt


### PR DESCRIPTION
Restore processing of inputs from a configured prescribed volcanic aerosol file.

fixes #66 