### PR TITLE
oslo_aero_3_0a015: Do not set FLBC nudging for emission-driven run when CO2 is advected

### DIFF
--- a/src_cam/chemistry.F90
+++ b/src_cam/chemistry.F90
@@ -13,7 +13,7 @@ module chemistry
   use physics_types,    only : physics_state, physics_ptend, physics_ptend_init
   use spmd_utils,       only : masterproc
   use cam_logfile,      only : iulog
-  use mo_gas_phase_chemdr, only : map2chm
+  use mo_gas_phase_chemdr, only : map2chm, initialize_map2chm
   use shr_megan_mod,    only : shr_megan_mechcomps, shr_megan_mechcomps_n
   use srf_field_check,  only : active_Fall_flxvoc
   use tracer_data,      only : MAXTRCRS
@@ -207,12 +207,14 @@ end function chem_is
     character(len=128) :: molectype
     logical :: ndropmixed
     integer :: islvd
+    integer :: new_chm_map(pcnst)
 
 !-----------------------------------------------------------------------
 ! Set the simulation chemistry variables
 !-----------------------------------------------------------------------
     call set_sim_dat
 
+    new_chm_map(:) = 0
     o3_ndx    = get_spc_ndx('O3')
     o3_inv_ndx= get_inv_ndx('O3')
     ch4_ndx   = get_spc_ndx('CH4')
@@ -307,7 +309,7 @@ end function chem_is
        else if( m == nop_ndx ) then
           lng_name = 'NO+'
        else if( m == h2o_ndx ) then
-          map2chm(1) = m
+          new_chm_map(1) = m
           cycle
        endif
 
@@ -329,10 +331,11 @@ end function chem_is
           if( imozart == -1 ) then
              imozart = n
           end if
-          map2chm(n) = m
+          new_chm_map(n) = m
        endif
 
     end do
+    call initialize_map2chm(new_chm_map)
 
     call register_short_lived_species()
     call register_cfc11star()
@@ -812,7 +815,7 @@ end function chem_is_active
           if (ii>0) then
              megan_wght_factors(n) = adv_mass(ii)*1.e-3_r8 ! kg/moles (to convert moles/m2/sec to kg/m2/sec)
           else
-             call endrun( 'gas_phase_chemdr_inti: MEGAN compound not in chemistry mechanism : '&
+             call endrun( 'chem_init: MEGAN compound not in chemistry mechanism : '&
                   //trim(shr_megan_mechcomps(n)%name))
           endif
 

--- a/src_cam/mo_gas_phase_chemdr.F90
+++ b/src_cam/mo_gas_phase_chemdr.F90
@@ -17,9 +17,11 @@ module mo_gas_phase_chemdr
 
   private
   public :: gas_phase_chemdr, gas_phase_chemdr_inti
-  public :: map2chm
+  public :: initialize_map2chm
 
-  integer :: map2chm(pcnst) = 0           ! index map to/from chemistry/constituents list
+  integer, public, protected :: map2chm(pcnst) = 0  ! index map to/from chemistry/constituents list
+  integer                    :: flbc_map(pcnst) = 0 ! map2chm with emissions-driven species excluded from FLBC
+  logical :: map2chm_initialized = .false.
 
   integer :: so4_ndx, h2o_ndx, o2_ndx, o_ndx, hno3_ndx, hcl_ndx, cldice_ndx, snow_ndx
   integer :: o3_ndx, o3s_ndx, o3_inv_ndx, srf_ozone_pbf_ndx=-1
@@ -60,17 +62,32 @@ module mo_gas_phase_chemdr
 
 contains
 
+  subroutine initialize_map2chm(new_map)
+    use cam_abortutils, only : endrun
+
+    ! Initialize map2chm
+    integer, intent(in) :: new_map(:)
+
+    if (map2chm_initialized) then
+       call endrun("initialize_map2chm: map2chm is already initialized")
+    else
+       map2chm_initialized = .true.
+       map2chm(:) = new_map(:)
+    end if
+  end subroutine initialize_map2chm
+
   subroutine gas_phase_chemdr_inti()
 
     ! OSLO_AERO begin
-    use mo_chem_utls,      only : get_spc_ndx, get_extfrc_ndx, get_rxt_ndx, get_inv_ndx
+    use mo_chem_utls,   only : get_spc_ndx, get_extfrc_ndx, get_rxt_ndx, get_inv_ndx
     ! OSLO_AERO end
-    use cam_history,       only : addfld,add_default,horiz_only
-    use mo_chm_diags,      only : chm_diags_inti
-    use constituents,      only : cnst_get_ind
-    use physics_buffer,    only : pbuf_get_index
-    use rate_diags,        only : rate_diags_init
-    use cam_abortutils,    only : endrun
+    use cam_history,    only : addfld,add_default,horiz_only
+    use mo_chm_diags,   only : chm_diags_inti
+    use constituents,   only : cnst_get_ind
+    use physics_buffer, only : pbuf_get_index
+    use rate_diags,     only : rate_diags_init
+    use co2_cycle,      only : co2_transport, c_i
+    use cam_abortutils, only : endrun
 
     character(len=3) :: string
     integer          :: n, m, err, ii
@@ -95,6 +112,13 @@ contains
     ! OSLO_AERO end
 
     ndx_h2so4 = get_spc_ndx('H2SO4')
+
+    ! Do not apply FLBC to CO2 tracer in emission-driven runs
+    flbc_map(:) = map2chm(:)
+    if (co2_transport()) then
+       flbc_map(c_i(4)) = 0
+    end if
+
 !
 ! CCMI
 !
@@ -1095,7 +1119,7 @@ contains
     !-----------------------------------------------------------------------
     !         ... Set fixed lower boundary mmr values
     !-----------------------------------------------------------------------
-    call flbc_set( vmr, ncol, lchnk, map2chm )
+    call flbc_set( vmr, ncol, lchnk, flbc_map )
 
     if ( ghg_chem ) then
        call ghg_chem_set_flbc( vmr, ncol )


### PR DESCRIPTION
The CO2 from the FLBC file overwrites the prognostic CO2 when GHG chemistry is combined with emissions-driven CO2.

This PR addresses this by using a separate mapping for FLBC. `flbc_map` is identical to `map2chm` except that CO2 is removed for emission-driven runs (`co_transport == .true.`).

In the failing case, `flbc_set` is called using `flbc_map` (which has CO2 removed) instead of `map2chm` (which maps CO2).

fixes #77 