### PR TITLE
Tuning handle for aerosol optical, by  scaling effective relative humidity during look-up table interpolation

### DIFF
--- a/src/oslo_aero_aerocom.F90
+++ b/src/oslo_aero_aerocom.F90
@@ -11,6 +11,7 @@ module oslo_aero_aerocom
   use oslo_aero_linear_interp , only: lininterpol3dim, lininterpol4dim, lininterpol5dim
   use oslo_aero_share,          only: rhopart, l_bc_ni, l_om_ni
   use oslo_aero_share,          only: nmodes, nbmodes, nbands, nlwbands, nbmp1
+  use oslo_aero_control,        only: rh_fine_aer_scale_fact_optics
 
   public  :: aerocom1
   public  :: aerocom2
@@ -57,7 +58,7 @@ contains
     real(r8), intent(out) :: Ctotdry(pcols,pver)
 
     ! Local variables
-    integer  :: ilev, icol, imode
+    integer  :: ilev, icol, imode, kcomp
     real(r8) :: asydry_aer(pcols,pver)     ! dry asymtot in the visible band
     real(r8) :: asymtot(pcols,pver,nbands) ! spectral aerosol asymmetry factor
     real(r8) :: ssatot(pcols,pver,nbands)  ! spectral aerosol single scattering albedo
@@ -189,39 +190,35 @@ contains
     call interpol0 (ncol, daylight, Nnatk, ssa, asym, be, ke, lw_on, kalw)
 
     ! SO4/SOA(Ait) mode:
-    mplus10=0
-    call interpol1 (ncol, daylight, xrhnull, irh1null, mplus10, &
+    call interpol1 (ncol, daylight, xrhnull, irh1null, 1, &
          Nnatk, xfombg, ifombg1, xct, ict1, xfac, ifac1, &
          ssa, asym, be, ke, lw_on, kalw)
 
     ! BC(Ait) and OC(Ait) modes:
-    mplus10=0
-    call interpol2to3 (ncol, daylight, xrhnull, irh1null, mplus10, &
+    call interpol2to3 (ncol, daylight, xrhnull, irh1null, 2, &
          Nnatk, xct, ict1, xfac, ifac1, &
          ssa, asym, be, ke, lw_on, kalw)
 
     ! BC&OC(Ait) mode: fcm not valid here (=0).
-    mplus10=0
-    call interpol4 (ncol, daylight, xrhnull, irh1null, mplus10, &
+    call interpol4 (ncol, daylight, xrhnull, irh1null, 4, &
          Nnatk, xfbcbg, ifbcbg1, xct, ict1, xfac, ifac1, &
          xfaq, ifaq1, ssa, asym, be, ke, lw_on, kalw)
 
     ! SO4(Ait75) (5), Mineral (6-7) and Sea-salt (8-10) modes:
-    mplus10=0
-    call interpol5to10 (ncol, daylight, xrhnull, irh1null, &
-         Nnatk, xct, ict1, xfac, ifac1, &
-         xfbc, ifbc1, xfaq, ifaq1, &
-         ssa, asym, be, ke, lw_on, kalw)
+    do kcomp=5,10
+       call interpol5to10 (ncol, daylight, xrhnull, irh1null, kcomp, &
+            Nnatk, xct, ict1, xfac, ifac1, &
+            xfbc, ifbc1, xfaq, ifaq1, &
+            ssa, asym, be, ke, lw_on, kalw)
+    end do
 
-    ! BC(Ait) and OC(Ait) modes:
-    mplus10=1
-    call interpol2to3 (ncol, daylight, xrhnull, irh1null, mplus10, &
+    ! BC(Ait) and OC(Ait) nucleation modes:
+    call interpol2to3 (ncol, daylight, xrhnull, irh1null, 12, &
          Nnatk, xct, ict1, xfac, ifac1, &
          ssa, asym, be, ke, lw_on, kalw)
 
     ! BC&OC(n) mode:
-    mplus10=1
-    call interpol4 (ncol, daylight, xrhnull, irh1null, mplus10, &
+    call interpol4 (ncol, daylight, xrhnull, irh1null, 14, &
          Nnatk, xfbcbgn, ifbcbgn1, xct, ict1, &
          xfac, ifac1, xfaq, ifaq1, &
          ssa, asym, be, ke, lw_on, kalw)
@@ -1726,7 +1723,7 @@ contains
     real(r8), intent(out) :: backsc550n(pcols,pver,0:nbmodes)
 
     ! Local variables
-    integer  :: imode, ilev, icol, mplus10, irh
+    integer  :: imode, ilev, icol, kcomp, irh
     integer  :: iloop
     real(r8) :: deltah
     real(r8) :: dod550rh(pcols), abs550rh(pcols)
@@ -1807,8 +1804,7 @@ contains
          backsc550, babg550, babc550, baoc550, basu550)
 
     ! SO4(Ait), BC(Ait) and OC(Ait) modes:
-    mplus10=0
-    call intaeropt1(lchnk, ncol, xrh, irh1, mplus10,  &
+    call intaeropt1(lchnk, ncol, xrh, irh1,  &
          Nnatk, xfombg, ifombg1, xct, ict1, xfac, ifac1,&
          bext440, bext500, bext550, bext670, bext870,   &
          bebg440, bebg500, bebg550, bebg670, bebg870,   &
@@ -1820,9 +1816,8 @@ contains
          beoclt1, beocgt1, bes4lt1, bes4gt1,            &
          backsc550, babg550, babc550, baoc550, basu550)
 
-    mplus10=0
-    call intaeropt2to3(lchnk, ncol, xrh, irh1, mplus10, &
-         Nnatk, xct, ict1, xfac, ifac1,                   &
+    call intaeropt2to3(lchnk, ncol, xrh, irh1, 2, &
+         Nnatk, xct, ict1, xfac, ifac1,           &
          bext440, bext500, bext550, bext670, bext870,     &
          bebg440, bebg500, bebg550, bebg670, bebg870,     &
          bebc440, bebc500, bebc550, bebc670, bebc870,     &
@@ -1834,8 +1829,7 @@ contains
          backsc550, babg550, babc550, baoc550, basu550)
 
     ! BC&OC(Ait) (4), OC&BC(Ait) mode
-    mplus10=0
-    call intaeropt4(lchnk, ncol, xrh, irh1, mplus10, Nnatk,  &
+    call intaeropt4(lchnk, ncol, xrh, irh1, 4, Nnatk,  &
          xfbcbg, ifbcbg1, xct, ict1, xfac, ifac1, xfaq, ifaq1, &
          bext440, bext500, bext550, bext670, bext870,          &
          bebg440, bebg500, bebg550, bebg670, bebg870,          &
@@ -1848,7 +1842,8 @@ contains
          backsc550, babg550, babc550, baoc550, basu550)
 
     ! SO4(Ait75) (5), Mineral (6-7) and Sea-salt (8-10) modes:
-    call intaeropt5to10(lchnk, ncol, xrh, irh1, Nnatk,   &
+    do kcomp=5,10
+    call intaeropt5to10(lchnk, ncol, xrh, irh1, kcomp, Nnatk,   &
          xct, ict1, xfac, ifac1, xfbc, ifbc1, xfaq, ifaq1, &
          bext440, bext500, bext550, bext670, bext870,      &
          bebg440, bebg500, bebg550, bebg670, bebg870,      &
@@ -1859,10 +1854,10 @@ contains
          bebglt1, bebggt1, bebclt1, bebcgt1,               &
          beoclt1, beocgt1, bes4lt1, bes4gt1,               &
          backsc550, babg550, babc550, baoc550, basu550)
+    end do
 
     ! then to the externally mixed SO4(n), BC(n) and OC(n) modes:
-    mplus10=1
-    call intaeropt2to3(lchnk, ncol, xrh, irh1, mplus10,  &
+    call intaeropt2to3(lchnk, ncol, xrh, irh1, 12,  &
          Nnatk, xct, ict1, xfac, ifac1,                    &
          bext440n, bext500n, bext550n, bext670n, bext870n, &
          bebg440n, bebg500n, bebg550n, bebg670n, bebg870n, &
@@ -1875,8 +1870,7 @@ contains
          backsc550n, babg550n, babc550n, baoc550n, basu550n)
 
     ! finally the BC&OC(n) mode:
-    mplus10=1
-    call intaeropt4(lchnk, ncol, xrh, irh1, mplus10, Nnatk,    &
+    call intaeropt4(lchnk, ncol, xrh, irh1, 14, Nnatk,    &
          xfbcbgn, ifbcbgn1, xct, ict1, xfac, ifac1, xfaq, ifaq1, &
          bext440n, bext500n, bext550n, bext670n, bext870n,       &
          bebg440n, bebg500n, bebg550n, bebg670n, bebg870n,       &

--- a/src/oslo_aero_aerocom.F90
+++ b/src/oslo_aero_aerocom.F90
@@ -1824,7 +1824,7 @@ contains
          backsc550, babg550, babc550, baoc550, basu550)
 
     ! SO4(Ait), BC(Ait) and OC(Ait) modes:
-    call intaeropt1(lchnk, ncol, xrh_sc, irh1_sc,  &
+    call intaeropt1(lchnk, ncol, xrh_sc, irh1_sc, 1,  &
          Nnatk, xfombg, ifombg1, xct, ict1, xfac, ifac1,&
          bext440, bext500, bext550, bext670, bext870,   &
          bebg440, bebg500, bebg550, bebg670, bebg870,   &

--- a/src/oslo_aero_aerocom.F90
+++ b/src/oslo_aero_aerocom.F90
@@ -1723,7 +1723,7 @@ contains
     real(r8), intent(out) :: backsc550n(pcols,pver,0:nbmodes)
 
     ! Local variables
-    integer  :: imode, ilev, icol, kcomp, irh
+    integer  :: imode, ilev, icol, kcomp, irh, irelh
     integer  :: iloop
     real(r8) :: deltah
     real(r8) :: dod550rh(pcols), abs550rh(pcols)
@@ -1787,9 +1787,29 @@ contains
     real(r8) :: besslt1(pcols,pver), bessgt1(pcols,pver)
     real(r8) :: bbclt1xt(pcols,pver)
     real(r8) :: boclt1xt(pcols,pver)
+    real(r8) :: xrh_sc(pcols,pver)
+    integer  :: irh1_sc(pcols,pver)
     !-------------------------------------------------------------------------
 
     belt1x(:,:,:) = 0._r8
+
+    ! scale RH by rh_fine_aer_scale_fact_optics for all modes except dust (6-7) and seasalt (8-10).
+    do ilev=1,pver
+       do icol=1,ncol
+          xrh_sc(icol,ilev) = min(max(xrh(icol,ilev)*rh_fine_aer_scale_fact_optics, rh(1)), rh(10))
+       end do
+    end do
+
+    irh1_sc(:,:) = 1
+    do irelh=1,9
+       do ilev=1,pver
+          do icol=1,ncol
+             if (xrh_sc(icol,ilev) >= rh(irelh) .and. xrh_sc(icol,ilev) <= rh(irelh+1)) then
+                irh1_sc(icol,ilev) = irelh
+             end if
+          end do
+       end do
+    end do
 
     ! BC(ax) mode (hydrophobic, so no rhum needed here):
     call intaeropt0(lchnk, ncol, Nnatk,               &
@@ -1804,7 +1824,7 @@ contains
          backsc550, babg550, babc550, baoc550, basu550)
 
     ! SO4(Ait), BC(Ait) and OC(Ait) modes:
-    call intaeropt1(lchnk, ncol, xrh, irh1,  &
+    call intaeropt1(lchnk, ncol, xrh_sc, irh1_sc,  &
          Nnatk, xfombg, ifombg1, xct, ict1, xfac, ifac1,&
          bext440, bext500, bext550, bext670, bext870,   &
          bebg440, bebg500, bebg550, bebg670, bebg870,   &
@@ -1816,7 +1836,7 @@ contains
          beoclt1, beocgt1, bes4lt1, bes4gt1,            &
          backsc550, babg550, babc550, baoc550, basu550)
 
-    call intaeropt2to3(lchnk, ncol, xrh, irh1, 2, &
+    call intaeropt2to3(lchnk, ncol, xrh_sc, irh1_sc, 2, &
          Nnatk, xct, ict1, xfac, ifac1,           &
          bext440, bext500, bext550, bext670, bext870,     &
          bebg440, bebg500, bebg550, bebg670, bebg870,     &
@@ -1829,7 +1849,7 @@ contains
          backsc550, babg550, babc550, baoc550, basu550)
 
     ! BC&OC(Ait) (4), OC&BC(Ait) mode
-    call intaeropt4(lchnk, ncol, xrh, irh1, 4, Nnatk,  &
+    call intaeropt4(lchnk, ncol, xrh_sc, irh1_sc, 4, Nnatk,  &
          xfbcbg, ifbcbg1, xct, ict1, xfac, ifac1, xfaq, ifaq1, &
          bext440, bext500, bext550, bext670, bext870,          &
          bebg440, bebg500, bebg550, bebg670, bebg870,          &
@@ -1841,9 +1861,8 @@ contains
          beoclt1, beocgt1, bes4lt1, bes4gt1,                   &
          backsc550, babg550, babc550, baoc550, basu550)
 
-    ! SO4(Ait75) (5), Mineral (6-7) and Sea-salt (8-10) modes:
-    do kcomp=5,10
-    call intaeropt5to10(lchnk, ncol, xrh, irh1, kcomp, Nnatk,   &
+    ! SO4(Ait75) (5) — scaled RH, matching interpol5to10 in oslo_aero_optical_params.F90:
+    call intaeropt5to10(lchnk, ncol, xrh_sc, irh1_sc, 5, Nnatk,   &
          xct, ict1, xfac, ifac1, xfbc, ifbc1, xfaq, ifaq1, &
          bext440, bext500, bext550, bext670, bext870,      &
          bebg440, bebg500, bebg550, bebg670, bebg870,      &
@@ -1854,10 +1873,23 @@ contains
          bebglt1, bebggt1, bebclt1, bebcgt1,               &
          beoclt1, beocgt1, bes4lt1, bes4gt1,               &
          backsc550, babg550, babc550, baoc550, basu550)
+    ! Mineral (6-7) and Sea-salt (8-10) modes — unscaled RH:
+    do kcomp=6,10
+       call intaeropt5to10(lchnk, ncol, xrh, irh1, kcomp, Nnatk,   &
+            xct, ict1, xfac, ifac1, xfbc, ifbc1, xfaq, ifaq1, &
+            bext440, bext500, bext550, bext670, bext870,      &
+            bebg440, bebg500, bebg550, bebg670, bebg870,      &
+            bebc440, bebc500, bebc550, bebc670, bebc870,      &
+            beoc440, beoc500, beoc550, beoc670, beoc870,      &
+            besu440, besu500, besu550, besu670, besu870,      &
+            babs440, babs500, babs550, babs670, babs870,      &
+            bebglt1, bebggt1, bebclt1, bebcgt1,               &
+            beoclt1, beocgt1, bes4lt1, bes4gt1,               &
+            backsc550, babg550, babc550, baoc550, basu550)
     end do
 
     ! then to the externally mixed SO4(n), BC(n) and OC(n) modes:
-    call intaeropt2to3(lchnk, ncol, xrh, irh1, 12,  &
+    call intaeropt2to3(lchnk, ncol, xrh_sc, irh1_sc, 12,  &
          Nnatk, xct, ict1, xfac, ifac1,                    &
          bext440n, bext500n, bext550n, bext670n, bext870n, &
          bebg440n, bebg500n, bebg550n, bebg670n, bebg870n, &
@@ -1870,7 +1902,7 @@ contains
          backsc550n, babg550n, babc550n, baoc550n, basu550n)
 
     ! finally the BC&OC(n) mode:
-    call intaeropt4(lchnk, ncol, xrh, irh1, 14, Nnatk,    &
+    call intaeropt4(lchnk, ncol, xrh_sc, irh1_sc, 14, Nnatk,    &
          xfbcbgn, ifbcbgn1, xct, ict1, xfac, ifac1, xfaq, ifaq1, &
          bext440n, bext500n, bext550n, bext670n, bext870n,       &
          bebg440n, bebg500n, bebg550n, bebg670n, bebg870n,       &

--- a/src/oslo_aero_aerocom_tables.F90
+++ b/src/oslo_aero_aerocom_tables.F90
@@ -706,7 +706,7 @@ contains
   end subroutine intaeropt0
 
   !===============================================================================
-  subroutine intaeropt1 (lchnk, ncol, xrh, irh1,    &
+  subroutine intaeropt1 (lchnk, ncol, xrh, irh1, kout, &
        Nnatk, xfombg, ifombg1, xct, ict1, xfac, ifac1, &
        bext440, bext500, bext550, bext670, bext870,    &
        bebg440, bebg500, bebg550, bebg670, bebg870,    &
@@ -724,6 +724,7 @@ contains
     ! Arguments
     integer  , intent(in)  :: lchnk                       ! chunk identifier
     integer  , intent(in)  :: ncol                        ! number of atmospheric columns
+    integer  , intent(in)  :: kout                        ! source mode index (1 or 11)
     real(r8) , intent(in)  :: xrh(pcols,pver)            ! level relative humidity (fraction)
     integer  , intent(in)  :: irh1(pcols,pver)
     real(r8) , intent(in)  :: Nnatk(pcols,pver,0:nmodes) ! modal aerosol number concentration
@@ -830,7 +831,7 @@ contains
 
     do ilev=1,pver
        do icol=1,ncol
-          if(Nnatk(icol,ilev,kcomp)>0) then
+          if(Nnatk(icol,ilev,kout)>0) then
 
              ! Collect all the vector elements into temporary storage
              ! to avoid cache conflicts and excessive cross-referencing
@@ -838,9 +839,9 @@ contains
              t_irh2 = t_irh1+1
              t_ifo1 = ifombg1(icol,ilev)
              t_ifo2 = t_ifo1+1
-             t_ict1 = ict1(icol,ilev,kcomp)
+             t_ict1 = ict1(icol,ilev,kout)
              t_ict2 = t_ict1+1
-             t_ifc1 = ifac1(icol,ilev,kcomp)
+             t_ifc1 = ifac1(icol,ilev,kout)
              t_ifc2 = t_ifc1+1
 
              t_rh1  = rh(t_irh1)
@@ -853,8 +854,8 @@ contains
              t_fac2 = fac(t_ifc2)
 
              t_xrh  = xrh(icol,ilev)
-             t_xct  = xct(icol,ilev,kcomp)
-             t_xfac = xfac(icol,ilev,kcomp)
+             t_xct  = xct(icol,ilev,kout)
+             t_xfac = xfac(icol,ilev,kout)
              t_xfombg = xfombg(icol,ilev)
 
              ! partial lengths along each dimension (1-4) for interpolation

--- a/src/oslo_aero_aerocom_tables.F90
+++ b/src/oslo_aero_aerocom_tables.F90
@@ -706,7 +706,7 @@ contains
   end subroutine intaeropt0
 
   !===============================================================================
-  subroutine intaeropt1 (lchnk, ncol, xrh, irh1, mplus10,    &
+  subroutine intaeropt1 (lchnk, ncol, xrh, irh1,    &
        Nnatk, xfombg, ifombg1, xct, ict1, xfac, ifac1, &
        bext440, bext500, bext550, bext670, bext870,    &
        bebg440, bebg500, bebg550, bebg670, bebg870,    &
@@ -724,7 +724,6 @@ contains
     ! Arguments
     integer  , intent(in)  :: lchnk                       ! chunk identifier
     integer  , intent(in)  :: ncol                        ! number of atmospheric columns
-    integer  , intent(in)  :: mplus10                     ! mode number (0) or number + 10 (1)
     real(r8) , intent(in)  :: xrh(pcols,pver)            ! level relative humidity (fraction)
     integer  , intent(in)  :: irh1(pcols,pver)
     real(r8) , intent(in)  :: Nnatk(pcols,pver,0:nmodes) ! modal aerosol number concentration
@@ -766,7 +765,7 @@ contains
     real(r8) , intent(out) :: backsc550(pcols,pver,0:nbmodes)
 
     ! Local variables
-    integer  :: iv, ierr, irelh, ifombg, ictot, ifac, kcomp, ilev, icol, kc10
+    integer  :: iv, ierr, irelh, ifombg, ictot, ifac, ilev, icol
     integer  :: t_irh1, t_irh2, t_ifo1, t_ifo2, t_ict1, t_ict2, t_ifc1, t_ifc2
     real(r8) :: a, b, e
     real(r8) :: t_fac1, t_fac2, t_xfac
@@ -778,13 +777,7 @@ contains
     real(r8) :: opt1, opt2, opt(38)
     !-------------------------------------------------------------------------
 
-    kcomp = 1
-    if (mplus10==0) then
-       kc10=kcomp
-    else
-       write(*,*) "mplus10=1 is no loger an option for kcomp=1."
-       stop
-    endif
+    integer, parameter :: kcomp = 1
 
     ! initialize all output fields
     do ilev=1,pver
@@ -837,7 +830,7 @@ contains
 
     do ilev=1,pver
        do icol=1,ncol
-          if(Nnatk(icol,ilev,kc10)>0) then
+          if(Nnatk(icol,ilev,kcomp)>0) then
 
              ! Collect all the vector elements into temporary storage
              ! to avoid cache conflicts and excessive cross-referencing
@@ -860,7 +853,7 @@ contains
              t_fac2 = fac(t_ifc2)
 
              t_xrh  = xrh(icol,ilev)
-             t_xct  = xct(icol,ilev,kc10)
+             t_xct  = xct(icol,ilev,kcomp)
              t_xfac = xfac(icol,ilev,kcomp)
              t_xfombg = xfombg(icol,ilev)
 
@@ -955,7 +948,7 @@ contains
 
   !===============================================================================
   subroutine intaeropt2to3 (&
-       lchnk, ncol, xrh, irh1, mplus10,                &
+       lchnk, ncol, xrh, irh1, kout,                   &
        Nnatk, xct, ict1, xfac, ifac1,                  &
        bext440, bext500, bext550, bext670, bext870,    &
        bebg440, bebg500, bebg550, bebg670, bebg870,    &
@@ -973,7 +966,7 @@ contains
     ! arguments
     integer  , intent(in)  :: lchnk                      ! chunk identifier
     integer  , intent(in)  :: ncol                       ! number of atmospheric columns
-    integer  , intent(in)  :: mplus10                    ! mode number (0) or number + 10 (1)
+    integer  , intent(in)  :: kout                       ! source mode index (2 or 12)
     real(r8) , intent(in)  :: xrh(pcols,pver)            ! level relative humidity (fraction)
     integer  , intent(in)  :: irh1(pcols,pver)
     real(r8) , intent(in)  :: Nnatk(pcols,pver,0:nmodes) ! modal aerosol number concentration
@@ -1014,21 +1007,14 @@ contains
 
     ! Local variables
     real(r8) :: a, b, e
-    integer  :: iv, kcomp, ilev, icol, kc10
+    integer  :: iv, ilev, icol
     integer  :: t_irh1, t_irh2, t_ict1, t_ict2, t_ifc1, t_ifc2
     real(r8) :: t_fac1, t_fac2, t_xfac, t_xrh, t_xct, t_rh1, t_rh2, t_cat1, t_cat2
     real(r8) :: d2mx(3), dxm1(3), invd(3)
     real(r8) :: opt3d(2,2,2)
     real(r8) :: opt1, opt2, opt(38)
+    integer, parameter :: kcomp = 2
     !-------------------------------------------------------------------------
-
-    ! SO4(Ait), BC(Ait) and OC(Ait) modes:
-    kcomp = 2
-    if (mplus10==0) then
-       kc10=kcomp
-    else
-       kc10=kcomp+10
-    endif
 
     ! initialize all output fields
     do ilev=1,pver
@@ -1081,13 +1067,13 @@ contains
 
     do ilev=1,pver
        do icol=1,ncol
-          if(Nnatk(icol,ilev,kc10)>0) then
+          if(Nnatk(icol,ilev,kout)>0) then
              ! Collect all the vector elements into temporary storage
              ! to avoid cache conflicts and excessive cross-referencing
 
              t_irh1 = irh1(icol,ilev)
              t_irh2 = t_irh1+1
-             t_ict1 = ict1(icol,ilev,kc10)
+             t_ict1 = ict1(icol,ilev,kout)
              t_ict2 = t_ict1+1
              t_ifc1 = ifac1(icol,ilev,kcomp)
              t_ifc2 = t_ifc1+1
@@ -1098,7 +1084,7 @@ contains
              t_fac1 = fac(t_ifc1)
              t_fac2 = fac(t_ifc2)
              t_xrh  = xrh(icol,ilev)
-             t_xct  = xct(icol,ilev,kc10)
+             t_xct  = xct(icol,ilev,kout)
              t_xfac = xfac(icol,ilev,kcomp)
 
              ! partial lengths along each dimension (1-4) for interpolation
@@ -1180,7 +1166,7 @@ contains
   end subroutine intaeropt2to3
 
   !===============================================================================
-  subroutine intaeropt4 (lchnk, ncol, xrh, irh1, mplus10, Nnatk,   &
+  subroutine intaeropt4 (lchnk, ncol, xrh, irh1, kout, Nnatk,   &
        xfbcbg, ifbcbg1, xct, ict1, xfac, ifac1, xfaq, ifaq1, &
        bext440, bext500, bext550, bext670, bext870,          &
        bebg440, bebg500, bebg550, bebg670, bebg870,          &
@@ -1198,7 +1184,7 @@ contains
     ! Arguments
     integer  , intent(in)  :: lchnk                      ! chunk identifier
     integer  , intent(in)  :: ncol                       ! number of atmospheric columns
-    integer  , intent(in)  :: mplus10                    ! mode number (0) or number + 10 (1)
+    integer  , intent(in)  :: kout                       ! source mode index (4 or 14)
     real(r8) , intent(in)  :: xrh(pcols,pver)            ! level relative humidity (fraction)
     integer  , intent(in)  :: irh1(pcols,pver)
     real(r8) , intent(in)  :: Nnatk(pcols,pver,0:nmodes) ! modal aerosol number concentration
@@ -1243,7 +1229,7 @@ contains
 
     ! Local variables
     real(r8) :: a, b, e
-    integer  :: iv, kcomp, ilev, icol, kc10
+    integer  :: iv, ilev, icol
     integer  :: t_irh1, t_irh2, t_ict1, t_ict2, t_ifc1, t_ifc2,  t_ifa1, t_ifa2
     integer  :: t_ifb1, t_ifb2
     real(r8) :: t_fbcbg1, t_fbcbg2
@@ -1257,12 +1243,7 @@ contains
     real(r8) :: opt1, opt2, opt(38)
     !-------------------------------------------------------------------------
 
-    kcomp = 4
-    if(mplus10==0) then
-       kc10=kcomp
-    else
-       kc10=kcomp+10
-    endif
+    integer, parameter :: kcomp = 4
 
     ! initialize all output fields
     do ilev=1,pver
@@ -1315,7 +1296,7 @@ contains
 
     do ilev=1,pver
        do icol=1,ncol
-          if(Nnatk(icol,ilev,kc10)>0) then
+          if(Nnatk(icol,ilev,kout)>0) then
              ! Collect all the vector elements into temporary storage
              ! to avoid cache conflicts and excessive cross-referencing
 
@@ -1323,7 +1304,7 @@ contains
              t_irh2 = t_irh1+1
              t_ifb1 = ifbcbg1(icol,ilev)
              t_ifb2 = t_ifb1+1
-             t_ict1 = ict1(icol,ilev,kc10)
+             t_ict1 = ict1(icol,ilev,kout)
              t_ict2 = t_ict1+1
              t_ifc1 = ifac1(icol,ilev,kcomp)
              t_ifc2 = t_ifc1+1
@@ -1343,7 +1324,7 @@ contains
 
              t_xrh  = xrh(icol,ilev)
              t_xfbcbg = xfbcbg(icol,ilev)
-             t_xct  = xct(icol,ilev,kc10)
+             t_xct  = xct(icol,ilev,kout)
              t_xfac = xfac(icol,ilev,kcomp)
              t_xfaq = xfaq(icol,ilev,kcomp)
 
@@ -1457,7 +1438,7 @@ contains
   end subroutine intaeropt4
 
   !===============================================================================
-  subroutine intaeropt5to10 (lchnk, ncol, xrh, irh1, Nnatk,    &
+  subroutine intaeropt5to10 (lchnk, ncol, xrh, irh1, kcomp, Nnatk,    &
        xct, ict1, xfac, ifac1, xfbc, ifbc1, xfaq, ifaq1, &
        bext440, bext500, bext550, bext670, bext870,      &
        bebg440, bebg500, bebg550, bebg670, bebg870,      &
@@ -1475,6 +1456,7 @@ contains
     ! arguments
     integer  , intent(in)  :: lchnk                       ! chunk identifier
     integer  , intent(in)  :: ncol                        ! number of atmospheric columns
+    integer  , intent(in)  :: kcomp                       ! mode index (5-10)
     real(r8) , intent(in)  :: xrh(pcols,pver)            ! level relative humidity (fraction)
     integer  ,  intent(in) :: irh1(pcols,pver)
     real(r8) , intent(in)  :: Nnatk(pcols,pver,0:nmodes) ! modal aerosol number concentration
@@ -1519,7 +1501,7 @@ contains
 
     ! Local variables
     real(r8) :: a, b, e
-    integer  :: iv, kcomp, ilev, icol
+    integer  :: iv, ilev, icol
     integer  :: t_irh1, t_irh2, t_ict1, t_ict2, t_ifa1, t_ifa2
     integer  :: t_ifb1, t_ifb2, t_ifc1, t_ifc2
     real(r8) :: t_faq1, t_faq2, t_xfaq
@@ -1534,12 +1516,10 @@ contains
 
     ! Modes 5 to 10 (SO4(Ait75) and mineral and seasalt-modes + cond./coag./aq.):
 
-    do kcomp=5,10
-
-       ! initialize all output fields
-       do ilev=1,pver
-          do icol=1,ncol
-             bext440(icol,ilev,kcomp)=0.0_r8
+    ! initialize all output fields
+    do ilev=1,pver
+       do icol=1,ncol
+          bext440(icol,ilev,kcomp)=0.0_r8
              babs440(icol,ilev,kcomp)=0.0_r8
              bext500(icol,ilev,kcomp)=0.0_r8
              babs500(icol,ilev,kcomp)=0.0_r8
@@ -1726,7 +1706,6 @@ contains
              endif
           end do ! icol
        end do ! ilev
-    end do  ! kcomp
   end subroutine intaeropt5to10
 
   !===============================================================================

--- a/src/oslo_aero_control.F90
+++ b/src/oslo_aero_control.F90
@@ -29,7 +29,8 @@ module oslo_aero_control
 
   ! Public Namelist variables:
   logical, public, protected :: use_aerocom = .false. ! If true, turn on aerocom output
-
+  
+  real(r8), public, protected :: rh_fine_aer_scale_fact_optics = 1.0_r8
   ! Private Namelist variables:
   real(r8)          :: volc_fraction_coarse = 0.0_r8  !Fraction of volcanic aerosols in coarse mode
   character(len=dir_string_length) :: aerotab_table_dir = unset_str
@@ -61,7 +62,7 @@ contains
     namelist /oslo_ctl_nl/ volc_fraction_coarse, aerotab_table_dir, dms_source, &
                            dms_source_type, opom_source, opom_source_type, &
                            ocean_filename, ocean_filepath, dms_cycle_year, opom_cycle_year, &
-                           use_aerocom
+                           use_aerocom, rh_fine_aer_scale_fact_optics
     !-----------------------------------------------------------------------------
 
     if (masterproc) then
@@ -106,6 +107,11 @@ contains
     if (ierr /= mpi_success) call endrun(subname//" mpi_bcast: ocean_filename")
     call mpi_bcast(ocean_filepath, len(ocean_filepath), mpi_character, mstrid, mpicom, ierr)
     if (ierr /= mpi_success) call endrun(subname//" mpi_bcast: ocean_filepath")
+
+    ! Relhum scaling in the optics for tuning of aerosol optical depth
+    call mpi_bcast(rh_fine_aer_scale_fact_optics, len(ocean_filename), mpi_character, mstrid, mpicom, ierr)
+    if (ierr /= mpi_success) call endrun(subname//" mpi_bcast: rh_fine_aer_scale_fact_optics")
+
 
     ! Reset dms_source if ocean is sending dms to atm
     if (dms_from_ocn) then

--- a/src/oslo_aero_optical_params.F90
+++ b/src/oslo_aero_optical_params.F90
@@ -18,7 +18,7 @@ module oslo_aero_optical_params
   use oslo_aero_conc,      only: calculateBulkProperties, partitionMass
   use oslo_aero_sw_tables, only: interpol0, interpol1, interpol2to3, interpol4, interpol5to10
   use oslo_aero_aerocom,   only: aerocom1, aerocom2
-  use oslo_aero_control,   only: use_aerocom
+  use oslo_aero_control,   only: use_aerocom, rh_fine_aer_scale_fact_optics
   use perf_mod,            only: t_startf, t_stopf
 
   implicit none
@@ -66,7 +66,7 @@ contains
     real(r8), intent(out) :: absvis(pcols)                        ! AAOD vis
 
     ! Local variables
-    integer  :: imode, index, ilev, ib, icol, mplus10
+    integer  :: imode, index, ilev, ib, icol, kcomp, irelh
     real(r8) :: Nnatk(pcols,pver,0:nmodes) ! aerosol mode number concentration
     logical  :: daylight(pcols)            ! SW calculations also at (polar) night in interpol* if daylight=.true.
     real(r8) :: aodvisvolc(pcols)          ! AOD vis for CMIP6 volcanic aerosol
@@ -103,6 +103,8 @@ contains
     real(r8) :: rh_temp(pcols,pver) ! relative humidity (fraction) for input to LUT
     real(r8) :: xrh(pcols,pver)
     integer  :: irh1(pcols,pver)
+    real(r8) :: xrh_sc(pcols,pver)   ! RH scaled by 1.1 for all modes except dust (6-7) and seasalt (8-10)
+    integer  :: irh1_sc(pcols,pver)
     real(r8) :: xfombg(pcols,pver)
     integer  :: ifombg1(pcols,pver), ifombg2(pcols,pver)
     real(r8) :: xct(pcols,pver,nmodes)
@@ -249,6 +251,23 @@ contains
          focm, fcm, xfac, ifac1, fbcm, xfbc, ifbc1, faqm, xfaq, ifaq1)
     call t_stopf('oslo_aero_input_interpol')
 
+    ! scale RH by rh_fine_aer_scale_fact_optics for all modes except dust (6-7) and seasalt (8-10).
+    do ilev=1,pver
+       do icol=1,ncol
+          xrh_sc(icol,ilev) = min(max(rhum(icol,ilev)*rh_fine_aer_scale_fact_optics, rh(1)), rh(10))
+       end do
+    end do
+    irh1_sc(:,:) = 1
+    do irelh=1,9
+       do ilev=1,pver
+          do icol=1,ncol
+             if (xrh_sc(icol,ilev) >= rh(irelh) .and. xrh_sc(icol,ilev) <= rh(irelh+1)) then
+                irh1_sc(icol,ilev) = irelh
+             end if
+          end do
+       end do
+    end do
+
     if (use_aerocom) then
        call aerocom1(lchnk, ncol, Cam, Nnatk, deltah_km, &
             xct, ict1, xfac, ifac1, xfbc, ifbc1, xfaq, ifaq1, &
@@ -265,33 +284,38 @@ contains
     call interpol0 (ncol, daylight, Nnatk, ssa, asym, be, ke, lw_on, kalw)
     call t_stopf('oslo_aero_interpol0')
 
-    mplus10=0
     ! SO4/SOA(Ait) mode:
     call t_startf('oslo_aero_interpol1')
-    call interpol1 (ncol, daylight, xrh, irh1, mplus10, &
+    call interpol1 (ncol, daylight, xrh_sc, irh1_sc, 1, &
          Nnatk, xfombg, ifombg1, xct, ict1,    &
          xfac, ifac1, ssa, asym, be, ke, lw_on, kalw)
     call t_stopf('oslo_aero_interpol1')
 
     ! BC(Ait) and OC(Ait) modes:
     call t_startf('oslo_aero_interpol2to3')
-    call interpol2to3 (ncol, daylight, xrh, irh1, mplus10, &
+    call interpol2to3 (ncol, daylight, xrh_sc, irh1_sc, 2, &
          Nnatk, xct, ict1, xfac, ifac1, &
          ssa, asym, be, ke, lw_on, kalw)
     call t_stopf('oslo_aero_interpol2to3')
 
     ! BC&OC(Ait) mode:   ------ fcm invalid here (=0). Using faitbc instead
     call t_startf('oslo_aero_interpol4')
-    call interpol4 (ncol, daylight, xrh, irh1, mplus10, &
+    call interpol4 (ncol, daylight, xrh_sc, irh1_sc, 4, &
          Nnatk, xfbcbg, ifbcbg1, xct, ict1,    &
          xfac, ifac1, xfaq, ifaq1, ssa, asym, be, ke, lw_on, kalw)
     call t_stopf('oslo_aero_interpol4')
 
-    ! SO4(Ait75) (5), Mineral (6-7) and Sea-salt (8-10) modes:
+    ! SO4(Ait75) (5), 
     call t_startf('oslo_aero_interpol5to10')
-    call interpol5to10 (ncol, daylight, xrh, irh1, &
-         Nnatk, xct, ict1, xfac, ifac1, &
-         xfbc, ifbc1, xfaq, ifaq1, ssa, asym, be, ke, lw_on, kalw)
+    call interpol5to10 (ncol, daylight, xrh_sc, irh1_sc, 5, &
+            Nnatk, xct, ict1, xfac, ifac1, &
+            xfbc, ifbc1, xfaq, ifaq1, ssa, asym, be, ke, lw_on, kalw)
+    ! Mineral (6-7) and Sea-salt (8-10) modes:
+    do kcomp=6,10
+       call interpol5to10 (ncol, daylight, xrh, irh1, kcomp, &
+            Nnatk, xct, ict1, xfac, ifac1, &
+            xfbc, ifbc1, xfaq, ifaq1, ssa, asym, be, ke, lw_on, kalw)
+    end do
     call t_stopf('oslo_aero_interpol5to10')
 
     ! total aerosol number concentrations
@@ -304,18 +328,16 @@ contains
     enddo
     call outfld('N_AER   ',n_aer ,pcols,lchnk)
 
-    ! BC(Ait) and OC(Ait) modes:
-    mplus10=1
+    ! BC(Ait) and OC(Ait) nucleation modes:
     call t_startf('oslo_aero_interpol2to3')
-    call interpol2to3 (ncol, daylight, xrh, irh1, mplus10, &
+    call interpol2to3 (ncol, daylight, xrh_sc, irh1_sc, 12, &
          Nnatk, xct, ict1, xfac, ifac1, &
          ssa, asym, be, ke, lw_on, kalw)
     call t_stopf('oslo_aero_interpol2to3')
 
     ! BC&OC(n) mode:    ------ fcm not valid here (=0). Use fnbc instead
-    mplus10=1
     call t_startf('oslo_aero_interpol4')
-    call interpol4 (ncol, daylight, xrh, irh1, mplus10, &
+    call interpol4 (ncol, daylight, xrh_sc, irh1_sc, 14, &
          Nnatk, xfbcbgn, ifbcbgn1, xct, ict1,  &
          xfac, ifac1, xfaq, ifaq1, ssa, asym, be, ke, lw_on, kalw)
     call t_stopf('oslo_aero_interpol4')

--- a/src/oslo_aero_optical_params.F90
+++ b/src/oslo_aero_optical_params.F90
@@ -103,7 +103,7 @@ contains
     real(r8) :: rh_temp(pcols,pver) ! relative humidity (fraction) for input to LUT
     real(r8) :: xrh(pcols,pver)
     integer  :: irh1(pcols,pver)
-    real(r8) :: xrh_sc(pcols,pver)   ! RH scaled by 1.1 for all modes except dust (6-7) and seasalt (8-10)
+    real(r8) :: xrh_sc(pcols,pver)   ! RH scaled by rh_fine_aer_scale_fact_optics for all modes except dust (6-7) and seasalt (8-10)
     integer  :: irh1_sc(pcols,pver)
     real(r8) :: xfombg(pcols,pver)
     integer  :: ifombg1(pcols,pver), ifombg2(pcols,pver)
@@ -254,7 +254,7 @@ contains
     ! scale RH by rh_fine_aer_scale_fact_optics for all modes except dust (6-7) and seasalt (8-10).
     do ilev=1,pver
        do icol=1,ncol
-          xrh_sc(icol,ilev) = min(max(rhum(icol,ilev)*rh_fine_aer_scale_fact_optics, rh(1)), rh(10))
+          xrh_sc(icol,ilev) = min(max(xrh(icol,ilev)*rh_fine_aer_scale_fact_optics, rh(1)), rh(10))
        end do
     end do
     irh1_sc(:,:) = 1

--- a/src/oslo_aero_sw_tables.F90
+++ b/src/oslo_aero_sw_tables.F90
@@ -863,13 +863,13 @@ contains
 
   !=============================================================================
 
-  subroutine interpol1 (ncol, daylight, xrh, irh1, mplus10, Nnatk, xfombg, ifombg1, &
+  subroutine interpol1 (ncol, daylight, xrh, irh1, kout, Nnatk, xfombg, ifombg1, &
        xct, ict1, xfac, ifac1, omega, gass, bex, ske, lw_on, kabs)
 
     !
     ! Arguments
     integer, intent(in) :: ncol                        ! number of atmospheric columns
-    integer, intent(in) :: mplus10                     ! mode number (0) or number + 10 (1)
+    integer, intent(in) :: kout                        ! output mode index
     logical, intent(in) :: daylight(pcols)             ! only daylight calculations if .true.
     logical, intent(in) :: lw_on                       ! LW calculations are performed if true
     real(r8), intent(in) :: Nnatk(pcols,pver,0:nmodes) ! modal aerosol number concentration
@@ -889,7 +889,8 @@ contains
     real(r8), intent(out) :: kabs(pcols,pver,0:nmodes,nlwbands)! LW spectral modal specific absoption coefficient
     !
     ! Local variables
-    integer iband, kcomp, ilev, icol, kc10
+    integer iband, ilev, icol
+    integer, parameter :: kcomp = 1
     real(r8) a, b
     integer t_irh1, t_irh2, t_ict1, t_ict2, t_ifc1, t_ifc2, t_ifo1, t_ifo2
     real(r8) t_fac1, t_fac2, t_xfac, t_xrh, t_xct, t_rh1, t_rh2
@@ -900,30 +901,20 @@ contains
     real(r8) kabs1, kabs2
     !---------------------------------------
 
-    ! write(*,*) 'Before kcomp-loop'
-    do kcomp=1,1
-
-       if(mplus10==0) then
-          kc10=kcomp
-       else
-          kc10=kcomp+10
-       endif
-
-       ! write(*,*) 'Before init-loop', kc10
        do iband=1,nbands
           do icol=1,ncol
              do ilev=1,pver
-                omega(icol,ilev,kc10,iband)=0.0_r8
-                gass(icol,ilev,kc10,iband)=0.0_r8
-                bex(icol,ilev,kc10,iband)=0.0_r8
-                ske(icol,ilev,kc10,iband)=0.0_r8
+                omega(icol,ilev,kout,iband)=0.0_r8
+                gass(icol,ilev,kout,iband)=0.0_r8
+                bex(icol,ilev,kout,iband)=0.0_r8
+                ske(icol,ilev,kout,iband)=0.0_r8
              end do
           end do
        end do
        do iband=1,nlwbands
           do icol=1,ncol
              do ilev=1,pver
-                kabs(icol,ilev,kc10,iband)=0.0_r8
+                kabs(icol,ilev,kout,iband)=0.0_r8
              end do
           end do
        end do
@@ -1002,7 +993,7 @@ contains
                    call lininterpol4dim (d2mx, dxm1, invd, opt4d, ome1, ome2)
 
                    ! finally, interpolation in the rh dimension
-                   omega(icol,ilev,kc10,iband)=((t_rh2-t_xrh)*ome1+(t_xrh-t_rh1)*ome2) /(t_rh2-t_rh1)
+                   omega(icol,ilev,kout,iband)=((t_rh2-t_xrh)*ome1+(t_xrh-t_rh1)*ome2) /(t_rh2-t_rh1)
 
                    ! asymmetry factor
 
@@ -1028,7 +1019,7 @@ contains
                    call lininterpol4dim (d2mx, dxm1, invd, opt4d, ge1, ge2)
 
                    ! finally, interpolation in the rh dimension (dim. 1)
-                   gass(icol,ilev,kc10,iband)=((t_rh2-t_xrh)*ge1+(t_xrh-t_rh1)*ge2) /(t_rh2-t_rh1)
+                   gass(icol,ilev,kout,iband)=((t_rh2-t_xrh)*ge1+(t_xrh-t_rh1)*ge2) /(t_rh2-t_rh1)
 
                    ! aerosol extinction
 
@@ -1058,11 +1049,11 @@ contains
 
                    ! finally, interpolation in the rh dimension
                    if(t_xrh <= 0.37_r8) then
-                      bex(icol,ilev,kc10,iband)=((t_rh2-t_xrh)*bex1+(t_xrh-t_rh1)*bex2) /(t_rh2-t_rh1)
+                      bex(icol,ilev,kout,iband)=((t_rh2-t_xrh)*bex1+(t_xrh-t_rh1)*bex2) /(t_rh2-t_rh1)
                    else
                       a=(log(bex2)-log(bex1))/(t_rh2-t_rh1)
                       b=(t_rh2*log(bex1)-t_rh1*log(bex2))/(t_rh2-t_rh1)
-                      bex(icol,ilev,kc10,iband)=e**(a*t_xrh+b)
+                      bex(icol,ilev,kout,iband)=e**(a*t_xrh+b)
                    endif
 
                 end do ! iband
@@ -1098,11 +1089,11 @@ contains
 
                 ! finally, interpolation in the rh dimension
                 if(t_xrh <= 0.37_r8) then
-                   bex(icol,ilev,kc10,iband)=((t_rh2-t_xrh)*bex1+(t_xrh-t_rh1)*bex2)/(t_rh2-t_rh1)
+                   bex(icol,ilev,kout,iband)=((t_rh2-t_xrh)*bex1+(t_xrh-t_rh1)*bex2)/(t_rh2-t_rh1)
                 else
                    a=(log(bex2)-log(bex1))/(t_rh2-t_rh1)
                    b=(t_rh2*log(bex1)-t_rh1*log(bex2))/(t_rh2-t_rh1)
-                   bex(icol,ilev,kc10,iband)=e**(a*t_xrh+b)
+                   bex(icol,ilev,kout,iband)=e**(a*t_xrh+b)
                 endif
 
              endif  ! daylight
@@ -1137,11 +1128,11 @@ contains
 
                 ! finally, interpolation in the rh dimension
                 if(t_xrh <= 0.37_r8) then
-                   ske(icol,ilev,kc10,iband)=((t_rh2-t_xrh)*ske1+(t_xrh-t_rh1)*ske2)/(t_rh2-t_rh1)
+                   ske(icol,ilev,kout,iband)=((t_rh2-t_xrh)*ske1+(t_xrh-t_rh1)*ske2)/(t_rh2-t_rh1)
                 else
                    a=(log(ske2)-log(ske1))/(t_rh2-t_rh1)
                    b=(t_rh2*log(ske1)-t_rh1*log(ske2))/(t_rh2-t_rh1)
-                   ske(icol,ilev,kc10,iband)=e**(a*t_xrh+b)
+                   ske(icol,ilev,kout,iband)=e**(a*t_xrh+b)
                 endif
 
              end do ! iband
@@ -1179,12 +1170,12 @@ contains
 
                    ! write(*,*) 'Before kabs'
                    if(t_xrh <= 0.37) then
-                      kabs(icol,ilev,kc10,iband)=((t_rh2-t_xrh)*kabs1+(t_xrh-t_rh1)*kabs2) &
+                      kabs(icol,ilev,kout,iband)=((t_rh2-t_xrh)*kabs1+(t_xrh-t_rh1)*kabs2) &
                            /(t_rh2-t_rh1)
                    else
                       a=(log(kabs2)-log(kabs1))/(t_rh2-t_rh1)
                       b=(t_rh2*log(kabs1)-t_rh1*log(kabs2))/(t_rh2-t_rh1)
-                      kabs(icol,ilev,kc10,iband)=e**(a*t_xrh+b)
+                      kabs(icol,ilev,kout,iband)=e**(a*t_xrh+b)
                    endif
 
                 end do ! iband
@@ -1193,22 +1184,16 @@ contains
 
           end do ! icol
        end do ! ilev
-       ! write(*,*) 'kcomp, omega(1,26,kcomp,4)=', kcomp, omega(1,26,kcomp,4)
-       ! write(*,*) 'kcomp, gass(1,26,kcomp,4)=', kcomp, gass(1,26,kcomp,4)
-       ! write(*,*) 'kcomp, bex(1,26,kcomp,4)=', kcomp, bex(1,26,kcomp,4)
-       ! write(*,*) 'kcomp, ske(1,26,kcomp,4)=', kcomp, ske(1,26,kcomp,4)
-    end do  ! kcomp
-
   end subroutine interpol1
 
   !=============================================================================
 
-  subroutine interpol2to3 (ncol, daylight, xrh, irh1, mplus10, Nnatk, &
+  subroutine interpol2to3 (ncol, daylight, xrh, irh1, kout, Nnatk, &
        xct, ict1, xfac, ifac1, omega, gass, bex, ske, lw_on, kabs)
 
     ! Arguments
     integer,  intent(in)  :: ncol                       ! number of atmospheric columns
-    integer,  intent(in)  :: mplus10                    ! mode number (0) or number + 10 (1)
+    integer,  intent(in)  :: kout                       ! output mode index
     logical,  intent(in)  :: daylight(pcols)            ! only daylight calculations if .true.
     logical,  intent(in)  :: lw_on                      ! LW calculations are performed if true
     real(r8), intent(in)  :: Nnatk(pcols,pver,0:nmodes) ! modal aerosol number concentration
@@ -1225,7 +1210,8 @@ contains
     real(r8), intent(out) :: kabs(pcols,pver,0:nmodes,nlwbands)! LW spectral modal specific absorption coefficient
     !
     ! Local variables
-    integer  :: iband, kcomp, ilev, icol, kc10
+    integer  :: iband, ilev, icol
+    integer, parameter :: kcomp = 2
     real(r8) :: a, b
     integer  :: t_irh1, t_irh2, t_ict1, t_ict2, t_ifc1, t_ifc2
     real(r8) :: t_fac1, t_fac2, t_xfac, t_xrh, t_xct, t_rh1, t_rh2,t_cat1, t_cat2
@@ -1235,29 +1221,20 @@ contains
     real(r8) :: kabs1, kabs2
     !---------------------------------------
 
-    do kcomp=2,2
-
-       if(mplus10==0) then
-          kc10=kcomp
-       else
-          kc10=kcomp+10
-       endif
-
-       ! write(*,*) 'Before init-loop', kc10
        do iband=1,nbands
           do icol=1,ncol
              do ilev=1,pver
-                omega(icol,ilev,kc10,iband)=0.0_r8
-                gass(icol,ilev,kc10,iband)=0.0_r8
-                bex(icol,ilev,kc10,iband)=0.0_r8
-                ske(icol,ilev,kc10,iband)=0.0_r8
+                omega(icol,ilev,kout,iband)=0.0_r8
+                gass(icol,ilev,kout,iband)=0.0_r8
+                bex(icol,ilev,kout,iband)=0.0_r8
+                ske(icol,ilev,kout,iband)=0.0_r8
              end do
           end do
        end do
        do iband=1,nlwbands
           do icol=1,ncol
              do ilev=1,pver
-                kabs(icol,ilev,kc10,iband)=0.0_r8
+                kabs(icol,ilev,kout,iband)=0.0_r8
              end do
           end do
        end do
@@ -1269,7 +1246,7 @@ contains
              ! to avoid cache conflicts and excessive cross-referencing
              t_irh1 = irh1(icol,ilev)
              t_irh2 = t_irh1+1
-             t_ict1 = ict1(icol,ilev,kc10)
+             t_ict1 = ict1(icol,ilev,kout)
              t_ict2 = t_ict1+1
              t_ifc1 = ifac1(icol,ilev,kcomp)
              t_ifc2 = t_ifc1+1
@@ -1281,7 +1258,7 @@ contains
              t_fac1 = fac(t_ifc1)
              t_fac2 = fac(t_ifc2)
              t_xrh  = xrh(icol,ilev)
-             t_xct  = xct(icol,ilev,kc10)
+             t_xct  = xct(icol,ilev,kout)
              t_xfac = xfac(icol,ilev,kcomp)
 
              ! partial lengths along each dimension (1-4) for interpolation
@@ -1316,7 +1293,7 @@ contains
                    call lininterpol3dim (d2mx, dxm1, invd, opt3d, ome1, ome2)
 
                    ! finally, interpolation in the rh dimension
-                   omega(icol,ilev,kc10,iband)=((t_rh2-t_xrh)*ome1+(t_xrh-t_rh1)*ome2)/(t_rh2-t_rh1)
+                   omega(icol,ilev,kout,iband)=((t_rh2-t_xrh)*ome1+(t_xrh-t_rh1)*ome2)/(t_rh2-t_rh1)
 
                    ! asymmetry factor
                    ! end points as basis for multidimentional linear interpolation
@@ -1333,7 +1310,7 @@ contains
                    call lininterpol3dim (d2mx, dxm1, invd, opt3d, ge1, ge2)
 
                    ! finally, interpolation in the rh dimension
-                   gass(icol,ilev,kc10,iband)=((t_rh2-t_xrh)*ge1+(t_xrh-t_rh1)*ge2)/(t_rh2-t_rh1)
+                   gass(icol,ilev,kout,iband)=((t_rh2-t_xrh)*ge1+(t_xrh-t_rh1)*ge2)/(t_rh2-t_rh1)
 
                    ! aerosol extinction
                    ! end points as basis for multidimentional linear interpolation
@@ -1354,11 +1331,11 @@ contains
 
                    ! finally, interpolation in the rh dimension
                    if(t_xrh <= 0.37) then
-                      bex(icol,ilev,kc10,iband)=((t_rh2-t_xrh)*bex1+(t_xrh-t_rh1)*bex2)/(t_rh2-t_rh1)
+                      bex(icol,ilev,kout,iband)=((t_rh2-t_xrh)*bex1+(t_xrh-t_rh1)*bex2)/(t_rh2-t_rh1)
                    else
                       a=(log(bex2)-log(bex1))/(t_rh2-t_rh1)
                       b=(t_rh2*log(bex1)-t_rh1*log(bex2))/(t_rh2-t_rh1)
-                      bex(icol,ilev,kc10,iband)=e**(a*t_xrh+b)
+                      bex(icol,ilev,kout,iband)=e**(a*t_xrh+b)
                    endif
 
                 end do ! iband
@@ -1384,11 +1361,11 @@ contains
 
                 ! finally, interpolation in the rh dimension
                 if(t_xrh <= 0.37) then
-                   bex(icol,ilev,kc10,iband)=((t_rh2-t_xrh)*bex1+(t_xrh-t_rh1)*bex2)/(t_rh2-t_rh1)
+                   bex(icol,ilev,kout,iband)=((t_rh2-t_xrh)*bex1+(t_xrh-t_rh1)*bex2)/(t_rh2-t_rh1)
                 else
                    a=(log(bex2)-log(bex1))/(t_rh2-t_rh1)
                    b=(t_rh2*log(bex1)-t_rh1*log(bex2))/(t_rh2-t_rh1)
-                   bex(icol,ilev,kc10,iband)=e**(a*t_xrh+b)
+                   bex(icol,ilev,kout,iband)=e**(a*t_xrh+b)
                 endif
 
              endif  ! daylight
@@ -1414,11 +1391,11 @@ contains
 
                 ! finally, interpolation in the rh dimension
                 if(t_xrh <= 0.37) then
-                   ske(icol,ilev,kc10,iband)=((t_rh2-t_xrh)*ske1+(t_xrh-t_rh1)*ske2)/(t_rh2-t_rh1)
+                   ske(icol,ilev,kout,iband)=((t_rh2-t_xrh)*ske1+(t_xrh-t_rh1)*ske2)/(t_rh2-t_rh1)
                 else
                    a=(log(ske2)-log(ske1))/(t_rh2-t_rh1)
                    b=(t_rh2*log(ske1)-t_rh1*log(ske2))/(t_rh2-t_rh1)
-                   ske(icol,ilev,kc10,iband)=e**(a*t_xrh+b)
+                   ske(icol,ilev,kout,iband)=e**(a*t_xrh+b)
                 endif
 
              end do ! iband
@@ -1446,34 +1423,28 @@ contains
                    kabs2=max(kabs2,1.e-30_r8)
 
                    if(t_xrh <= 0.37_r8) then
-                      kabs(icol,ilev,kc10,iband)=((t_rh2-t_xrh)*kabs1+(t_xrh-t_rh1)*kabs2)/(t_rh2-t_rh1)
+                      kabs(icol,ilev,kout,iband)=((t_rh2-t_xrh)*kabs1+(t_xrh-t_rh1)*kabs2)/(t_rh2-t_rh1)
                    else
                       a=(log(kabs2)-log(kabs1))/(t_rh2-t_rh1)
                       b=(t_rh2*log(kabs1)-t_rh1*log(kabs2))/(t_rh2-t_rh1)
-                      kabs(icol,ilev,kc10,iband)=e**(a*t_xrh+b)
+                      kabs(icol,ilev,kout,iband)=e**(a*t_xrh+b)
                    endif
 
                 end do ! iband
              endif ! lw_on
           end do ! icol
        end do ! ilev
-       ! write(*,*) 'kcomp, omega(1,26,kcomp,4)=', kcomp, omega(1,26,kcomp,4)
-       ! write(*,*) 'kcomp, gass(1,26,kcomp,4)=', kcomp, gass(1,26,kcomp,4)
-       ! write(*,*) 'kcomp, bex(1,26,kcomp,4)=', kcomp, bex(1,26,kcomp,4)
-       ! write(*,*) 'kcomp, ske(1,26,kcomp,4)=', kcomp, ske(1,26,kcomp,4)
-    end do  ! kcomp
-
   end subroutine interpol2to3
 
   !=============================================================================
 
-  subroutine interpol4 (ncol, daylight, xrh, irh1, mplus10, Nnatk, xfbcbg, ifbcbg1, &
+  subroutine interpol4 (ncol, daylight, xrh, irh1, kout, Nnatk, xfbcbg, ifbcbg1, &
        xct, ict1, xfac, ifac1, xfaq, ifaq1, &
        omega, gass, bex, ske, lw_on, kabs)
 
     ! Arguments
     integer, intent(in)   :: ncol                       ! number of atmospheric columns
-    integer, intent(in)   :: mplus10                    ! mode number (0) or number + 10 (1)
+    integer, intent(in)   :: kout                       ! output mode index
     logical, intent(in)   :: daylight(pcols)            ! only daylight calculations if .true.
     logical, intent(in)   :: lw_on                      ! LW calculations are performed if true
     real(r8), intent(in)  :: Nnatk(pcols,pver,0:nmodes) ! modal aerosol number concentration
@@ -1494,7 +1465,8 @@ contains
     real(r8), intent(out) :: kabs(pcols,pver,0:nmodes,nlwbands)! LW spectral modal specific absorption coefficient
     !
     ! Local variables
-    integer  :: iband, kcomp, ilev, kc10, icol
+    integer  :: iband, ilev, icol
+    integer, parameter :: kcomp = 4
     real(r8) :: a, b
     integer  :: t_irh1, t_irh2, t_ict1, t_ict2, t_ifa1, t_ifa2, t_ifb1, t_ifb2, t_ifc1, t_ifc2
     real(r8) :: t_faq1, t_faq2, t_xfaq, t_fbcbg1, t_fbcbg2, t_xfbcbg, t_fac1
@@ -1505,29 +1477,20 @@ contains
     real(r8) :: kabs1, kabs2
     !---------------------------------------
 
-    do kcomp=4,4
-
-       if(mplus10==0) then
-          kc10=kcomp
-       else
-          kc10=kcomp+10
-       endif
-
-       ! write(*,*) 'Before init-loop', kc10
        do iband=1,nbands
           do ilev=1,pver
              do icol=1,ncol
-                omega(icol,ilev,kc10,iband)=0.0_r8
-                gass(icol,ilev,kc10,iband)=0.0_r8
-                bex(icol,ilev,kc10,iband)=0.0_r8
-                ske(icol,ilev,kc10,iband)=0.0_r8
+                omega(icol,ilev,kout,iband)=0.0_r8
+                gass(icol,ilev,kout,iband)=0.0_r8
+                bex(icol,ilev,kout,iband)=0.0_r8
+                ske(icol,ilev,kout,iband)=0.0_r8
              end do
           end do
        end do
        do iband=1,nlwbands
           do ilev=1,pver
              do icol=1,ncol
-                kabs(icol,ilev,kc10,iband)=0.0_r8
+                kabs(icol,ilev,kout,iband)=0.0_r8
              end do
           end do
        end do
@@ -1540,7 +1503,7 @@ contains
 
              t_irh1 = irh1(icol,ilev)
              t_irh2 = t_irh1+1
-             t_ict1 = ict1(icol,ilev,kc10)
+             t_ict1 = ict1(icol,ilev,kout)
              t_ict2 = t_ict1+1
              t_ifc1 = ifac1(icol,ilev,kcomp)
              t_ifc2 = t_ifc1+1
@@ -1561,7 +1524,7 @@ contains
              t_faq2 = faq(t_ifa2)
 
              t_xrh  = xrh(icol,ilev)
-             t_xct  = xct(icol,ilev,kc10)
+             t_xct  = xct(icol,ilev,kout)
              t_xfac = xfac(icol,ilev,kcomp)
              t_xfbcbg = xfbcbg(icol,ilev)
              t_xfaq = xfaq(icol,ilev,kcomp)
@@ -1626,7 +1589,7 @@ contains
                    call lininterpol5dim (d2mx, dxm1, invd, opt5d, ome1, ome2)
 
                    ! finally, interpolation in the rh dimension
-                   omega(icol,ilev,kc10,iband)=((t_rh2-t_xrh)*ome1+(t_xrh-t_rh1)*ome2) /(t_rh2-t_rh1)
+                   omega(icol,ilev,kout,iband)=((t_rh2-t_xrh)*ome1+(t_xrh-t_rh1)*ome2) /(t_rh2-t_rh1)
 
                    ! asymmetry factor
                    opt5d(1,1,1,1,1)=g4(iband,t_irh1,t_ifb1,t_ict1,t_ifc1,t_ifa1)
@@ -1666,7 +1629,7 @@ contains
                    call lininterpol5dim (d2mx, dxm1, invd, opt5d, ge1, ge2)
 
                    ! finally, interpolation in the rh dimension
-                   gass(icol,ilev,kc10,iband)=((t_rh2-t_xrh)*ge1+(t_xrh-t_rh1)*ge2)/(t_rh2-t_rh1)
+                   gass(icol,ilev,kout,iband)=((t_rh2-t_xrh)*ge1+(t_xrh-t_rh1)*ge2)/(t_rh2-t_rh1)
 
                    ! aerosol extinction
                    opt5d(1,1,1,1,1)=be4(iband,t_irh1,t_ifb1,t_ict1,t_ifc1,t_ifa1)
@@ -1710,11 +1673,11 @@ contains
 
                    ! finally, interpolation in the rh dimension
                    if(t_xrh <= 0.37_r8) then
-                      bex(icol,ilev,kc10,iband)=((t_rh2-t_xrh)*bex1+(t_xrh-t_rh1)*bex2)/(t_rh2-t_rh1)
+                      bex(icol,ilev,kout,iband)=((t_rh2-t_xrh)*bex1+(t_xrh-t_rh1)*bex2)/(t_rh2-t_rh1)
                    else
                       a=(log(bex2)-log(bex1))/(t_rh2-t_rh1)
                       b=(t_rh2*log(bex1)-t_rh1*log(bex2))/(t_rh2-t_rh1)
-                      bex(icol,ilev,kc10,iband)=e**(a*t_xrh+b)
+                      bex(icol,ilev,kout,iband)=e**(a*t_xrh+b)
                    endif
 
                 end do ! iband
@@ -1765,11 +1728,11 @@ contains
                 ! finally, interpolation in the rh dimension
                 ! write(*,*) 'Before bex'
                 if(t_xrh <= 0.37_r8) then
-                   bex(icol,ilev,kc10,iband)=((t_rh2-t_xrh)*bex1+(t_xrh-t_rh1)*bex2)/(t_rh2-t_rh1)
+                   bex(icol,ilev,kout,iband)=((t_rh2-t_xrh)*bex1+(t_xrh-t_rh1)*bex2)/(t_rh2-t_rh1)
                 else
                    a=(log(bex2)-log(bex1))/(t_rh2-t_rh1)
                    b=(t_rh2*log(bex1)-t_rh1*log(bex2))/(t_rh2-t_rh1)
-                   bex(icol,ilev,kc10,iband)=e**(a*t_xrh+b)
+                   bex(icol,ilev,kout,iband)=e**(a*t_xrh+b)
                 endif
 
              endif  ! daylight
@@ -1819,11 +1782,11 @@ contains
                 ! finally, interpolation in the rh dimension
                 ! write(*,*) 'Before ske'
                 if(t_xrh <= 0.37_r8) then
-                   ske(icol,ilev,kc10,iband)=((t_rh2-t_xrh)*ske1+(t_xrh-t_rh1)*ske2)/(t_rh2-t_rh1)
+                   ske(icol,ilev,kout,iband)=((t_rh2-t_xrh)*ske1+(t_xrh-t_rh1)*ske2)/(t_rh2-t_rh1)
                 else
                    a=(log(ske2)-log(ske1))/(t_rh2-t_rh1)
                    b=(t_rh2*log(ske1)-t_rh1*log(ske2))/(t_rh2-t_rh1)
-                   ske(icol,ilev,kc10,iband)=e**(a*t_xrh+b)
+                   ske(icol,ilev,kout,iband)=e**(a*t_xrh+b)
                 endif
              end do ! iband
 
@@ -1872,33 +1835,28 @@ contains
                    kabs2=max(kabs2,1.e-30_r8)
 
                    if(t_xrh <= 0.37_r8) then
-                      kabs(icol,ilev,kc10,iband)=((t_rh2-t_xrh)*kabs1+(t_xrh-t_rh1)*kabs2)/(t_rh2-t_rh1)
+                      kabs(icol,ilev,kout,iband)=((t_rh2-t_xrh)*kabs1+(t_xrh-t_rh1)*kabs2)/(t_rh2-t_rh1)
                    else
                       a=(log(kabs2)-log(kabs1))/(t_rh2-t_rh1)
                       b=(t_rh2*log(kabs1)-t_rh1*log(kabs2))/(t_rh2-t_rh1)
-                      kabs(icol,ilev,kc10,iband)=e**(a*t_xrh+b)
+                      kabs(icol,ilev,kout,iband)=e**(a*t_xrh+b)
                    endif
 
                 end do ! iband
              endif ! lw_on
           end do ! icol
        end do ! ilev
-       ! write(*,*) 'kcomp, omega(1,26,kc10,4)=', kcomp, omega(1,26,kc10,4)
-       ! write(*,*) 'kcomp, gass(1,26,kc10,4)=', kcomp, gass(1,26,kc10,4)
-       ! write(*,*) 'kcomp, bex(1,26,kc10,4)=', kcomp, bex(1,26,kc10,4)
-       ! write(*,*) 'kcomp, ske(1,26,kc10,4)=', kcomp, ske(1,26,kc10,4)
-    end do  ! kcomp
-
   end subroutine interpol4
 
   !=============================================================================
 
-  subroutine interpol5to10 (ncol, daylight, xrh, irh1, Nnatk, xct, ict1, &
+  subroutine interpol5to10 (ncol, daylight, xrh, irh1, kcomp, Nnatk, xct, ict1, &
        xfac, ifac1, xfbc, ifbc1, xfaq, ifaq1, &
        omega, gass, bex, ske, lw_on, kabs)
 
     ! Input arguments
     integer, intent(in) :: ncol                        ! number of atmospheric columns
+    integer, intent(in) :: kcomp                       ! mode index, 5-10
     logical, intent(in) :: daylight(pcols)             ! only daylight calculations if .true.
     logical, intent(in) :: lw_on                       ! LW calculations are performed if true
     real(r8), intent(in) :: Nnatk(pcols,pver,0:nmodes) ! modal aerosol number concentration
@@ -1921,7 +1879,7 @@ contains
     real(r8), intent(out) :: kabs(pcols,pver,0:nmodes,nlwbands)! LW spectral modal specific absorption coefficient
 
     ! Local variables
-    integer  :: iband, kcomp, ilev, icol
+    integer  :: iband, ilev, icol
     real(r8) :: a, b
     integer  :: t_irh1, t_irh2, t_ict1, t_ict2, t_ifa1, t_ifa2
     integer  :: t_ifb1, t_ifb2, t_ifc1, t_ifc2
@@ -1933,7 +1891,6 @@ contains
     real(r8) :: kabs1, kabs2
     !---------------------------------------
 
-    do kcomp=5,10
        do iband=1,nbands
           do ilev=1,pver
              do icol=1,ncol
@@ -2303,7 +2260,6 @@ contains
 
           end do ! icol
        end do ! ilev
-    end do  ! kcomp
 
   end subroutine interpol5to10
 

--- a/src/oslo_aero_sw_tables.F90
+++ b/src/oslo_aero_sw_tables.F90
@@ -1891,215 +1891,161 @@ contains
     real(r8) :: kabs1, kabs2
     !---------------------------------------
 
-       do iband=1,nbands
-          do ilev=1,pver
-             do icol=1,ncol
-                omega(icol,ilev,kcomp,iband)=0.0_r8
-                gass(icol,ilev,kcomp,iband)=0.0_r8
-                bex(icol,ilev,kcomp,iband)=0.0_r8
-                ske(icol,ilev,kcomp,iband)=0.0_r8
-             end do
-          end do
-       end do
-       do iband=1,nlwbands
-          do ilev=1,pver
-             do icol=1,ncol
-                kabs(icol,ilev,kcomp,iband)=0.0_r8
-             end do
-          end do
-       end do
-
+    do iband=1,nbands
        do ilev=1,pver
           do icol=1,ncol
+             omega(icol,ilev,kcomp,iband)=0.0_r8
+             gass(icol,ilev,kcomp,iband)=0.0_r8
+             bex(icol,ilev,kcomp,iband)=0.0_r8
+             ske(icol,ilev,kcomp,iband)=0.0_r8
+          end do
+       end do
+    end do
+    do iband=1,nlwbands
+       do ilev=1,pver
+          do icol=1,ncol
+             kabs(icol,ilev,kcomp,iband)=0.0_r8
+          end do
+       end do
+    end do
 
-             ! Collect all the vector elements into temporary storage
-             ! to avoid cache conflicts and excessive cross-referencing
+    do ilev=1,pver
+       do icol=1,ncol
 
-             t_irh1 = irh1(icol,ilev)
-             t_irh2 = t_irh1+1
-             t_ict1 = ict1(icol,ilev,kcomp)
-             t_ict2 = t_ict1+1
-             t_ifc1 = ifac1(icol,ilev,kcomp)
-             t_ifc2 = t_ifc1+1
+          ! Collect all the vector elements into temporary storage
+          ! to avoid cache conflicts and excessive cross-referencing
 
-             t_ifb1 = ifbc1(icol,ilev,kcomp)
-             t_ifb2 = t_ifb1+1
-             t_ifa1 = ifaq1(icol,ilev,kcomp)
-             t_ifa2 = t_ifa1+1
+          t_irh1 = irh1(icol,ilev)
+          t_irh2 = t_irh1+1
+          t_ict1 = ict1(icol,ilev,kcomp)
+          t_ict2 = t_ict1+1
+          t_ifc1 = ifac1(icol,ilev,kcomp)
+          t_ifc2 = t_ifc1+1
 
-             t_rh1  = rh(t_irh1)
-             t_rh2  = rh(t_irh2)
-             t_cat1 = cat(kcomp,t_ict1)
-             t_cat2 = cat(kcomp,t_ict2)
-             t_fac1 = fac(t_ifc1)
-             t_fac2 = fac(t_ifc2)
-             t_fbc1 = fbc(t_ifb1)
-             t_fbc2 = fbc(t_ifb2)
-             t_faq1 = faq(t_ifa1)
-             t_faq2 = faq(t_ifa2)
+          t_ifb1 = ifbc1(icol,ilev,kcomp)
+          t_ifb2 = t_ifb1+1
+          t_ifa1 = ifaq1(icol,ilev,kcomp)
+          t_ifa2 = t_ifa1+1
 
-             t_xrh  = xrh(icol,ilev)
-             t_xct  = xct(icol,ilev,kcomp)
-             t_xfac = xfac(icol,ilev,kcomp)
-             t_xfbc = xfbc(icol,ilev,kcomp)
-             t_xfaq = xfaq(icol,ilev,kcomp)
+          t_rh1  = rh(t_irh1)
+          t_rh2  = rh(t_irh2)
+          t_cat1 = cat(kcomp,t_ict1)
+          t_cat2 = cat(kcomp,t_ict2)
+          t_fac1 = fac(t_ifc1)
+          t_fac2 = fac(t_ifc2)
+          t_fbc1 = fbc(t_ifb1)
+          t_fbc2 = fbc(t_ifb2)
+          t_faq1 = faq(t_ifa1)
+          t_faq2 = faq(t_ifa2)
 
-             ! partial lengths along each dimension (1-5) for interpolation
-             d2mx(1) = (t_rh2-t_xrh)
-             dxm1(1) = (t_xrh-t_rh1)
-             invd(1) = 1.0_r8/(t_rh2-t_rh1)
-             d2mx(2) = (t_cat2-t_xct)
-             dxm1(2) = (t_xct-t_cat1)
-             invd(2) = 1.0_r8/(t_cat2-t_cat1)
-             d2mx(3) = (t_fac2-t_xfac)
-             dxm1(3) = (t_xfac-t_fac1)
-             invd(3) = 1.0_r8/(t_fac2-t_fac1)
-             d2mx(4) = (t_fbc2-t_xfbc)
-             dxm1(4) = (t_xfbc-t_fbc1)
-             invd(4) = 1.0_r8/(t_fbc2-t_fbc1)
-             d2mx(5) = (t_faq2-t_xfaq)
-             dxm1(5) = (t_xfaq-t_faq1)
-             invd(5) = 1.0_r8/(t_faq2-t_faq1)
+          t_xrh  = xrh(icol,ilev)
+          t_xct  = xct(icol,ilev,kcomp)
+          t_xfac = xfac(icol,ilev,kcomp)
+          t_xfbc = xfbc(icol,ilev,kcomp)
+          t_xfaq = xfaq(icol,ilev,kcomp)
 
-             ! SW optical parameters
-             if(daylight(icol)) then
-                do iband=1,nbands            ! iband = wavelength index
+          ! partial lengths along each dimension (1-5) for interpolation
+          d2mx(1) = (t_rh2-t_xrh)
+          dxm1(1) = (t_xrh-t_rh1)
+          invd(1) = 1.0_r8/(t_rh2-t_rh1)
+          d2mx(2) = (t_cat2-t_xct)
+          dxm1(2) = (t_xct-t_cat1)
+          invd(2) = 1.0_r8/(t_cat2-t_cat1)
+          d2mx(3) = (t_fac2-t_xfac)
+          dxm1(3) = (t_xfac-t_fac1)
+          invd(3) = 1.0_r8/(t_fac2-t_fac1)
+          d2mx(4) = (t_fbc2-t_xfbc)
+          dxm1(4) = (t_xfbc-t_fbc1)
+          invd(4) = 1.0_r8/(t_fbc2-t_fbc1)
+          d2mx(5) = (t_faq2-t_xfaq)
+          dxm1(5) = (t_xfaq-t_faq1)
+          invd(5) = 1.0_r8/(t_faq2-t_faq1)
 
-                   ! single scattering albedo:
-                   opt5d(1,1,1,1,1)=om5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb1,t_ifa1,kcomp)
-                   opt5d(1,1,1,1,2)=om5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb1,t_ifa2,kcomp)
-                   opt5d(1,1,1,2,1)=om5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb2,t_ifa1,kcomp)
-                   opt5d(1,1,1,2,2)=om5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb2,t_ifa2,kcomp)
-                   opt5d(1,1,2,1,1)=om5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb1,t_ifa1,kcomp)
-                   opt5d(1,1,2,1,2)=om5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb1,t_ifa2,kcomp)
-                   opt5d(1,1,2,2,1)=om5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb2,t_ifa1,kcomp)
-                   opt5d(1,1,2,2,2)=om5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb2,t_ifa2,kcomp)
-                   opt5d(1,2,1,1,1)=om5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb1,t_ifa1,kcomp)
-                   opt5d(1,2,1,1,2)=om5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb1,t_ifa2,kcomp)
-                   opt5d(1,2,1,2,1)=om5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb2,t_ifa1,kcomp)
-                   opt5d(1,2,1,2,2)=om5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb2,t_ifa2,kcomp)
-                   opt5d(1,2,2,1,1)=om5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb1,t_ifa1,kcomp)
-                   opt5d(1,2,2,1,2)=om5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb1,t_ifa2,kcomp)
-                   opt5d(1,2,2,2,1)=om5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb2,t_ifa1,kcomp)
-                   opt5d(1,2,2,2,2)=om5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb2,t_ifa2,kcomp)
-                   opt5d(2,1,1,1,1)=om5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb1,t_ifa1,kcomp)
-                   opt5d(2,1,1,1,2)=om5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb1,t_ifa2,kcomp)
-                   opt5d(2,1,1,2,1)=om5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb2,t_ifa1,kcomp)
-                   opt5d(2,1,1,2,2)=om5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb2,t_ifa2,kcomp)
-                   opt5d(2,1,2,1,1)=om5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb1,t_ifa1,kcomp)
-                   opt5d(2,1,2,1,2)=om5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb1,t_ifa2,kcomp)
-                   opt5d(2,1,2,2,1)=om5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb2,t_ifa1,kcomp)
-                   opt5d(2,1,2,2,2)=om5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb2,t_ifa2,kcomp)
-                   opt5d(2,2,1,1,1)=om5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb1,t_ifa1,kcomp)
-                   opt5d(2,2,1,1,2)=om5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb1,t_ifa2,kcomp)
-                   opt5d(2,2,1,2,1)=om5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb2,t_ifa1,kcomp)
-                   opt5d(2,2,1,2,2)=om5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb2,t_ifa2,kcomp)
-                   opt5d(2,2,2,1,1)=om5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb1,t_ifa1,kcomp)
-                   opt5d(2,2,2,1,2)=om5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb1,t_ifa2,kcomp)
-                   opt5d(2,2,2,2,1)=om5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb2,t_ifa1,kcomp)
-                   opt5d(2,2,2,2,2)=om5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb2,t_ifa2,kcomp)
+          ! SW optical parameters
+          if(daylight(icol)) then
+             do iband=1,nbands            ! iband = wavelength index
 
-                   ! interpolation in the faq, fbc, fac and cat dimensions
-                   call lininterpol5dim (d2mx, dxm1, invd, opt5d, ome1, ome2)
+                ! single scattering albedo:
+                opt5d(1,1,1,1,1)=om5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb1,t_ifa1,kcomp)
+                opt5d(1,1,1,1,2)=om5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb1,t_ifa2,kcomp)
+                opt5d(1,1,1,2,1)=om5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb2,t_ifa1,kcomp)
+                opt5d(1,1,1,2,2)=om5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb2,t_ifa2,kcomp)
+                opt5d(1,1,2,1,1)=om5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb1,t_ifa1,kcomp)
+                opt5d(1,1,2,1,2)=om5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb1,t_ifa2,kcomp)
+                opt5d(1,1,2,2,1)=om5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb2,t_ifa1,kcomp)
+                opt5d(1,1,2,2,2)=om5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb2,t_ifa2,kcomp)
+                opt5d(1,2,1,1,1)=om5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb1,t_ifa1,kcomp)
+                opt5d(1,2,1,1,2)=om5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb1,t_ifa2,kcomp)
+                opt5d(1,2,1,2,1)=om5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb2,t_ifa1,kcomp)
+                opt5d(1,2,1,2,2)=om5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb2,t_ifa2,kcomp)
+                opt5d(1,2,2,1,1)=om5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb1,t_ifa1,kcomp)
+                opt5d(1,2,2,1,2)=om5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb1,t_ifa2,kcomp)
+                opt5d(1,2,2,2,1)=om5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb2,t_ifa1,kcomp)
+                opt5d(1,2,2,2,2)=om5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb2,t_ifa2,kcomp)
+                opt5d(2,1,1,1,1)=om5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb1,t_ifa1,kcomp)
+                opt5d(2,1,1,1,2)=om5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb1,t_ifa2,kcomp)
+                opt5d(2,1,1,2,1)=om5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb2,t_ifa1,kcomp)
+                opt5d(2,1,1,2,2)=om5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb2,t_ifa2,kcomp)
+                opt5d(2,1,2,1,1)=om5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb1,t_ifa1,kcomp)
+                opt5d(2,1,2,1,2)=om5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb1,t_ifa2,kcomp)
+                opt5d(2,1,2,2,1)=om5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb2,t_ifa1,kcomp)
+                opt5d(2,1,2,2,2)=om5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb2,t_ifa2,kcomp)
+                opt5d(2,2,1,1,1)=om5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb1,t_ifa1,kcomp)
+                opt5d(2,2,1,1,2)=om5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb1,t_ifa2,kcomp)
+                opt5d(2,2,1,2,1)=om5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb2,t_ifa1,kcomp)
+                opt5d(2,2,1,2,2)=om5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb2,t_ifa2,kcomp)
+                opt5d(2,2,2,1,1)=om5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb1,t_ifa1,kcomp)
+                opt5d(2,2,2,1,2)=om5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb1,t_ifa2,kcomp)
+                opt5d(2,2,2,2,1)=om5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb2,t_ifa1,kcomp)
+                opt5d(2,2,2,2,2)=om5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb2,t_ifa2,kcomp)
 
-                   ! finally, interpolation in the rh dimension
-                   omega(icol,ilev,kcomp,iband)=((t_rh2-t_xrh)*ome1+(t_xrh-t_rh1)*ome2)/(t_rh2-t_rh1)
+                ! interpolation in the faq, fbc, fac and cat dimensions
+                call lininterpol5dim (d2mx, dxm1, invd, opt5d, ome1, ome2)
 
-                   ! asymmetry factor
-                   opt5d(1,1,1,1,1)=g5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb1,t_ifa1,kcomp)
-                   opt5d(1,1,1,1,2)=g5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb1,t_ifa2,kcomp)
-                   opt5d(1,1,1,2,1)=g5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb2,t_ifa1,kcomp)
-                   opt5d(1,1,1,2,2)=g5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb2,t_ifa2,kcomp)
-                   opt5d(1,1,2,1,1)=g5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb1,t_ifa1,kcomp)
-                   opt5d(1,1,2,1,2)=g5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb1,t_ifa2,kcomp)
-                   opt5d(1,1,2,2,1)=g5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb2,t_ifa1,kcomp)
-                   opt5d(1,1,2,2,2)=g5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb2,t_ifa2,kcomp)
-                   opt5d(1,2,1,1,1)=g5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb1,t_ifa1,kcomp)
-                   opt5d(1,2,1,1,2)=g5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb1,t_ifa2,kcomp)
-                   opt5d(1,2,1,2,1)=g5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb2,t_ifa1,kcomp)
-                   opt5d(1,2,1,2,2)=g5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb2,t_ifa2,kcomp)
-                   opt5d(1,2,2,1,1)=g5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb1,t_ifa1,kcomp)
-                   opt5d(1,2,2,1,2)=g5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb1,t_ifa2,kcomp)
-                   opt5d(1,2,2,2,1)=g5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb2,t_ifa1,kcomp)
-                   opt5d(1,2,2,2,2)=g5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb2,t_ifa2,kcomp)
-                   opt5d(2,1,1,1,1)=g5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb1,t_ifa1,kcomp)
-                   opt5d(2,1,1,1,2)=g5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb1,t_ifa2,kcomp)
-                   opt5d(2,1,1,2,1)=g5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb2,t_ifa1,kcomp)
-                   opt5d(2,1,1,2,2)=g5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb2,t_ifa2,kcomp)
-                   opt5d(2,1,2,1,1)=g5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb1,t_ifa1,kcomp)
-                   opt5d(2,1,2,1,2)=g5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb1,t_ifa2,kcomp)
-                   opt5d(2,1,2,2,1)=g5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb2,t_ifa1,kcomp)
-                   opt5d(2,1,2,2,2)=g5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb2,t_ifa2,kcomp)
-                   opt5d(2,2,1,1,1)=g5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb1,t_ifa1,kcomp)
-                   opt5d(2,2,1,1,2)=g5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb1,t_ifa2,kcomp)
-                   opt5d(2,2,1,2,1)=g5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb2,t_ifa1,kcomp)
-                   opt5d(2,2,1,2,2)=g5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb2,t_ifa2,kcomp)
-                   opt5d(2,2,2,1,1)=g5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb1,t_ifa1,kcomp)
-                   opt5d(2,2,2,1,2)=g5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb1,t_ifa2,kcomp)
-                   opt5d(2,2,2,2,1)=g5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb2,t_ifa1,kcomp)
-                   opt5d(2,2,2,2,2)=g5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb2,t_ifa2,kcomp)
+                ! finally, interpolation in the rh dimension
+                omega(icol,ilev,kcomp,iband)=((t_rh2-t_xrh)*ome1+(t_xrh-t_rh1)*ome2)/(t_rh2-t_rh1)
 
-                   ! interpolation in the faq, fbc, fac and cat dimensions
-                   call lininterpol5dim (d2mx, dxm1, invd, opt5d, ge1, ge2)
+                ! asymmetry factor
+                opt5d(1,1,1,1,1)=g5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb1,t_ifa1,kcomp)
+                opt5d(1,1,1,1,2)=g5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb1,t_ifa2,kcomp)
+                opt5d(1,1,1,2,1)=g5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb2,t_ifa1,kcomp)
+                opt5d(1,1,1,2,2)=g5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb2,t_ifa2,kcomp)
+                opt5d(1,1,2,1,1)=g5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb1,t_ifa1,kcomp)
+                opt5d(1,1,2,1,2)=g5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb1,t_ifa2,kcomp)
+                opt5d(1,1,2,2,1)=g5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb2,t_ifa1,kcomp)
+                opt5d(1,1,2,2,2)=g5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb2,t_ifa2,kcomp)
+                opt5d(1,2,1,1,1)=g5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb1,t_ifa1,kcomp)
+                opt5d(1,2,1,1,2)=g5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb1,t_ifa2,kcomp)
+                opt5d(1,2,1,2,1)=g5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb2,t_ifa1,kcomp)
+                opt5d(1,2,1,2,2)=g5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb2,t_ifa2,kcomp)
+                opt5d(1,2,2,1,1)=g5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb1,t_ifa1,kcomp)
+                opt5d(1,2,2,1,2)=g5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb1,t_ifa2,kcomp)
+                opt5d(1,2,2,2,1)=g5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb2,t_ifa1,kcomp)
+                opt5d(1,2,2,2,2)=g5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb2,t_ifa2,kcomp)
+                opt5d(2,1,1,1,1)=g5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb1,t_ifa1,kcomp)
+                opt5d(2,1,1,1,2)=g5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb1,t_ifa2,kcomp)
+                opt5d(2,1,1,2,1)=g5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb2,t_ifa1,kcomp)
+                opt5d(2,1,1,2,2)=g5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb2,t_ifa2,kcomp)
+                opt5d(2,1,2,1,1)=g5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb1,t_ifa1,kcomp)
+                opt5d(2,1,2,1,2)=g5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb1,t_ifa2,kcomp)
+                opt5d(2,1,2,2,1)=g5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb2,t_ifa1,kcomp)
+                opt5d(2,1,2,2,2)=g5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb2,t_ifa2,kcomp)
+                opt5d(2,2,1,1,1)=g5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb1,t_ifa1,kcomp)
+                opt5d(2,2,1,1,2)=g5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb1,t_ifa2,kcomp)
+                opt5d(2,2,1,2,1)=g5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb2,t_ifa1,kcomp)
+                opt5d(2,2,1,2,2)=g5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb2,t_ifa2,kcomp)
+                opt5d(2,2,2,1,1)=g5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb1,t_ifa1,kcomp)
+                opt5d(2,2,2,1,2)=g5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb1,t_ifa2,kcomp)
+                opt5d(2,2,2,2,1)=g5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb2,t_ifa1,kcomp)
+                opt5d(2,2,2,2,2)=g5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb2,t_ifa2,kcomp)
 
-                   ! finally, interpolation in the rh dimension
-                   gass(icol,ilev,kcomp,iband)=((t_rh2-t_xrh)*ge1+(t_xrh-t_rh1)*ge2)/(t_rh2-t_rh1)
+                ! interpolation in the faq, fbc, fac and cat dimensions
+                call lininterpol5dim (d2mx, dxm1, invd, opt5d, ge1, ge2)
 
-                   ! aerosol extinction
-                   opt5d(1,1,1,1,1)=be5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb1,t_ifa1,kcomp)
-                   opt5d(1,1,1,1,2)=be5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb1,t_ifa2,kcomp)
-                   opt5d(1,1,1,2,1)=be5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb2,t_ifa1,kcomp)
-                   opt5d(1,1,1,2,2)=be5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb2,t_ifa2,kcomp)
-                   opt5d(1,1,2,1,1)=be5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb1,t_ifa1,kcomp)
-                   opt5d(1,1,2,1,2)=be5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb1,t_ifa2,kcomp)
-                   opt5d(1,1,2,2,1)=be5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb2,t_ifa1,kcomp)
-                   opt5d(1,1,2,2,2)=be5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb2,t_ifa2,kcomp)
-                   opt5d(1,2,1,1,1)=be5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb1,t_ifa1,kcomp)
-                   opt5d(1,2,1,1,2)=be5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb1,t_ifa2,kcomp)
-                   opt5d(1,2,1,2,1)=be5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb2,t_ifa1,kcomp)
-                   opt5d(1,2,1,2,2)=be5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb2,t_ifa2,kcomp)
-                   opt5d(1,2,2,1,1)=be5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb1,t_ifa1,kcomp)
-                   opt5d(1,2,2,1,2)=be5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb1,t_ifa2,kcomp)
-                   opt5d(1,2,2,2,1)=be5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb2,t_ifa1,kcomp)
-                   opt5d(1,2,2,2,2)=be5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb2,t_ifa2,kcomp)
-                   opt5d(2,1,1,1,1)=be5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb1,t_ifa1,kcomp)
-                   opt5d(2,1,1,1,2)=be5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb1,t_ifa2,kcomp)
-                   opt5d(2,1,1,2,1)=be5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb2,t_ifa1,kcomp)
-                   opt5d(2,1,1,2,2)=be5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb2,t_ifa2,kcomp)
-                   opt5d(2,1,2,1,1)=be5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb1,t_ifa1,kcomp)
-                   opt5d(2,1,2,1,2)=be5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb1,t_ifa2,kcomp)
-                   opt5d(2,1,2,2,1)=be5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb2,t_ifa1,kcomp)
-                   opt5d(2,1,2,2,2)=be5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb2,t_ifa2,kcomp)
-                   opt5d(2,2,1,1,1)=be5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb1,t_ifa1,kcomp)
-                   opt5d(2,2,1,1,2)=be5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb1,t_ifa2,kcomp)
-                   opt5d(2,2,1,2,1)=be5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb2,t_ifa1,kcomp)
-                   opt5d(2,2,1,2,2)=be5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb2,t_ifa2,kcomp)
-                   opt5d(2,2,2,1,1)=be5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb1,t_ifa1,kcomp)
-                   opt5d(2,2,2,1,2)=be5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb1,t_ifa2,kcomp)
-                   opt5d(2,2,2,2,1)=be5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb2,t_ifa1,kcomp)
-                   opt5d(2,2,2,2,2)=be5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb2,t_ifa2,kcomp)
+                ! finally, interpolation in the rh dimension
+                gass(icol,ilev,kcomp,iband)=((t_rh2-t_xrh)*ge1+(t_xrh-t_rh1)*ge2)/(t_rh2-t_rh1)
 
-                   ! interpolation in the faq, fbc, fac and cat dimensions
-                   call lininterpol5dim (d2mx, dxm1, invd, opt5d, bex1, bex2)
-
-                   bex1=max(bex1,1.e-30_r8)
-                   bex2=max(bex2,1.e-30_r8)
-
-                   ! finally, interpolation in the rh dimension
-                   if(t_xrh <= 0.37_r8) then
-                      bex(icol,ilev,kcomp,iband)=((t_rh2-t_xrh)*bex1 + (t_xrh-t_rh1)*bex2)/(t_rh2-t_rh1)
-                   else
-                      a=(log(bex2)-log(bex1))/(t_rh2-t_rh1)
-                      b=(t_rh2*log(bex1)-t_rh1*log(bex2))/(t_rh2-t_rh1)
-                      bex(icol,ilev,kcomp,iband)=e**(a*t_xrh+b)
-                   endif
-
-                end do ! iband
-
-             else  ! daylight
-
-                ! aerosol extinction  used for aerosol size estimate needed for LW calculations
-                iband=4
+                ! aerosol extinction
                 opt5d(1,1,1,1,1)=be5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb1,t_ifa1,kcomp)
                 opt5d(1,1,1,1,2)=be5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb1,t_ifa2,kcomp)
                 opt5d(1,1,1,2,1)=be5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb2,t_ifa1,kcomp)
@@ -2141,125 +2087,179 @@ contains
 
                 ! finally, interpolation in the rh dimension
                 if(t_xrh <= 0.37_r8) then
-                   bex(icol,ilev,kcomp,iband)=((t_rh2-t_xrh)*bex1+(t_xrh-t_rh1)*bex2)/(t_rh2-t_rh1)
+                   bex(icol,ilev,kcomp,iband)=((t_rh2-t_xrh)*bex1 + (t_xrh-t_rh1)*bex2)/(t_rh2-t_rh1)
                 else
                    a=(log(bex2)-log(bex1))/(t_rh2-t_rh1)
                    b=(t_rh2*log(bex1)-t_rh1*log(bex2))/(t_rh2-t_rh1)
                    bex(icol,ilev,kcomp,iband)=e**(a*t_xrh+b)
                 endif
 
-             endif  ! daylight
-
-             do iband=4,4            ! iband = wavelength index
-
-                ! aerosol specific extinction
-                opt5d(1,1,1,1,1)=ke5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb1,t_ifa1,kcomp)
-                opt5d(1,1,1,1,2)=ke5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb1,t_ifa2,kcomp)
-                opt5d(1,1,1,2,1)=ke5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb2,t_ifa1,kcomp)
-                opt5d(1,1,1,2,2)=ke5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb2,t_ifa2,kcomp)
-                opt5d(1,1,2,1,1)=ke5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb1,t_ifa1,kcomp)
-                opt5d(1,1,2,1,2)=ke5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb1,t_ifa2,kcomp)
-                opt5d(1,1,2,2,1)=ke5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb2,t_ifa1,kcomp)
-                opt5d(1,1,2,2,2)=ke5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb2,t_ifa2,kcomp)
-                opt5d(1,2,1,1,1)=ke5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb1,t_ifa1,kcomp)
-                opt5d(1,2,1,1,2)=ke5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb1,t_ifa2,kcomp)
-                opt5d(1,2,1,2,1)=ke5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb2,t_ifa1,kcomp)
-                opt5d(1,2,1,2,2)=ke5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb2,t_ifa2,kcomp)
-                opt5d(1,2,2,1,1)=ke5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb1,t_ifa1,kcomp)
-                opt5d(1,2,2,1,2)=ke5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb1,t_ifa2,kcomp)
-                opt5d(1,2,2,2,1)=ke5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb2,t_ifa1,kcomp)
-                opt5d(1,2,2,2,2)=ke5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb2,t_ifa2,kcomp)
-                opt5d(2,1,1,1,1)=ke5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb1,t_ifa1,kcomp)
-                opt5d(2,1,1,1,2)=ke5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb1,t_ifa2,kcomp)
-                opt5d(2,1,1,2,1)=ke5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb2,t_ifa1,kcomp)
-                opt5d(2,1,1,2,2)=ke5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb2,t_ifa2,kcomp)
-                opt5d(2,1,2,1,1)=ke5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb1,t_ifa1,kcomp)
-                opt5d(2,1,2,1,2)=ke5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb1,t_ifa2,kcomp)
-                opt5d(2,1,2,2,1)=ke5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb2,t_ifa1,kcomp)
-                opt5d(2,1,2,2,2)=ke5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb2,t_ifa2,kcomp)
-                opt5d(2,2,1,1,1)=ke5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb1,t_ifa1,kcomp)
-                opt5d(2,2,1,1,2)=ke5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb1,t_ifa2,kcomp)
-                opt5d(2,2,1,2,1)=ke5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb2,t_ifa1,kcomp)
-                opt5d(2,2,1,2,2)=ke5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb2,t_ifa2,kcomp)
-                opt5d(2,2,2,1,1)=ke5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb1,t_ifa1,kcomp)
-                opt5d(2,2,2,1,2)=ke5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb1,t_ifa2,kcomp)
-                opt5d(2,2,2,2,1)=ke5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb2,t_ifa1,kcomp)
-                opt5d(2,2,2,2,2)=ke5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb2,t_ifa2,kcomp)
-
-                ! interpolation in the faq, fbc, fac and cat dimensions
-                call lininterpol5dim (d2mx, dxm1, invd, opt5d, ske1, ske2)
-
-                ske1=max(ske1,1.e-30_r8)
-                ske2=max(ske2,1.e-30_r8)
-
-                ! finally, interpolation in the rh dimension
-                ! write(*,*) 'Before ske'
-                if(t_xrh <= 0.37_r8) then
-                   ske(icol,ilev,kcomp,iband)=((t_rh2-t_xrh)*ske1+(t_xrh-t_rh1)*ske2)/(t_rh2-t_rh1)
-                else
-                   a=(log(ske2)-log(ske1))/(t_rh2-t_rh1)
-                   b=(t_rh2*log(ske1)-t_rh1*log(ske2))/(t_rh2-t_rh1)
-                   ske(icol,ilev,kcomp,iband)=e**(a*t_xrh+b)
-                endif
              end do ! iband
 
-             ! LW optical parameters
-             if (lw_on) then
-                do iband=1,nlwbands            ! iband = wavelength index
-                   ! aerosol specific absorption
-                   opt5d(1,1,1,1,1)=ka5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb1,t_ifa1,kcomp)
-                   opt5d(1,1,1,1,2)=ka5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb1,t_ifa2,kcomp)
-                   opt5d(1,1,1,2,1)=ka5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb2,t_ifa1,kcomp)
-                   opt5d(1,1,1,2,2)=ka5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb2,t_ifa2,kcomp)
-                   opt5d(1,1,2,1,1)=ka5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb1,t_ifa1,kcomp)
-                   opt5d(1,1,2,1,2)=ka5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb1,t_ifa2,kcomp)
-                   opt5d(1,1,2,2,1)=ka5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb2,t_ifa1,kcomp)
-                   opt5d(1,1,2,2,2)=ka5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb2,t_ifa2,kcomp)
-                   opt5d(1,2,1,1,1)=ka5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb1,t_ifa1,kcomp)
-                   opt5d(1,2,1,1,2)=ka5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb1,t_ifa2,kcomp)
-                   opt5d(1,2,1,2,1)=ka5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb2,t_ifa1,kcomp)
-                   opt5d(1,2,1,2,2)=ka5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb2,t_ifa2,kcomp)
-                   opt5d(1,2,2,1,1)=ka5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb1,t_ifa1,kcomp)
-                   opt5d(1,2,2,1,2)=ka5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb1,t_ifa2,kcomp)
-                   opt5d(1,2,2,2,1)=ka5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb2,t_ifa1,kcomp)
-                   opt5d(1,2,2,2,2)=ka5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb2,t_ifa2,kcomp)
-                   opt5d(2,1,1,1,1)=ka5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb1,t_ifa1,kcomp)
-                   opt5d(2,1,1,1,2)=ka5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb1,t_ifa2,kcomp)
-                   opt5d(2,1,1,2,1)=ka5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb2,t_ifa1,kcomp)
-                   opt5d(2,1,1,2,2)=ka5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb2,t_ifa2,kcomp)
-                   opt5d(2,1,2,1,1)=ka5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb1,t_ifa1,kcomp)
-                   opt5d(2,1,2,1,2)=ka5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb1,t_ifa2,kcomp)
-                   opt5d(2,1,2,2,1)=ka5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb2,t_ifa1,kcomp)
-                   opt5d(2,1,2,2,2)=ka5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb2,t_ifa2,kcomp)
-                   opt5d(2,2,1,1,1)=ka5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb1,t_ifa1,kcomp)
-                   opt5d(2,2,1,1,2)=ka5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb1,t_ifa2,kcomp)
-                   opt5d(2,2,1,2,1)=ka5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb2,t_ifa1,kcomp)
-                   opt5d(2,2,1,2,2)=ka5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb2,t_ifa2,kcomp)
-                   opt5d(2,2,2,1,1)=ka5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb1,t_ifa1,kcomp)
-                   opt5d(2,2,2,1,2)=ka5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb1,t_ifa2,kcomp)
-                   opt5d(2,2,2,2,1)=ka5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb2,t_ifa1,kcomp)
-                   opt5d(2,2,2,2,2)=ka5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb2,t_ifa2,kcomp)
+          else  ! daylight
 
-                   ! interpolation in the faq, fbc, fac and cat dimensions
-                   call lininterpol5dim (d2mx, dxm1, invd, opt5d, kabs1, kabs2)
+             ! aerosol extinction  used for aerosol size estimate needed for LW calculations
+             iband=4
+             opt5d(1,1,1,1,1)=be5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb1,t_ifa1,kcomp)
+             opt5d(1,1,1,1,2)=be5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb1,t_ifa2,kcomp)
+             opt5d(1,1,1,2,1)=be5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb2,t_ifa1,kcomp)
+             opt5d(1,1,1,2,2)=be5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb2,t_ifa2,kcomp)
+             opt5d(1,1,2,1,1)=be5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb1,t_ifa1,kcomp)
+             opt5d(1,1,2,1,2)=be5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb1,t_ifa2,kcomp)
+             opt5d(1,1,2,2,1)=be5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb2,t_ifa1,kcomp)
+             opt5d(1,1,2,2,2)=be5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb2,t_ifa2,kcomp)
+             opt5d(1,2,1,1,1)=be5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb1,t_ifa1,kcomp)
+             opt5d(1,2,1,1,2)=be5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb1,t_ifa2,kcomp)
+             opt5d(1,2,1,2,1)=be5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb2,t_ifa1,kcomp)
+             opt5d(1,2,1,2,2)=be5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb2,t_ifa2,kcomp)
+             opt5d(1,2,2,1,1)=be5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb1,t_ifa1,kcomp)
+             opt5d(1,2,2,1,2)=be5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb1,t_ifa2,kcomp)
+             opt5d(1,2,2,2,1)=be5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb2,t_ifa1,kcomp)
+             opt5d(1,2,2,2,2)=be5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb2,t_ifa2,kcomp)
+             opt5d(2,1,1,1,1)=be5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb1,t_ifa1,kcomp)
+             opt5d(2,1,1,1,2)=be5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb1,t_ifa2,kcomp)
+             opt5d(2,1,1,2,1)=be5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb2,t_ifa1,kcomp)
+             opt5d(2,1,1,2,2)=be5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb2,t_ifa2,kcomp)
+             opt5d(2,1,2,1,1)=be5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb1,t_ifa1,kcomp)
+             opt5d(2,1,2,1,2)=be5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb1,t_ifa2,kcomp)
+             opt5d(2,1,2,2,1)=be5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb2,t_ifa1,kcomp)
+             opt5d(2,1,2,2,2)=be5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb2,t_ifa2,kcomp)
+             opt5d(2,2,1,1,1)=be5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb1,t_ifa1,kcomp)
+             opt5d(2,2,1,1,2)=be5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb1,t_ifa2,kcomp)
+             opt5d(2,2,1,2,1)=be5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb2,t_ifa1,kcomp)
+             opt5d(2,2,1,2,2)=be5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb2,t_ifa2,kcomp)
+             opt5d(2,2,2,1,1)=be5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb1,t_ifa1,kcomp)
+             opt5d(2,2,2,1,2)=be5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb1,t_ifa2,kcomp)
+             opt5d(2,2,2,2,1)=be5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb2,t_ifa1,kcomp)
+             opt5d(2,2,2,2,2)=be5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb2,t_ifa2,kcomp)
 
-                   kabs1=max(kabs1,1.e-30_r8)
-                   kabs2=max(kabs2,1.e-30_r8)
+             ! interpolation in the faq, fbc, fac and cat dimensions
+             call lininterpol5dim (d2mx, dxm1, invd, opt5d, bex1, bex2)
 
-                   if(t_xrh <= 0.37_r8) then
-                      kabs(icol,ilev,kcomp,iband)=((t_rh2-t_xrh)*kabs1+(t_xrh-t_rh1)*kabs2)/(t_rh2-t_rh1)
-                   else
-                      a=(log(kabs2)-log(kabs1))/(t_rh2-t_rh1)
-                      b=(t_rh2*log(kabs1)-t_rh1*log(kabs2))/(t_rh2-t_rh1)
-                      kabs(icol,ilev,kcomp,iband)=e**(a*t_xrh+b)
-                   endif
+             bex1=max(bex1,1.e-30_r8)
+             bex2=max(bex2,1.e-30_r8)
 
-                end do ! iband
+             ! finally, interpolation in the rh dimension
+             if(t_xrh <= 0.37_r8) then
+                bex(icol,ilev,kcomp,iband)=((t_rh2-t_xrh)*bex1+(t_xrh-t_rh1)*bex2)/(t_rh2-t_rh1)
+             else
+                a=(log(bex2)-log(bex1))/(t_rh2-t_rh1)
+                b=(t_rh2*log(bex1)-t_rh1*log(bex2))/(t_rh2-t_rh1)
+                bex(icol,ilev,kcomp,iband)=e**(a*t_xrh+b)
+             endif
 
-             endif ! lw_on
+          endif  ! daylight
 
-          end do ! icol
-       end do ! ilev
+          do iband=4,4            ! iband = wavelength index
+
+             ! aerosol specific extinction
+             opt5d(1,1,1,1,1)=ke5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb1,t_ifa1,kcomp)
+             opt5d(1,1,1,1,2)=ke5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb1,t_ifa2,kcomp)
+             opt5d(1,1,1,2,1)=ke5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb2,t_ifa1,kcomp)
+             opt5d(1,1,1,2,2)=ke5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb2,t_ifa2,kcomp)
+             opt5d(1,1,2,1,1)=ke5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb1,t_ifa1,kcomp)
+             opt5d(1,1,2,1,2)=ke5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb1,t_ifa2,kcomp)
+             opt5d(1,1,2,2,1)=ke5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb2,t_ifa1,kcomp)
+             opt5d(1,1,2,2,2)=ke5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb2,t_ifa2,kcomp)
+             opt5d(1,2,1,1,1)=ke5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb1,t_ifa1,kcomp)
+             opt5d(1,2,1,1,2)=ke5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb1,t_ifa2,kcomp)
+             opt5d(1,2,1,2,1)=ke5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb2,t_ifa1,kcomp)
+             opt5d(1,2,1,2,2)=ke5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb2,t_ifa2,kcomp)
+             opt5d(1,2,2,1,1)=ke5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb1,t_ifa1,kcomp)
+             opt5d(1,2,2,1,2)=ke5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb1,t_ifa2,kcomp)
+             opt5d(1,2,2,2,1)=ke5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb2,t_ifa1,kcomp)
+             opt5d(1,2,2,2,2)=ke5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb2,t_ifa2,kcomp)
+             opt5d(2,1,1,1,1)=ke5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb1,t_ifa1,kcomp)
+             opt5d(2,1,1,1,2)=ke5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb1,t_ifa2,kcomp)
+             opt5d(2,1,1,2,1)=ke5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb2,t_ifa1,kcomp)
+             opt5d(2,1,1,2,2)=ke5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb2,t_ifa2,kcomp)
+             opt5d(2,1,2,1,1)=ke5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb1,t_ifa1,kcomp)
+             opt5d(2,1,2,1,2)=ke5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb1,t_ifa2,kcomp)
+             opt5d(2,1,2,2,1)=ke5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb2,t_ifa1,kcomp)
+             opt5d(2,1,2,2,2)=ke5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb2,t_ifa2,kcomp)
+             opt5d(2,2,1,1,1)=ke5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb1,t_ifa1,kcomp)
+             opt5d(2,2,1,1,2)=ke5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb1,t_ifa2,kcomp)
+             opt5d(2,2,1,2,1)=ke5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb2,t_ifa1,kcomp)
+             opt5d(2,2,1,2,2)=ke5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb2,t_ifa2,kcomp)
+             opt5d(2,2,2,1,1)=ke5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb1,t_ifa1,kcomp)
+             opt5d(2,2,2,1,2)=ke5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb1,t_ifa2,kcomp)
+             opt5d(2,2,2,2,1)=ke5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb2,t_ifa1,kcomp)
+             opt5d(2,2,2,2,2)=ke5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb2,t_ifa2,kcomp)
+
+             ! interpolation in the faq, fbc, fac and cat dimensions
+             call lininterpol5dim (d2mx, dxm1, invd, opt5d, ske1, ske2)
+
+             ske1=max(ske1,1.e-30_r8)
+             ske2=max(ske2,1.e-30_r8)
+
+             ! finally, interpolation in the rh dimension
+             ! write(*,*) 'Before ske'
+             if(t_xrh <= 0.37_r8) then
+                ske(icol,ilev,kcomp,iband)=((t_rh2-t_xrh)*ske1+(t_xrh-t_rh1)*ske2)/(t_rh2-t_rh1)
+             else
+                a=(log(ske2)-log(ske1))/(t_rh2-t_rh1)
+                b=(t_rh2*log(ske1)-t_rh1*log(ske2))/(t_rh2-t_rh1)
+                ske(icol,ilev,kcomp,iband)=e**(a*t_xrh+b)
+             endif
+          end do ! iband
+
+          ! LW optical parameters
+          if (lw_on) then
+             do iband=1,nlwbands            ! iband = wavelength index
+                ! aerosol specific absorption
+                opt5d(1,1,1,1,1)=ka5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb1,t_ifa1,kcomp)
+                opt5d(1,1,1,1,2)=ka5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb1,t_ifa2,kcomp)
+                opt5d(1,1,1,2,1)=ka5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb2,t_ifa1,kcomp)
+                opt5d(1,1,1,2,2)=ka5to10(iband,t_irh1,t_ict1,t_ifc1,t_ifb2,t_ifa2,kcomp)
+                opt5d(1,1,2,1,1)=ka5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb1,t_ifa1,kcomp)
+                opt5d(1,1,2,1,2)=ka5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb1,t_ifa2,kcomp)
+                opt5d(1,1,2,2,1)=ka5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb2,t_ifa1,kcomp)
+                opt5d(1,1,2,2,2)=ka5to10(iband,t_irh1,t_ict1,t_ifc2,t_ifb2,t_ifa2,kcomp)
+                opt5d(1,2,1,1,1)=ka5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb1,t_ifa1,kcomp)
+                opt5d(1,2,1,1,2)=ka5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb1,t_ifa2,kcomp)
+                opt5d(1,2,1,2,1)=ka5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb2,t_ifa1,kcomp)
+                opt5d(1,2,1,2,2)=ka5to10(iband,t_irh1,t_ict2,t_ifc1,t_ifb2,t_ifa2,kcomp)
+                opt5d(1,2,2,1,1)=ka5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb1,t_ifa1,kcomp)
+                opt5d(1,2,2,1,2)=ka5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb1,t_ifa2,kcomp)
+                opt5d(1,2,2,2,1)=ka5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb2,t_ifa1,kcomp)
+                opt5d(1,2,2,2,2)=ka5to10(iband,t_irh1,t_ict2,t_ifc2,t_ifb2,t_ifa2,kcomp)
+                opt5d(2,1,1,1,1)=ka5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb1,t_ifa1,kcomp)
+                opt5d(2,1,1,1,2)=ka5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb1,t_ifa2,kcomp)
+                opt5d(2,1,1,2,1)=ka5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb2,t_ifa1,kcomp)
+                opt5d(2,1,1,2,2)=ka5to10(iband,t_irh2,t_ict1,t_ifc1,t_ifb2,t_ifa2,kcomp)
+                opt5d(2,1,2,1,1)=ka5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb1,t_ifa1,kcomp)
+                opt5d(2,1,2,1,2)=ka5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb1,t_ifa2,kcomp)
+                opt5d(2,1,2,2,1)=ka5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb2,t_ifa1,kcomp)
+                opt5d(2,1,2,2,2)=ka5to10(iband,t_irh2,t_ict1,t_ifc2,t_ifb2,t_ifa2,kcomp)
+                opt5d(2,2,1,1,1)=ka5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb1,t_ifa1,kcomp)
+                opt5d(2,2,1,1,2)=ka5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb1,t_ifa2,kcomp)
+                opt5d(2,2,1,2,1)=ka5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb2,t_ifa1,kcomp)
+                opt5d(2,2,1,2,2)=ka5to10(iband,t_irh2,t_ict2,t_ifc1,t_ifb2,t_ifa2,kcomp)
+                opt5d(2,2,2,1,1)=ka5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb1,t_ifa1,kcomp)
+                opt5d(2,2,2,1,2)=ka5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb1,t_ifa2,kcomp)
+                opt5d(2,2,2,2,1)=ka5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb2,t_ifa1,kcomp)
+                opt5d(2,2,2,2,2)=ka5to10(iband,t_irh2,t_ict2,t_ifc2,t_ifb2,t_ifa2,kcomp)
+
+                ! interpolation in the faq, fbc, fac and cat dimensions
+                call lininterpol5dim (d2mx, dxm1, invd, opt5d, kabs1, kabs2)
+
+                kabs1=max(kabs1,1.e-30_r8)
+                kabs2=max(kabs2,1.e-30_r8)
+
+                if(t_xrh <= 0.37_r8) then
+                   kabs(icol,ilev,kcomp,iband)=((t_rh2-t_xrh)*kabs1+(t_xrh-t_rh1)*kabs2)/(t_rh2-t_rh1)
+                else
+                   a=(log(kabs2)-log(kabs1))/(t_rh2-t_rh1)
+                   b=(t_rh2*log(kabs1)-t_rh1*log(kabs2))/(t_rh2-t_rh1)
+                   kabs(icol,ilev,kcomp,iband)=e**(a*t_xrh+b)
+                endif
+
+             end do ! iband
+
+          endif ! lw_on
+
+       end do ! icol
+    end do ! ilev
 
   end subroutine interpol5to10
 


### PR DESCRIPTION
This PR is associated with CAM [#280](https://github.com/NorESMhub/CAM/pull/280) 

### New namelist parameter  rh_fine_aer_scale_fact_optics
Adds a new namelist parameter rh_fine_aer_scale_fact_optics (default 1.0, i.e. no change) that scales the effective relative humidity seen by fine aerosol modes during look-up table interpolation. This provides a tuning handle for aerosol optical depth without modifying the underlying aerosol state.

The scaling is applied to SO4/SOA, BC, and OC modes (modes 1–5) in both the main optics routine (oslo_aero_optical_params.F90) and the AeroCom diagnostics routine (oslo_aero_aerocom.F90). 

### Refactoring of interpol* / intaeropt* subroutines
To enable mode-selective RH scaling, the internal loop over modes 5–10 in interpol5to10 and intaeropt5to10 was moved to the callers, so each mode can be called with a different RH array. As part of this, the opaque mplus10 flag (0/1 indicating whether to offset the mode index by 10) was replaced throughout with an explicit mode index argument (kout/kcomp), covering interpol1, interpol2to3, interpol4, interpol5to10 and their intaeropt* counterparts.