### PR TITLE
noresm_develop : corrected units of N_AER in call to addfld 

### DIFF
--- a/src/oslo_aero_diagnostics.F90
+++ b/src/oslo_aero_diagnostics.F90
@@ -29,7 +29,7 @@ contains
       call addfld ('CABSVIS ',horiz_only,  'A','unitless' ,'Clear air aerosol absorptive optical depth')
       call addfld ('CLDFREE ',horiz_only,  'A','unitless' ,'Cloud free fraction wrt CAODVIS and CABSVIS')
       call addfld ('DAYFOC  ',horiz_only,  'A','unitless' ,'Daylight fraction')
-      call addfld ('N_AER   ',(/'lev'/),   'A', 'unitless','Aerosol number concentration')
+      call addfld ('N_AER   ',(/'lev'/),   'A','1/cm3   ' ,'Aerosol number concentration')
       call addfld ('SSAVIS  ',(/'lev'/),   'A','unitless' ,'Aerosol single scattering albedo in visible wavelength band')
       call addfld ('ASYMMVIS',(/'lev'/),   'A','unitless' ,'Aerosol assymetry factor in visible wavelength band')
       call addfld ('EXTVIS  ',(/'lev'/),   'A','1/km    ' ,'Aerosol extinction')


### PR DESCRIPTION
*General*
This PR corrects the units description in the call to `addfld` for `N_AER`.  These units appear in the h0, h1, ... NetCDF files with CAM diagnostics.  Until now the units where described as *unitless*, whereas the actual units of the field are *1/cm3*.  

The only file changed is `oslo_aero_diagnostics.F90`.

*Some explanation*
Some clarification on the actual units of `N_AER` can be found in `oslo_aero_optical_params.F90`.   
- In the following part of the code `Nnatk` is converted from #/m3 to # cm-3:
```
!The following uses non-standard units, #/cm3
    Nnatk(:ncol,:,:) = Nnatk(:ncol,:,:)*1.e-6_r8
```
- In the following part there is  a sum over all modes
```
! total aerosol number concentrations
    do imode=0,nmodes    ! mode 0 to 14
       do ilev=1,pver
          do icol=1,ncol
             n_aer(icol,ilev)=n_aer(icol,ilev)+Nnatk(icol,ilev,imode)
          end do
       enddo
    enddo
```
- Generating output of the final field :
```
    call outfld('N_AER   ',n_aer ,pcols,lchnk)
```