### PR TITLE
noresm_develop : added aerosol-free radiation call diagnostics

### DIFF
--- a/src/oslo_aero_diagnostics.F90
+++ b/src/oslo_aero_diagnostics.F90
@@ -49,6 +49,29 @@ contains
       call addfld ('FSDSCDRF',horiz_only, 'A','W/m^2   ','SW downwelling clear sky flux at surface')
       call addfld ('FLUS    ',horiz_only, 'A','W/m^2   ','LW surface upwelling flux')
 
+      !+++ djlo +++  
+      call addfld ('FSNTAF'   ,horiz_only, 'A','W/m^2   ','Net solar flux at top of model from aerosol-free radiation call')  
+      call addfld ('FSNTCAF'  ,horiz_only, 'A','W/m^2   ','Clearsky net solar flux at top of model from aerosol-free radiation call')  
+      call addfld ('FSNTOAAF' ,horiz_only, 'A','W/m^2   ','Net solar flux at top of atmosphere from aerosol-free radiation call')  
+      call addfld ('FSNTOACAF',horiz_only, 'A','W/m^2   ','Clearsky net solar flux at top of atmosphere from aerosol-free radiation call')  
+      call addfld ('FSUTOAAF' ,horiz_only, 'A','W/m^2   ','Upwelling solar flux at top of atmosphere from aerosol-free radiation call')  
+
+      call addfld ('FLNTAF'   ,horiz_only, 'A','W/m^2   ','Net longwave flux at top of model from aerosol-free radiation call') 
+      call addfld ('FLNTCAF'  ,horiz_only, 'A','W/m^2   ','Clearsky net longwave flux at top of model from aerosol-free radiation call') 
+      call addfld ('FLUTAF'   ,horiz_only, 'A','W/m^2   ','Upwelling longwave flux at top of model from aerosol-free radiation call') 
+      call addfld ('FLUTCAF'  ,horiz_only, 'A','W/m^2   ','Clearsky upwelling longwave flux at top of model from aerosol-free radiation call') 
+
+      call addfld ('FSNSAF'   ,horiz_only, 'A','W/m^2   ','Net solar flux at surface from aerosol-free radiation call')
+      call addfld ('FSNSCAF'  ,horiz_only, 'A','W/m^2   ','Clearsky net solar flux at surface from aerosol-free radiation call')
+      call addfld ('FSDSAF'   ,horiz_only, 'A','W/m^2   ','Downwelling solar flux at surface from aerosol-free radiation call')
+      call addfld ('FSDSCAF'  ,horiz_only, 'A','W/m^2   ','Clearsky downwelling solar flux at surface from aerosol-free radiation call')
+
+      call addfld ('FLNSAF'   ,horiz_only, 'A','W/m^2   ','Net longwave flux at surface from aerosol-free radiation call')  
+      call addfld ('FLNSCAF'  ,horiz_only, 'A','W/m^2   ','Clearsky net longwave flux at surface from aerosol-free radiation call')  
+      call addfld ('FLDSAF'   ,horiz_only, 'A','W/m^2   ','Downwelling longwave flux at surface from aerosol-free radiation call')  
+      call addfld ('FLDSCAF'  ,horiz_only, 'A','W/m^2   ','Clearsky Downwelling longwave flux at surface from aerosol-free radiation call')  
+      !--- djlo ---  
+
       if ( history_aerosol_base ) then
         call add_default ('AODVIS  ', 1, ' ')
         call add_default ('ABSVIS  ', 1, ' ')
@@ -79,6 +102,30 @@ contains
          call add_default ('FSUS_DRF', 1, ' ')
          call add_default ('FSDSCDRF', 1, ' ')
          call add_default ('FLUS    ', 1, ' ')
+
+      !+++ djlo +++  
+         call add_default ('FSNTAF'   , 1, ' ')
+         call add_default ('FSNTCAF'  , 1, ' ')
+         call add_default ('FSNTOAAF' , 1, ' ')
+         call add_default ('FSNTOACAF', 1, ' ')
+         call add_default ('FSUTOAAF' , 1, ' ')
+
+         call add_default ('FLNTAF'   , 1, ' ')
+         call add_default ('FLNTCAF'  , 1, ' ')
+         call add_default ('FLUTAF'   , 1, ' ')
+         call add_default ('FLUTCAF'  , 1, ' ')
+
+         call add_default ('FSNSAF'   , 1, ' ')
+         call add_default ('FSNSCAF'  , 1, ' ')
+         call add_default ('FSDSAF'   , 1, ' ')
+         call add_default ('FSDSCAF'  , 1, ' ')
+
+         call add_default ('FLNSAF'   , 1, ' ')
+         call add_default ('FLNSCAF'  , 1, ' ')
+         call add_default ('FLDSAF'   , 1, ' ')
+         call add_default ('FLDSCAF'  , 1, ' ')
+      !--- djlo ---  
+
       endif
 
       if (use_aerocom) then

--- a/src/oslo_aero_diagnostics.F90
+++ b/src/oslo_aero_diagnostics.F90
@@ -35,21 +35,10 @@ contains
       call addfld ('EXTVIS  ',(/'lev'/),   'A','1/km    ' ,'Aerosol extinction')
       call addfld ('BVISVOLC ',(/'lev'/),  'A','1/km    ' ,'CMIP6 volcanic aerosol extinction at 0.442-0.625um')
 
-      call addfld ('FSNT_DRF',horiz_only, 'A','W/m^2   ','Total column absorbed solar flux (DIRind)')
-      call addfld ('FSNTCDRF',horiz_only, 'A','W/m^2   ','Clear sky total column absorbed solar flux (DIRind)' )
-      call addfld ('FSNS_DRF',horiz_only, 'A','W/m^2   ','Surface absorbed solar flux (DIRind)' )
-      call addfld ('FSNSCDRF',horiz_only, 'A','W/m^2   ','Clear sky surface absorbed solar flux (DIRind)' )
-      call addfld ('QRS_DRF ',(/'lev'/),  'A','K/s     ','Solar heating rate (DIRind)')
-      call addfld ('QRSC_DRF',(/'lev'/),  'A','K/s     ','Clearsky solar heating rate (DIRind)' )
-      call addfld ('FLNT_DRF',horiz_only, 'A','W/m^2   ','Total column longwave flux (DIRind)' )
-      call addfld ('FLNTCDRF',horiz_only, 'A','W/m^2   ','Clear sky total column longwave flux (DIRind)' )
-      call addfld ('FSUTADRF',horiz_only, 'A','W/m^2   ','SW upwelling flux at TOA')
-      call addfld ('FSDS_DRF',horiz_only, 'A','W/m^2   ','SW downelling flux at surface')
-      call addfld ('FSUS_DRF',horiz_only, 'A','W/m^2   ','SW upwelling flux at surface')
-      call addfld ('FSDSCDRF',horiz_only, 'A','W/m^2   ','SW downwelling clear sky flux at surface')
+      call addfld ('QRSAF'   ,(/'lev'/),  'A','K/s     ','Solar heating rate from aerosol-free radiation call')
+      call addfld ('QRSCAF'  ,(/'lev'/),  'A','K/s     ','Clearsky solar heating rate from aerosol-free radiation call' )
       call addfld ('FLUS    ',horiz_only, 'A','W/m^2   ','LW surface upwelling flux')
 
-      !+++ djlo +++  
       call addfld ('FSNTAF'   ,horiz_only, 'A','W/m^2   ','Net solar flux at top of model from aerosol-free radiation call')  
       call addfld ('FSNTCAF'  ,horiz_only, 'A','W/m^2   ','Clearsky net solar flux at top of model from aerosol-free radiation call')  
       call addfld ('FSNTOAAF' ,horiz_only, 'A','W/m^2   ','Net solar flux at top of atmosphere from aerosol-free radiation call')  
@@ -70,7 +59,6 @@ contains
       call addfld ('FLNSCAF'  ,horiz_only, 'A','W/m^2   ','Clearsky net longwave flux at surface from aerosol-free radiation call')  
       call addfld ('FLDSAF'   ,horiz_only, 'A','W/m^2   ','Downwelling longwave flux at surface from aerosol-free radiation call')  
       call addfld ('FLDSCAF'  ,horiz_only, 'A','W/m^2   ','Clearsky Downwelling longwave flux at surface from aerosol-free radiation call')  
-      !--- djlo ---  
 
       if ( history_aerosol_base ) then
         call add_default ('AODVIS  ', 1, ' ')
@@ -89,21 +77,8 @@ contains
          call add_default ('ASYMMVIS', 1, ' ')
          call add_default ('EXTVIS  ', 1, ' ')
          call add_default ('BVISVOLC', 1, ' ')
-         call add_default ('FSNT_DRF', 1, ' ')
-         call add_default ('FSNTCDRF', 1, ' ')
-         call add_default ('FSNS_DRF', 1, ' ')
-         call add_default ('FSNSCDRF', 1, ' ')
-         call add_default ('QRS_DRF ', 1, ' ')
-         call add_default ('QRSC_DRF', 1, ' ')
-         call add_default ('FLNT_DRF', 1, ' ')
-         call add_default ('FLNTCDRF', 1, ' ')
-         call add_default ('FSUTADRF', 1, ' ')
-         call add_default ('FSDS_DRF', 1, ' ')
-         call add_default ('FSUS_DRF', 1, ' ')
-         call add_default ('FSDSCDRF', 1, ' ')
          call add_default ('FLUS    ', 1, ' ')
 
-      !+++ djlo +++  
          call add_default ('FSNTAF'   , 1, ' ')
          call add_default ('FSNTCAF'  , 1, ' ')
          call add_default ('FSNTOAAF' , 1, ' ')
@@ -124,7 +99,6 @@ contains
          call add_default ('FLNSCAF'  , 1, ' ')
          call add_default ('FLDSAF'   , 1, ' ')
          call add_default ('FLDSCAF'  , 1, ' ')
-      !--- djlo ---  
 
       endif
 

--- a/src_cam/radiation.F90
+++ b/src_cam/radiation.F90
@@ -547,8 +547,8 @@ subroutine radiation_init(pbuf2d)
    end do
 
    ! OSLO_AERO begin
-   call addfld('FDSCDRF', (/ 'ilev' /), 'A', 'W/m2', 'Shortwave clear-sky downward flux')
-   call addfld('FUSCDRF', (/ 'ilev' /), 'A', 'W/m2', 'Shortwave clear-sky upward flux')
+   call addfld('FDSCAF', (/ 'ilev' /), 'A', 'W/m2', 'Shortwave clear-sky downward flux from aerosol-free radiation call')
+   call addfld('FUSCAF', (/ 'ilev' /), 'A', 'W/m2', 'Shortwave clear-sky upward flux from aerosol-free radiation call')
    ! OSLO_AERO end
 
    if (scm_crm_mode) then
@@ -1341,21 +1341,15 @@ subroutine radiation_tend( &
                   E_cld_tau_w_f=c_cld_tau_w_f, old_convert=.false., idrf=.true.)
 
                ! Dump shortwave radiation information to history tape buffer (diagnostics)
-               ! Note that DRF fields are now from the aer_tau=0 call (clean), no longer with
+               ! Note that AF fields are now from the aer_tau=0 call (clean), no longer with
                ! aer_tau from oslo_aero_optical_params_calc
 
                ftem(:ncol,:pver) = qrs(:ncol,:pver)/cpair
-               call outfld('QRS_DRF ',ftem  ,pcols,lchnk)
+               call outfld('QRSAF',ftem  ,pcols,lchnk)
 
                ftem(:ncol,:pver) = rd%qrsc(:ncol,:pver)/cpair
-               call outfld('QRSC_DRF',ftem  ,pcols,lchnk)
+               call outfld('QRSCAF',ftem  ,pcols,lchnk)
 
-               call outfld('FSNT_DRF',fsnt     , pcols, lchnk)
-               call outfld('FSNS_DRF',fsns     , pcols, lchnk)
-               call outfld('FSNTCDRF',rd%fsntc , pcols, lchnk)
-               call outfld('FSNSCDRF',rd%fsnsc , pcols, lchnk)
-
-               !+++ djlo +++ 
                call outfld('FSNTAF'   ,fsnt        , pcols, lchnk)
                call outfld('FSNTCAF'  ,rd%fsntc    , pcols, lchnk)
                call outfld('FSNTOAAF' ,rd%fsntoa   , pcols, lchnk) 
@@ -1366,15 +1360,6 @@ subroutine radiation_tend( &
                call outfld('FSNSCAF'  ,rd%fsnsc    , pcols, lchnk)
                call outfld('FSDSAF'   ,fsds(:)     , pcols, lchnk)
                call outfld('FSDSCAF'  ,rd%fsdsc(:) , pcols, lchnk)
-               !--- djlo ---
-
-               if (use_aerocom) then
-                  call outfld('FSUTADRF',rd%fsutoa(:) , pcols, lchnk)
-                  call outfld('FSDS_DRF',fsds(:)      , pcols, lchnk)
-                  ftem_1d(1:ncol) = fsds(1:ncol)-fsns(1:ncol)
-                  call outfld('FSUS_DRF',ftem_1d      , pcols, lchnk)
-                  call outfld('FSDSCDRF',rd%fsdsc(:)  , pcols, lchnk)
-               end if
 
                call rad_rrtmg_sw( &
                   lchnk, ncol, num_rrtmg_levs, r_state, state%pmid,          &
@@ -1432,10 +1417,6 @@ subroutine radiation_tend( &
                     rd%flut, rd%flutc, fnl, fcnl, rd%fldsc,                   &
                     lu, ld)
 
-               call outfld('FLNT_DRF',flnt(:)    , pcols, lchnk)
-               call outfld('FLNTCDRF',rd%flntc(:), pcols, lchnk)
-
-               !+++ djlo +++ 
                call outfld('FLNTAF' ,flnt(:)    , pcols, lchnk)
                call outfld('FLNTCAF',rd%flntc(:), pcols, lchnk)
                call outfld('FLUTAF' ,rd%flut(:) , pcols, lchnk)
@@ -1445,7 +1426,6 @@ subroutine radiation_tend( &
                call outfld('FLNSCAF',rd%flnsc(:)     , pcols, lchnk)
                call outfld('FLDSAF' ,cam_out%flwds(:), pcols, lchnk)
                call outfld('FLDSCAF',rd%fldsc(:)     , pcols, lchnk) 
-               !--- djlo ---
 
                ! OSLO_AERO_END
 

--- a/src_cam/radiation.F90
+++ b/src_cam/radiation.F90
@@ -1354,6 +1354,20 @@ subroutine radiation_tend( &
                call outfld('FSNS_DRF',fsns     , pcols, lchnk)
                call outfld('FSNTCDRF',rd%fsntc , pcols, lchnk)
                call outfld('FSNSCDRF',rd%fsnsc , pcols, lchnk)
+
+               !+++ djlo +++ 
+               call outfld('FSNTAF'   ,fsnt        , pcols, lchnk)
+               call outfld('FSNTCAF'  ,rd%fsntc    , pcols, lchnk)
+               call outfld('FSNTOAAF' ,rd%fsntoa   , pcols, lchnk) 
+               call outfld('FSNTOACAF',rd%fsntoac  , pcols, lchnk) 
+               call outfld('FSUTOAAF' ,rd%fsutoa(:), pcols, lchnk)  
+
+               call outfld('FSNSAF'   ,fsns        , pcols, lchnk)
+               call outfld('FSNSCAF'  ,rd%fsnsc    , pcols, lchnk)
+               call outfld('FSDSAF'   ,fsds(:)     , pcols, lchnk)
+               call outfld('FSDSCAF'  ,rd%fsdsc(:) , pcols, lchnk)
+               !--- djlo ---
+
                if (use_aerocom) then
                   call outfld('FSUTADRF',rd%fsutoa(:) , pcols, lchnk)
                   call outfld('FSDS_DRF',fsds(:)      , pcols, lchnk)
@@ -1420,6 +1434,19 @@ subroutine radiation_tend( &
 
                call outfld('FLNT_DRF',flnt(:)    , pcols, lchnk)
                call outfld('FLNTCDRF',rd%flntc(:), pcols, lchnk)
+
+               !+++ djlo +++ 
+               call outfld('FLNTAF' ,flnt(:)    , pcols, lchnk)
+               call outfld('FLNTCAF',rd%flntc(:), pcols, lchnk)
+               call outfld('FLUTAF' ,rd%flut(:) , pcols, lchnk)
+               call outfld('FLUTCAF',rd%flutc(:), pcols, lchnk) 
+
+               call outfld('FLNSAF' ,flns(:)         , pcols, lchnk)
+               call outfld('FLNSCAF',rd%flnsc(:)     , pcols, lchnk)
+               call outfld('FLDSAF' ,cam_out%flwds(:), pcols, lchnk)
+               call outfld('FLDSCAF',rd%fldsc(:)     , pcols, lchnk) 
+               !--- djlo ---
+
                ! OSLO_AERO_END
 
                ! Note that aer_lw_abs which is an input to

--- a/src_cam/radiation.F90
+++ b/src_cam/radiation.F90
@@ -547,6 +547,7 @@ subroutine radiation_init(pbuf2d)
    end do
 
    ! OSLO_AERO begin
+   ! The outfld call for these diagnostic fields is in rad_rrtmg_sw (radsw.F90)
    call addfld('FDSCAF', (/ 'ilev' /), 'A', 'W/m2', 'Shortwave clear-sky downward flux from aerosol-free radiation call')
    call addfld('FUSCAF', (/ 'ilev' /), 'A', 'W/m2', 'Shortwave clear-sky upward flux from aerosol-free radiation call')
    ! OSLO_AERO end
@@ -1322,10 +1323,10 @@ subroutine radiation_tend( &
                call rrtmg_state_update(state, pbuf, icall, r_state)
 
                ! OSLO_AERO begin
-               ! A first call with Oslo aerosols set to zero for radiative forcing diagnostics
-               ! follwoing the Ghan (2013) method:
-               ! for calculation of direct radiative forcing, not necessarily "offline" as such anymore
-               ! (just nudged), but with an extra call with 0 aerosol extiction.
+               ! A first call with Oslo aerosols set to zero for radiative
+               ! forcing diagnostics following the Ghan (2013) method:
+               ! For calculation of direct radiative forcing online (nudged)
+               ! but with an extra call with 0 aerosol extiction.
 
                call rad_rrtmg_sw( &
                   lchnk, ncol, num_rrtmg_levs, r_state, state%pmid,               &
@@ -1340,9 +1341,9 @@ subroutine radiation_tend( &
                   E_cld_tau_w=c_cld_tau_w, E_cld_tau_w_g=c_cld_tau_w_g,           &
                   E_cld_tau_w_f=c_cld_tau_w_f, old_convert=.false., idrf=.true.)
 
-               ! Dump shortwave radiation information to history tape buffer (diagnostics)
-               ! Note that AF fields are now from the aer_tau=0 call (clean), no longer with
-               ! aer_tau from oslo_aero_optical_params_calc
+               ! Copy shortwave radiation information to history buffers.
+               ! Note that AF fields are now from the aer_tau=0 call (clean), no
+               ! longer with aer_tau from oslo_aero_optical_params_calc
 
                ftem(:ncol,:pver) = qrs(:ncol,:pver)/cpair
                call outfld('QRSAF',ftem  ,pcols,lchnk)
@@ -1352,9 +1353,9 @@ subroutine radiation_tend( &
 
                call outfld('FSNTAF'   ,fsnt        , pcols, lchnk)
                call outfld('FSNTCAF'  ,rd%fsntc    , pcols, lchnk)
-               call outfld('FSNTOAAF' ,rd%fsntoa   , pcols, lchnk) 
-               call outfld('FSNTOACAF',rd%fsntoac  , pcols, lchnk) 
-               call outfld('FSUTOAAF' ,rd%fsutoa(:), pcols, lchnk)  
+               call outfld('FSNTOAAF' ,rd%fsntoa   , pcols, lchnk)
+               call outfld('FSNTOACAF',rd%fsntoac  , pcols, lchnk)
+               call outfld('FSUTOAAF' ,rd%fsutoa(:), pcols, lchnk)
 
                call outfld('FSNSAF'   ,fsns        , pcols, lchnk)
                call outfld('FSNSCAF'  ,rd%fsnsc    , pcols, lchnk)
@@ -1420,12 +1421,12 @@ subroutine radiation_tend( &
                call outfld('FLNTAF' ,flnt(:)    , pcols, lchnk)
                call outfld('FLNTCAF',rd%flntc(:), pcols, lchnk)
                call outfld('FLUTAF' ,rd%flut(:) , pcols, lchnk)
-               call outfld('FLUTCAF',rd%flutc(:), pcols, lchnk) 
+               call outfld('FLUTCAF',rd%flutc(:), pcols, lchnk)
 
                call outfld('FLNSAF' ,flns(:)         , pcols, lchnk)
                call outfld('FLNSCAF',rd%flnsc(:)     , pcols, lchnk)
                call outfld('FLDSAF' ,cam_out%flwds(:), pcols, lchnk)
-               call outfld('FLDSCAF',rd%fldsc(:)     , pcols, lchnk) 
+               call outfld('FLDSCAF',rd%fldsc(:)     , pcols, lchnk)
 
                ! OSLO_AERO_END
 

--- a/src_cam/radsw.F90
+++ b/src_cam/radsw.F90
@@ -636,8 +636,8 @@ subroutine rad_rrtmg_sw(lchnk,ncol       ,rrtmg_levs   ,r_state      , &
    ! OSLO_AERO end
    if (present(idrf)) then
       if (idrf) then
-         call outfld('FUSCDRF ', fusc(:ncol,:), ncol, lchnk)
-         call outfld('FDSCDRF ', fdsc(:ncol,:), ncol, lchnk)
+         call outfld('FUSCAF', fusc(:ncol,:), ncol, lchnk)
+         call outfld('FDSCAF', fdsc(:ncol,:), ncol, lchnk)
       endif
    end if
 


### PR DESCRIPTION
This PR adds aerosol-free radiation call diagnostics (17 in total) with clearer short names and long_names than before.

The shortnames have now all "AF" (aerosol free) in their naming, and the long names should describe better what the field is (it mentions that these fluxes are the result from an aerosol-free radiation call).   The list of these 17 fields is :
| Variable      | Long name                                                                          |
|-----------------|------------------------------------------------------------------------------|
|                     | *SW at  TOA or top of model*                                                |
| FSNTAF      | Net solar flux at top of model from aerosol-free radiation call| |
| FSNTCAF   | Clearsky net solar flux at top of model from aerosol-free radiation call |
| FSNTOAAF | Net solar flux at top of atmosphere from aerosol-free radiation call |
| FSNTOACAF | Clearsky net solar flux at top of atmosphere from aerosol-free radiation call |
| FSUTOAAF | Upwelling solar flux at top of atmosphere from aerosol-free radiation call |
|                     | *LW at top of model*                                                                                                                      |
| FLNTAF       | Net longwave flux at top of model from aerosol-free radiation call |
| FLNTCAF    | Clearsky net longwave flux at top of model from aerosol-free radiation call |
| FLUTAF       | Upwelling longwave flux at top of model from aerosol-free radiation call |
| FLUTCAF    | Clearsky upwelling longwave flux at top of model from aerosol-free radiation call |
|                     | *SW at surface*                                                       |
| FSNSAF      | Net solar flux at surface from aerosol-free radiation call |
| FSNSCAF    |Clearsky net solar flux at surface from aerosol-free radiation call |
| FSDSAF       | Downwelling solar flux at surface from aerosol-free radiation call |
| FSDSCAF     | Clearsky downwelling solar flux at surface from aerosol-free radiation call |
|                     | *LW at surface*                                                               |
| FLNSAF       | Net longwave flux at surface from aerosol-free radiation call |
| FLNSCAF    | Clearsky net longwave flux at surface from aerosol-free radiation call |
| FLDSAF       | Downwelling longwave flux at surface from aerosol-free radiation call |
| FLDSCAF    | Clearsky Downwelling longwave flux at surface from aerosol-free radiation call |


 On the long term these diagnostics can replace the existing aerosol-free radiation call diagnostics (10 in total), but at the moment they are kept, as some diagnostic tools are still using them.  These old diagnostics do not describe well what they actually are : they are all the result from an aerosol-free radiation call, but that it is not clear based on the short name and long names.  
| Variable      | Long name                                                                          |
|-----------------|------------------------------------------------------------------------------|
|                     | *SW at  TOA or top of model*                                                |
| FSNT_DRF |Total column absorbed solar flux (DIRind)                           |
| FSNTCDRF | Clear sky total column absorbed solar flux (DIRind)          |
| FSUTADRF | SW upwelling flux at TOA                                                    |
|                     | *LW at  TOA or top of model*                                                |
FLNT_DRF | Total column longwave flux (DIRind)                                     |
FLNTCDRF | Clear sky total column longwave flux (DIRind)                      |
|                     | *SW at  surface*                                                                    |
| FSNS_DRF | Surface absorbed solar flux (DIRind)                                  |
| FSNSCDRF | Clear sky surface absorbed solar flux (DIRind)                  |
| FSDS_DRF | SW downelling flux at surface                                              |
| FSUS_DRF | SW upwelling flux at surface                                                |
| FSDSCDRF | SW downwelling clear sky flux at surface                            | 

Some more information on the relation between the 17 new and 10 old fluxes can be found in:
https://docs.google.com/spreadsheets/d/1Axqx8uxw7nkrSez93O50AB0hytzeuF8dUWWHfqvgnWA/edit?usp=sharing
