### PR TITLE
oslo_aero_3_0a014: Diagnostic for emissions of primary organic matter (POM) from ocean

### DIFF
--- a/src/oslo_aero_ocean.F90
+++ b/src/oslo_aero_ocean.F90
@@ -189,6 +189,10 @@ contains
       call add_default('odms', 1, ' ')
    endif
 
+    call addfld('emipomocean', horiz_only,  'A',  'kg/m2/sec', 'POM ocean emissions flux' )
+    call add_default('emipomocean', 1, ' ')
+
+
   endsubroutine oslo_aero_ocean_init
 
   !===============================================================================
@@ -311,6 +315,8 @@ contains
        flux(:ncol)   = c_o*omFrac(:ncol) * em_ss1(:ncol)
        opomem_out(:ncol) = flux(:ncol)
     endif
+
+    call outfld('emipomocean', flux(:ncol), ncol, lchnk)
 
   end subroutine oslo_aero_opom_emis
 

--- a/src/oslo_aero_ocean.F90
+++ b/src/oslo_aero_ocean.F90
@@ -189,8 +189,11 @@ contains
       call add_default('odms', 1, ' ')
    endif
 
-    call addfld('emipomocean', horiz_only,  'A',  'kg/m2/sec', 'POM ocean emissions flux' )
-    call add_default('emipomocean', 1, ' ')
+   call addfld('emipomocean', horiz_only,  'A',  'kg/m2/sec', 'POM ocean emissions flux' )
+   ! Note: This variable is only computed if oslo_aero_opom_inq is .true.
+   if (history_aerosol_forcing .and. oslo_aero_opom_inq()) then
+      call add_default('emipomocean', 1, ' ')
+   end if
 
 
   endsubroutine oslo_aero_ocean_init
@@ -316,7 +319,7 @@ contains
        opomem_out(:ncol) = flux(:ncol)
     endif
 
-    call outfld('emipomocean', flux(:ncol), ncol, lchnk)
+    call outfld('emipomocean', opomem_out(:ncol), ncol, lchnk)
 
   end subroutine oslo_aero_opom_emis
 


### PR DESCRIPTION
This pull modification is aimed to have an extra diagnostic output field : the natural primary organic matter (POM) emissions from the ocean.  We modified one file `oslo_aero_ocean.F90`.

We added in the subroutine `oslo_aero_ocean_init` the lines :
```
call addfld('emipomocean', horiz_only,  'A',  'kg/m2/sec', 'POM ocean emissions flux' )
call add_default('emipomocean', 1, ' ')
```
We added in the subroutine `oslo_aero_opom_emis` the lines :
```
call outfld('emipomocean', flux(:ncol), ncol, lchnk)
```