### PR TITLE
oslo_aero_3_0a017: Make sure outfld is called before early return

### DIFF
--- a/src_cam/radsw.F90
+++ b/src_cam/radsw.F90
@@ -317,6 +317,17 @@ subroutine rad_rrtmg_sw(lchnk,ncol       ,rrtmg_levs   ,r_state      , &
 
    ! If night everywhere, return:
    if ( Nday == 0 ) then
+      ! Call outfld before returning to include zero values in average values
+      call outfld('FUS     ', fus(:ncol,:),  ncol, lchnk)
+      call outfld('FDS     ', fds(:ncol,:),  ncol, lchnk)
+      call outfld('FUSC    ', fusc(:ncol,:), ncol, lchnk)
+      call outfld('FDSC    ', fdsc(:ncol,:), ncol, lchnk)
+      if (present(idrf)) then
+         if (idrf) then
+            call outfld('FUSCAF', fusc(:ncol,:), ncol, lchnk)
+            call outfld('FDSCAF', fdsc(:ncol,:), ncol, lchnk)
+         end if
+      end if
      return
    endif
 


### PR DESCRIPTION
In a column with all night, `rad_rrtmg_sw` returns early to avoid unneeded computation. However, some fields will not get `outfld` calls which makes the average values incorrect. This also will fail restart.

This PR makes sure the `outfld` calls are always made once per call.