### PR TITLE
oslo_aero_3_0a016: Fix copy paste error in mpi_bcast for rh_fine_aer_scale_fact_optics

### DIFF
--- a/src/oslo_aero_control.F90
+++ b/src/oslo_aero_control.F90
@@ -109,7 +109,7 @@ contains
     if (ierr /= mpi_success) call endrun(subname//" mpi_bcast: ocean_filepath")
 
     ! Relhum scaling in the optics for tuning of aerosol optical depth
-    call mpi_bcast(rh_fine_aer_scale_fact_optics, len(ocean_filename), mpi_character, mstrid, mpicom, ierr)
+    call mpi_bcast(rh_fine_aer_scale_fact_optics, 1, mpi_real8, mstrid, mpicom, ierr)
     if (ierr /= mpi_success) call endrun(subname//" mpi_bcast: rh_fine_aer_scale_fact_optics")
 
 


### PR DESCRIPTION
A copy paste error was made when the rh_fine_aer_scale_fact_optics namelist variable was introduced. This error is not answer changing as the right value still got put on rh_fine_aer_scale_fact_optics. Since MPI copies raw bytes; MPI_CHARACTER × 8 is bit-identical to MPI_REAL8 × 1 for the first 8 bytes. So the first 8 bytes — the actual rh_fine_aer_scale_fact_optics — landed correctly on all ranks. Though it could lead to unpredictable behavior. 